### PR TITLE
Revert "[ARO-26376] Replace InsecureIgnoreHostKey with persistent TOFU for po…"

### DIFF
--- a/pkg/api/openshiftcluster.go
+++ b/pkg/api/openshiftcluster.go
@@ -185,13 +185,6 @@ type OpenShiftClusterProperties struct {
 	InfraID string      `json:"infraId,omitempty"`
 	SSHKey  SecureBytes `json:"sshKey,omitempty"`
 
-	// SSHHostPublicKeys stores the SSH host public keys for master nodes in SSH
-	// wire format (ssh.PublicKey.Marshal()), keyed by the string form of the
-	// master node index (e.g. "0", "1", "2"). Keys are captured on the first
-	// portal SSH connection to each master (TOFU) and used to verify all
-	// subsequent connections. Never exposed via any external API.
-	SSHHostPublicKeys map[string]SecureBytes `json:"sshHostPublicKeys,omitempty"`
-
 	// AdminKubeconfig is installer generated kubeconfig. It is 10 year config,
 	// and should never be returned to the user.
 	AdminKubeconfig SecureBytes `json:"adminKubeconfig,omitempty"`

--- a/pkg/portal/ssh/proxy.go
+++ b/pkg/portal/ssh/proxy.go
@@ -4,13 +4,11 @@ package ssh
 // Licensed under the Apache License 2.0.
 
 import (
-	"bytes"
 	"context"
 	"crypto/x509"
 	"fmt"
 	"io"
 	"net"
-	"strconv"
 	"strings"
 	"time"
 
@@ -147,8 +145,7 @@ func (s *SSH) newConn(ctx context.Context, clientConn net.Conn) error {
 		return err
 	}
 
-	masterNum := portalDoc.Portal.SSH.Master
-	address := fmt.Sprintf("%s:%d", openShiftDoc.OpenShiftCluster.Properties.NetworkProfile.APIServerPrivateEndpointIP, 2200+masterNum)
+	address := fmt.Sprintf("%s:%d", openShiftDoc.OpenShiftCluster.Properties.NetworkProfile.APIServerPrivateEndpointIP, 2200+portalDoc.Portal.SSH.Master)
 
 	c2, err := s.dialer.DialContext(ctx, "tcp", address)
 	if err != nil {
@@ -167,25 +164,13 @@ func (s *SSH) newConn(ctx context.Context, clientConn net.Conn) error {
 		return err
 	}
 
-	// Build the host key callback.  The master node generates its SSH host key
-	// at first boot (via sshd_keygen); the key is not embedded in the ignition
-	// config and is never transmitted to the RP, so we cannot know it in
-	// advance.  We implement persistent TOFU: on the first portal SSH session
-	// to a given master node the presented host key is accepted and stored in
-	// CosmosDB; all subsequent sessions verify against the stored key.
-	masterKey := strconv.Itoa(masterNum)
-	hostKeyCallback, capturedHostKey, err := s.buildHostKeyCallback(openShiftDoc, masterKey)
-	if err != nil {
-		return err
-	}
-
 	// Connect the second connection leg (portal->cluster).
 	downstreamConn, downstreamNewChannels, downstreamRequests, err := cryptossh.NewClientConn(c2, "", &cryptossh.ClientConfig{
 		User: "core",
 		Auth: []cryptossh.AuthMethod{
 			cryptossh.PublicKeys(signer),
 		},
-		HostKeyCallback: hostKeyCallback,
+		HostKeyCallback: cryptossh.InsecureIgnoreHostKey(),
 		Config: cryptossh.Config{
 			KeyExchanges: utilssh.KexAlgorithms(),
 			Ciphers:      utilssh.Ciphers(),
@@ -195,38 +180,6 @@ func (s *SSH) newConn(ctx context.Context, clientConn net.Conn) error {
 	})
 	if err != nil {
 		return err
-	}
-
-	// Persist the host key captured during TOFU (first connection to this master).
-	// The patch mutator is a compare-and-set: it writes the key only when absent,
-	// and returns an error (aborting the patch) if a different key is already stored.
-	// This prevents a concurrent TOFU session from silently overwriting a key that
-	// was already persisted by a racing first session.
-	//
-	// If persistence fails for any reason (including a key conflict detected by a
-	// racing session) we return the error and terminate the SSH session.  Continuing
-	// with an unpersisted key would leave subsequent connections unprotected against
-	// MITM, defeating the purpose of TOFU.
-	if *capturedHostKey != nil {
-		newKeyBytes := (*capturedHostKey).Marshal()
-		_, patchErr := s.dbOpenShiftClusters.Patch(ctx, strings.ToLower(portalDoc.Portal.ID), func(doc *api.OpenShiftClusterDocument) error {
-			existing := doc.OpenShiftCluster.Properties.SSHHostPublicKeys[masterKey]
-			if len(existing) > 0 {
-				if !bytes.Equal(existing, newKeyBytes) {
-					return fmt.Errorf("SSH host public key already stored for master-%s and differs from presented key", masterKey)
-				}
-				return nil
-			}
-			if doc.OpenShiftCluster.Properties.SSHHostPublicKeys == nil {
-				doc.OpenShiftCluster.Properties.SSHHostPublicKeys = map[string]api.SecureBytes{}
-			}
-			doc.OpenShiftCluster.Properties.SSHHostPublicKeys[masterKey] = newKeyBytes
-			return nil
-		})
-		if patchErr != nil {
-			accessLog.WithError(patchErr).Warnf("failed to persist SSH host public key for master-%d", masterNum)
-			return fmt.Errorf("failed to persist SSH host public key for master-%d: %w", masterNum, patchErr)
-		}
 	}
 
 	t := time.Now()
@@ -434,47 +387,6 @@ func (s *SSH) proxyChannel(ch1, ch2 cryptossh.Channel, rs1, rs2 <-chan *cryptoss
 	})
 
 	return g.Wait()
-}
-
-// buildHostKeyCallback returns an SSH HostKeyCallback for the portal->cluster
-// leg together with a pointer that is populated with the captured key when TOFU
-// is in effect (i.e. no stored key was found for masterKey).
-//
-// When a stored host public key exists for masterKey the callback strictly
-// verifies the presented key against it.  When no stored key exists the
-// callback accepts the first key it sees and writes it into *captured so the
-// caller can persist it.
-func (s *SSH) buildHostKeyCallback(doc *api.OpenShiftClusterDocument, masterKey string) (cryptossh.HostKeyCallback, *cryptossh.PublicKey, error) {
-	var captured cryptossh.PublicKey
-
-	if storedBytes := doc.OpenShiftCluster.Properties.SSHHostPublicKeys[masterKey]; len(storedBytes) > 0 {
-		knownKey, err := cryptossh.ParsePublicKey(storedBytes)
-		if err != nil {
-			return nil, nil, fmt.Errorf("parsing stored SSH host key for master-%s: %w", masterKey, err)
-		}
-		// Strict verification: reject any key that differs from the stored one.
-		cb := func(_ string, _ net.Addr, presented cryptossh.PublicKey) error {
-			if !bytes.Equal(knownKey.Marshal(), presented.Marshal()) {
-				return fmt.Errorf("SSH host key mismatch for master-%s: expected %s %s, got %s %s",
-					masterKey,
-					knownKey.Type(), cryptossh.FingerprintSHA256(knownKey),
-					presented.Type(), cryptossh.FingerprintSHA256(presented))
-			}
-			return nil
-		}
-		return cb, &captured, nil
-	}
-
-	// No stored key — TOFU: capture the first presented key for the caller to persist.
-	// Guard against the callback being invoked more than once by only recording
-	// the first key seen.
-	cb := func(_ string, _ net.Addr, key cryptossh.PublicKey) error {
-		if captured == nil {
-			captured = key
-		}
-		return nil
-	}
-	return cb, &captured, nil
 }
 
 func (s *SSH) keepAliveConn(ctx context.Context, channel cryptossh.Channel) {

--- a/pkg/portal/ssh/proxy_test.go
+++ b/pkg/portal/ssh/proxy_test.go
@@ -71,16 +71,13 @@ func fakeClient(c net.Conn, serverKey *rsa.PublicKey, user string, password stri
 }
 
 // fakeServer returns a test listener for an SSH server which validates the
-// client key, reads ping request(s) and writes pong replies.
-// It also returns the SSH host public key that the server presents during the
-// handshake so callers can pre-seed it into cluster documents to simulate the
-// post-TOFU state and exercise the strict host-key verification path.
-func fakeServer(clientKey *rsa.PublicKey) (*listener.Listener, cryptossh.PublicKey, error) {
+// client key, reads ping request(s) and writes pong replies
+func fakeServer(clientKey *rsa.PublicKey) (*listener.Listener, error) {
 	l := listener.NewListener()
 
 	clientPublicKey, err := cryptossh.NewPublicKey(clientKey)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	config := &cryptossh.ServerConfig{
@@ -103,12 +100,12 @@ func fakeServer(clientKey *rsa.PublicKey) (*listener.Listener, cryptossh.PublicK
 
 	key, _, err := utiltls.GenerateKeyAndCertificate("server", nil, nil, false, false)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	signer, err := cryptossh.NewSignerFromSigner(key)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	config.AddHostKey(signer)
@@ -147,7 +144,7 @@ func fakeServer(clientKey *rsa.PublicKey) (*listener.Listener, cryptossh.PublicK
 		}
 	}()
 
-	return l, signer.PublicKey(), nil
+	return l, nil
 }
 
 func TestProxy(t *testing.T) {
@@ -170,26 +167,12 @@ func TestProxy(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// wrongKey is used to seed a stored host key that differs from the server's
-	// actual key, to exercise the strict-verification rejection path.
-	wrongKey, _, err := utiltls.GenerateKeyAndCertificate("wrong", nil, nil, false, false)
-	if err != nil {
-		t.Fatal(err)
-	}
-	wrongHostPubKey, err := cryptossh.NewPublicKey(&wrongKey.PublicKey)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	l, serverHostPubKey, err := fakeServer(&clusterKey.PublicKey)
+	l, err := fakeServer(&clusterKey.PublicKey)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer l.Close()
 
-	// goodOpenShiftClusterDocument pre-seeds the stored SSH host public key for
-	// master-1 so the TOFU callback performs strict verification (simulating a
-	// cluster that has already had at least one portal SSH session).
 	goodOpenShiftClusterDocument := func() *api.OpenShiftClusterDocument {
 		return &api.OpenShiftClusterDocument{
 			ID:  resourceID,
@@ -200,9 +183,6 @@ func TestProxy(t *testing.T) {
 						APIServerPrivateEndpointIP: apiServerPrivateEndpointIP,
 					},
 					SSHKey: api.SecureBytes(x509.MarshalPKCS1PrivateKey(clusterKey)),
-					SSHHostPublicKeys: map[string]api.SecureBytes{
-						"1": serverHostPubKey.Marshal(),
-					},
 				},
 			},
 		}
@@ -254,86 +234,6 @@ func TestProxy(t *testing.T) {
 				portalDocument.Portal.SSH.Authenticated = true
 				checker.AddPortalDocuments(portalDocument)
 				checker.AddOpenShiftClusterDocuments(openShiftClusterDocument)
-			},
-			mocks: func(dialer *mock_proxy.MockDialer) {
-				dialer.EXPECT().DialContext(gomock.Any(), "tcp", apiServerPrivateEndpointIP+":2201").Return(l.DialContext(ctx, "", ""))
-			},
-			wantLogs: []testlog.ExpectedLogEntry{
-				{
-					"level":       gomega.Equal(logrus.InfoLevel),
-					"msg":         gomega.Equal("authentication succeeded"),
-					"remote_addr": gomega.Not(gomega.BeEmpty()),
-					"username":    gomega.Equal(username),
-				},
-				{
-					"level":           gomega.Equal(logrus.InfoLevel),
-					"msg":             gomega.Equal("connected"),
-					"hostname":        gomega.Equal("master-1"),
-					"resource_group":  gomega.Equal(resourceGroup),
-					"resource_id":     gomega.Equal(resourceID),
-					"resource_name":   gomega.Equal(resourceName),
-					"subscription_id": gomega.Equal(subscriptionID),
-					"username":        gomega.Equal(username),
-				},
-				{
-					"level":           gomega.Equal(logrus.InfoLevel),
-					"msg":             gomega.Equal("disconnected"),
-					"duration":        gomega.BeNumerically(">", 0),
-					"hostname":        gomega.Equal("master-1"),
-					"resource_group":  gomega.Equal(resourceGroup),
-					"resource_id":     gomega.Equal(resourceID),
-					"resource_name":   gomega.Equal(resourceName),
-					"subscription_id": gomega.Equal(subscriptionID),
-					"username":        gomega.Equal(username),
-				},
-			},
-			ciphers: goodCiphers,
-		},
-		{
-			// TOFU path: no host key pre-seeded; the proxy should capture the
-			// presented key and persist it to the cluster document.
-			name:     "good, TOFU first connection stores host key",
-			username: username,
-			password: password,
-			fixtureChecker: func(tt *test, fixture *testdatabase.Fixture, checker *testdatabase.Checker, openShiftClustersClient *cosmosdb.FakeOpenShiftClusterDocumentClient, portalClient *cosmosdb.FakePortalDocumentClient) {
-				portalDocument := goodPortalDocument(tt.password)
-				fixture.AddPortalDocuments(portalDocument)
-
-				// Cluster document has no SSHHostPublicKeys — first connection.
-				openShiftClusterDocument := &api.OpenShiftClusterDocument{
-					ID:  resourceID,
-					Key: resourceID,
-					OpenShiftCluster: &api.OpenShiftCluster{
-						Properties: api.OpenShiftClusterProperties{
-							NetworkProfile: api.NetworkProfile{
-								APIServerPrivateEndpointIP: apiServerPrivateEndpointIP,
-							},
-							SSHKey: api.SecureBytes(x509.MarshalPKCS1PrivateKey(clusterKey)),
-						},
-					},
-				}
-				fixture.AddOpenShiftClusterDocuments(openShiftClusterDocument)
-
-				portalDocument = goodPortalDocument(tt.password)
-				portalDocument.Portal.SSH.Authenticated = true
-				checker.AddPortalDocuments(portalDocument)
-
-				// After TOFU the cluster document should have the host key stored.
-				checker.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
-					ID:  resourceID,
-					Key: resourceID,
-					OpenShiftCluster: &api.OpenShiftCluster{
-						Properties: api.OpenShiftClusterProperties{
-							NetworkProfile: api.NetworkProfile{
-								APIServerPrivateEndpointIP: apiServerPrivateEndpointIP,
-							},
-							SSHKey: api.SecureBytes(x509.MarshalPKCS1PrivateKey(clusterKey)),
-							SSHHostPublicKeys: map[string]api.SecureBytes{
-								"1": serverHostPubKey.Marshal(),
-							},
-						},
-					},
-				})
 			},
 			mocks: func(dialer *mock_proxy.MockDialer) {
 				dialer.EXPECT().DialContext(gomock.Any(), "tcp", apiServerPrivateEndpointIP+":2201").Return(l.DialContext(ctx, "", ""))
@@ -565,57 +465,6 @@ func TestProxy(t *testing.T) {
 		// 		HostKeyAlgorithms: []string{cryptossh.KeyAlgoRSASHA512},
 		// 	},
 		// },
-		{
-			// Strict-verification path: the stored host key differs from what the
-			// server presents.  The connection must be rejected (not silently passed).
-			name:     "stored host key mismatch rejects connection",
-			username: username,
-			password: password,
-			fixtureChecker: func(tt *test, fixture *testdatabase.Fixture, checker *testdatabase.Checker, openShiftClustersClient *cosmosdb.FakeOpenShiftClusterDocumentClient, portalClient *cosmosdb.FakePortalDocumentClient) {
-				portalDocument := goodPortalDocument(tt.password)
-				fixture.AddPortalDocuments(portalDocument)
-
-				// Seed a different key — the server will present serverHostPubKey
-				// but we store wrongHostPubKey, so verification must fail.
-				openShiftClusterDocument := &api.OpenShiftClusterDocument{
-					ID:  resourceID,
-					Key: resourceID,
-					OpenShiftCluster: &api.OpenShiftCluster{
-						Properties: api.OpenShiftClusterProperties{
-							NetworkProfile: api.NetworkProfile{
-								APIServerPrivateEndpointIP: apiServerPrivateEndpointIP,
-							},
-							SSHKey: api.SecureBytes(x509.MarshalPKCS1PrivateKey(clusterKey)),
-							SSHHostPublicKeys: map[string]api.SecureBytes{
-								"1": wrongHostPubKey.Marshal(),
-							},
-						},
-					},
-				}
-				fixture.AddOpenShiftClusterDocuments(openShiftClusterDocument)
-
-				portalDocument = goodPortalDocument(tt.password)
-				portalDocument.Portal.SSH.Authenticated = true
-				checker.AddPortalDocuments(portalDocument)
-				// The cluster document must remain unchanged (no key persisted).
-				checker.AddOpenShiftClusterDocuments(openShiftClusterDocument)
-			},
-			mocks: func(dialer *mock_proxy.MockDialer) {
-				dialer.EXPECT().DialContext(gomock.Any(), "tcp", apiServerPrivateEndpointIP+":2201").Return(l.DialContext(ctx, "", ""))
-			},
-			// The client sees EOF because the proxy drops the downstream connection
-			// after the host key mismatch on the portal→cluster leg.
-			wantErrPrefix: "EOF",
-			wantLogs: []testlog.ExpectedLogEntry{
-				{
-					"level":       gomega.Equal(logrus.InfoLevel),
-					"msg":         gomega.Equal("authentication succeeded"),
-					"remote_addr": gomega.Not(gomega.BeEmpty()),
-					"username":    gomega.Equal(username),
-				},
-			},
-			ciphers: goodCiphers,
-		},
 		{
 			name:     "bad hostkey",
 			username: username,


### PR DESCRIPTION
Reverts Azure/ARO-RP#4901

This is incorrect and breaks master node replacements.