### PR TITLE
Admin API: JIT-elevated SSH endpoint

### DIFF
--- a/pkg/frontend/admin_openshiftcluster_ssh.go
+++ b/pkg/frontend/admin_openshiftcluster_ssh.go
@@ -1,0 +1,255 @@
+package frontend
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"bytes"
+	"context"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"regexp"
+	"strings"
+	"text/template"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/sirupsen/logrus"
+	cryptossh "golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
+	"github.com/Azure/ARO-RP/pkg/env"
+	"github.com/Azure/ARO-RP/pkg/frontend/middleware"
+	"github.com/Azure/ARO-RP/pkg/util/azureclient/azuresdk/azsecrets"
+	"github.com/Azure/ARO-RP/pkg/util/encryption"
+	utilssh "github.com/Azure/ARO-RP/pkg/util/ssh"
+)
+
+const adminSSHTTL = time.Minute
+
+// rxSSHUsername bounds the identity local-part embedded into the returned ssh
+// command to a conservative, shell-safe character set.
+var rxSSHUsername = regexp.MustCompile(`^[a-zA-Z0-9._%+-]+$`)
+
+type adminSSHRequest struct {
+	Master int `json:"master"`
+}
+
+type adminSSHResponse struct {
+	Command  string `json:"command,omitempty"`
+	Password string `json:"password,omitempty"`
+}
+
+// postAdminOpenShiftClusterSSHNewElevated mints a per-request SSH credential
+// consumed by the portal binary's SSH reverse proxy. Elevation is JIT-gated
+// upstream by the ACIS Geneva Action manifest that fronts this route.
+func (f *frontend) postAdminOpenShiftClusterSSHNewElevated(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	log := ctx.Value(middleware.ContextKeyLog).(*logrus.Entry)
+
+	resp, err := f._adminOpenShiftClusterSSHNewElevated(ctx, log, r)
+	if err != nil {
+		adminReply(log, w, nil, nil, err)
+		return
+	}
+
+	// Byte-for-byte parity with the portal binary's ssh.New response so
+	// existing tooling can consume either endpoint interchangeably.
+	w.Header().Set("Content-Type", "application/json")
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "    ")
+	if err := enc.Encode(resp); err != nil {
+		log.Warn(err)
+	}
+}
+
+// SECURITY: auth is enforced upstream by the ACIS Geneva Action manifest
+// (URL suffix + manifest role). RP does NOT do an in-process group check.
+// Uniform with other admin endpoints; portal binary diverges.
+func (f *frontend) _adminOpenShiftClusterSSHNewElevated(ctx context.Context, log *logrus.Entry, r *http.Request) (*adminSSHResponse, error) {
+	if f.portalSSHHostPubKey == nil {
+		return nil, api.NewCloudError(http.StatusServiceUnavailable, api.CloudErrorCodeInternalServerError, "", "Portal SSH host key is not available; the SSH endpoint is disabled.")
+	}
+
+	// Body middleware has already enforced Content-Type: application/json
+	// and buffered the payload into ContextKeyBody.
+	body := r.Context().Value(middleware.ContextKeyBody).([]byte)
+	var req adminSSHRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidRequestContent, "", fmt.Sprintf("The request body could not be parsed: %v.", err))
+	}
+	if req.Master < 0 || req.Master > 2 {
+		return nil, api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, "master", "master must be 0, 1, or 2.")
+	}
+
+	// Strip "/admin" prefix and the action suffix to leave the ARM ID. Suffix-
+	// trim (not LastIndex-slice) so a router-table bug can't panic.
+	const actionSuffix = "/ssh/newelevated"
+	resourceID := strings.TrimPrefix(r.URL.Path, "/admin")
+	if !strings.HasSuffix(resourceID, actionSuffix) {
+		return nil, api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "", "unexpected admin SSH URL path")
+	}
+	resourceID = strings.TrimSuffix(resourceID, actionSuffix)
+
+	// Confirm the target cluster exists before minting. Otherwise a typo'd or
+	// deleted resource ID leaves a stray PortalDocument (and a portal-side
+	// "authentication succeeded" record) for a token that can never connect.
+	dbOpenShiftClusters, err := f.dbGroup.OpenShiftClusters()
+	if err != nil {
+		return nil, api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "", err.Error())
+	}
+	if _, err := dbOpenShiftClusters.Get(ctx, strings.ToLower(resourceID)); err != nil {
+		if cosmosdb.IsErrorStatusCode(err, http.StatusNotFound) {
+			return nil, api.NewCloudError(http.StatusNotFound, api.CloudErrorCodeResourceNotFound, "",
+				fmt.Sprintf("The Resource '%s/%s' under resource group '%s' was not found.",
+					chi.URLParam(r, "resourceType"),
+					chi.URLParam(r, "resourceName"),
+					chi.URLParam(r, "resourceGroupName")))
+		}
+		return nil, api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "", err.Error())
+	}
+
+	// The minted command and the portal proxy's PasswordCallback both key off
+	// the caller identity; an empty username yields a token the proxy can never
+	// match. Fail fast rather than persist a dead PortalDocument.
+	username := sreUsername(ctx)
+	if username == "" {
+		return nil, api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, "", "The caller identity could not be determined from the request.")
+	}
+
+	// sshUser (the local-part of the identity) is embedded into the returned
+	// shell command and matched by the portal proxy's PasswordCallback. Reject
+	// whitespace, shell metacharacters, or an empty local-part (e.g. "@contoso")
+	// before minting, so the command can't break or be abused for injection by
+	// automation that runs it.
+	sshUser := strings.SplitN(username, "@", 2)[0]
+	if !rxSSHUsername.MatchString(sshUser) {
+		return nil, api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, "", "The caller identity contains unsupported characters.")
+	}
+
+	dbPortal, err := f.dbGroup.Portal()
+	if err != nil {
+		return nil, api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "", err.Error())
+	}
+
+	password := dbPortal.NewUUID()
+	portalDoc := &api.PortalDocument{
+		ID:  password,
+		TTL: int(adminSSHTTL / time.Second),
+		Portal: &api.Portal{
+			Username: username,
+			ID:       resourceID,
+			SSH: &api.SSH{
+				Master: req.Master,
+			},
+		},
+	}
+
+	// Audit trail. Emit BEFORE the Cosmos write so a failed Create still
+	// leaves a creation-attempt record. Do NOT log the password: it is the
+	// SSH bearer credential and would leak into Kusto.
+	log.WithFields(logrus.Fields{
+		"username":   username,
+		"resourceID": resourceID,
+		"master":     req.Master,
+		"ttlSeconds": portalDoc.TTL,
+	}).Info("admin ssh create")
+
+	if _, err := dbPortal.Create(ctx, portalDoc); err != nil {
+		return nil, api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "", err.Error())
+	}
+
+	// sshUser was validated above; the proxy's PasswordCallback matches it
+	// against the LHS of Portal.Username.
+	hostname := fmt.Sprintf("%s.admin.aro.azure.com", strings.ToLower(f.env.Location()))
+	command, err := adminCreateLoginCommand(sshUser, hostname, f.portalSSHHostPubKey)
+	if err != nil {
+		return nil, api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "", err.Error())
+	}
+
+	return &adminSSHResponse{Command: command, Password: password}, nil
+}
+
+// adminSSHCommand mirrors pkg/portal/ssh.sshCommand but hard-codes the
+// production SSH port (22). Duplicated intentionally: exporting the portal
+// template would bind an ARM-facing handler to a portal-package internal.
+const adminSSHCommand = "echo '{{ .KnownHostLine }}' > {{.Hostname}}_known_host ; " +
+	"ssh " +
+	"-o UserKnownHostsFile={{.Hostname}}_known_host " +
+	"-o Ciphers={{ .Ciphers }} " +
+	"-o HostKeyAlgorithms={{ .HostKeyAlgorithms }} " +
+	"-o KexAlgorithms={{ .KexAlgorithms }} " +
+	"-o MACs={{ .MACs }} {{.User}}@{{.Hostname}}"
+
+func adminCreateLoginCommand(user, host string, publicKey cryptossh.PublicKey) (string, error) {
+	line := knownhosts.Line([]string{host}, publicKey)
+	tmp, err := template.New("command").Parse(adminSSHCommand)
+	if err != nil {
+		return "", err
+	}
+	type fields struct {
+		User              string
+		Hostname          string
+		KnownHostLine     string
+		Ciphers           string
+		HostKeyAlgorithms string
+		KexAlgorithms     string
+		MACs              string
+	}
+	var buff bytes.Buffer
+	err = tmp.Execute(&buff, fields{
+		User:              user,
+		Hostname:          host,
+		KnownHostLine:     line,
+		Ciphers:           utilssh.Ciphers()[0],
+		HostKeyAlgorithms: utilssh.HostKeyAlgorithms()[0],
+		KexAlgorithms:     utilssh.KexAlgorithms()[0],
+		MACs:              utilssh.MACs()[0],
+	})
+	return buff.String(), err
+}
+
+// loadPortalSSHHostPubKey fetches the portal binary's SSH host key from the
+// portal keyvault and derives its public key. Called once at frontend
+// startup; on failure the admin SSH endpoint returns 503.
+func loadPortalSSHHostPubKey(ctx context.Context, _env env.Interface) (cryptossh.PublicKey, error) {
+	msiCredential, err := _env.NewMSITokenCredential()
+	if err != nil {
+		return nil, err
+	}
+
+	keyVaultPrefix := os.Getenv(encryption.KeyVaultPrefix)
+	if keyVaultPrefix == "" {
+		return nil, fmt.Errorf("%s env var not set", encryption.KeyVaultPrefix)
+	}
+
+	portalKeyvaultURI := azsecrets.URI(_env, env.PortalKeyvaultSuffix, keyVaultPrefix)
+	secretsClient, err := azsecrets.NewClient(portalKeyvaultURI, msiCredential, _env.Environment().AzureClientOptions())
+	if err != nil {
+		return nil, fmt.Errorf("cannot create portal keyvault secrets client: %w", err)
+	}
+
+	serverSSHKey, err := secretsClient.GetSecret(ctx, env.PortalServerSSHKeySecretName, "", nil)
+	if err != nil {
+		return nil, fmt.Errorf("cannot get portal server ssh key secret: %w", err)
+	}
+
+	b, err := azsecrets.ExtractBase64Value(serverSSHKey)
+	if err != nil {
+		return nil, err
+	}
+
+	// Portal binary stores an RSA host key in PKCS#1 form; mirror its parse.
+	priv, err := x509.ParsePKCS1PrivateKey(b)
+	if err != nil {
+		return nil, fmt.Errorf("cannot parse portal server ssh key: %w", err)
+	}
+
+	return cryptossh.NewPublicKey(&priv.PublicKey)
+}

--- a/pkg/frontend/admin_openshiftcluster_ssh.go
+++ b/pkg/frontend/admin_openshiftcluster_ssh.go
@@ -16,6 +16,7 @@ import (
 	"text/template"
 	"time"
 
+	mgmtcompute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
 	"github.com/go-chi/chi/v5"
 	"github.com/sirupsen/logrus"
 	cryptossh "golang.org/x/crypto/ssh"
@@ -28,6 +29,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/azuresdk/azsecrets"
 	"github.com/Azure/ARO-RP/pkg/util/encryption"
 	utilssh "github.com/Azure/ARO-RP/pkg/util/ssh"
+	"github.com/Azure/ARO-RP/pkg/util/stringutils"
 )
 
 const adminSSHTTL = time.Minute
@@ -104,7 +106,8 @@ func (f *frontend) _adminOpenShiftClusterSSHNewElevated(ctx context.Context, log
 	if err != nil {
 		return nil, api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "", err.Error())
 	}
-	if _, err := dbOpenShiftClusters.Get(ctx, strings.ToLower(resourceID)); err != nil {
+	doc, err := dbOpenShiftClusters.Get(ctx, strings.ToLower(resourceID))
+	if err != nil {
 		if cosmosdb.IsErrorStatusCode(err, http.StatusNotFound) {
 			return nil, api.NewCloudError(http.StatusNotFound, api.CloudErrorCodeResourceNotFound, "",
 				fmt.Sprintf("The Resource '%s/%s' under resource group '%s' was not found.",
@@ -131,6 +134,14 @@ func (f *frontend) _adminOpenShiftClusterSSHNewElevated(ctx context.Context, log
 	sshUser := strings.SplitN(username, "@", 2)[0]
 	if !rxSSHUsername.MatchString(sshUser) {
 		return nil, api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, "", "The caller identity contains unsupported characters.")
+	}
+
+	// Best-effort: if the requested master is powered off in Azure, reject now
+	// with a clear message rather than mint a token that dies on a dial timeout
+	// at connect. A transient Azure lookup failure must not block SSH access, so
+	// anything short of a definitive "not running" is allowed through.
+	if err := f.checkSSHMasterPowered(ctx, log, doc, req.Master); err != nil {
+		return nil, err
 	}
 
 	dbPortal, err := f.dbGroup.Portal()
@@ -174,6 +185,49 @@ func (f *frontend) _adminOpenShiftClusterSSHNewElevated(ctx context.Context, log
 	}
 
 	return &adminSSHResponse{Command: command, Password: password}, nil
+}
+
+// checkSSHMasterPowered rejects the request when the target master VM is not
+// running in Azure, so the SRE gets a clear error instead of a dial timeout at
+// connect. It is best-effort: subscription/client/lookup failures are logged
+// and allowed through so a transient Azure blip can't break SSH access.
+func (f *frontend) checkSSHMasterPowered(ctx context.Context, log *logrus.Entry, doc *api.OpenShiftClusterDocument, master int) error {
+	subscriptionDoc, err := f.getSubscriptionDocument(ctx, doc.Key)
+	if err != nil {
+		log.Warnf("admin ssh: skipping master power-state check, cannot load subscription: %v", err)
+		return nil
+	}
+	a, err := f.azureActionsFactory(log, f.env, doc.OpenShiftCluster, subscriptionDoc)
+	if err != nil {
+		log.Warnf("admin ssh: skipping master power-state check, cannot build azure client: %v", err)
+		return nil
+	}
+	clusterRGName := stringutils.LastTokenByte(doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID, '/')
+	vmName := fmt.Sprintf("%s-master-%d", doc.OpenShiftCluster.Properties.InfraID, master)
+	vm, err := a.GetVirtualMachine(ctx, clusterRGName, vmName, mgmtcompute.InstanceView)
+	if err != nil {
+		log.Warnf("admin ssh: skipping master power-state check, cannot get VM %s: %v", vmName, err)
+		return nil
+	}
+	if ps := masterPowerStateCode(vm); ps != "" && ps != "PowerState/running" {
+		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, "master",
+			fmt.Sprintf("master-%d is not running (%s); power it on or choose a running master.", master, ps))
+	}
+	return nil
+}
+
+// masterPowerStateCode returns the "PowerState/*" status code from a VM instance
+// view, or "" if none is present.
+func masterPowerStateCode(vm mgmtcompute.VirtualMachine) string {
+	if vm.InstanceView == nil || vm.InstanceView.Statuses == nil {
+		return ""
+	}
+	for _, status := range *vm.InstanceView.Statuses {
+		if status.Code != nil && strings.HasPrefix(*status.Code, "PowerState/") {
+			return *status.Code
+		}
+	}
+	return ""
 }
 
 // adminSSHCommand mirrors pkg/portal/ssh.sshCommand but hard-codes the

--- a/pkg/frontend/admin_openshiftcluster_ssh.go
+++ b/pkg/frontend/admin_openshiftcluster_ssh.go
@@ -35,8 +35,10 @@ import (
 const adminSSHTTL = time.Minute
 
 // rxSSHUsername bounds the identity local-part embedded into the returned ssh
-// command to a conservative, shell-safe character set.
-var rxSSHUsername = regexp.MustCompile(`^[a-zA-Z0-9._%+-]+$`)
+// command to a conservative, shell-safe character set. A leading dash is
+// disallowed so the command's "<user>@<host>" argument can't be parsed by ssh
+// as a CLI option.
+var rxSSHUsername = regexp.MustCompile(`^[a-zA-Z0-9._%+][a-zA-Z0-9._%+-]*$`)
 
 type adminSSHRequest struct {
 	Master int `json:"master"`

--- a/pkg/frontend/admin_openshiftcluster_ssh.go
+++ b/pkg/frontend/admin_openshiftcluster_ssh.go
@@ -16,11 +16,12 @@ import (
 	"text/template"
 	"time"
 
-	mgmtcompute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
 	"github.com/go-chi/chi/v5"
 	"github.com/sirupsen/logrus"
 	cryptossh "golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/knownhosts"
+
+	mgmtcompute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"

--- a/pkg/frontend/admin_openshiftcluster_ssh_test.go
+++ b/pkg/frontend/admin_openshiftcluster_ssh_test.go
@@ -1,0 +1,277 @@
+package frontend
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	cryptossh "golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/metrics/noop"
+	testdatabase "github.com/Azure/ARO-RP/test/database"
+)
+
+func TestAdminOpenShiftClusterSSHNewElevated(t *testing.T) {
+	mockSubID := "00000000-0000-0000-0000-000000000000"
+	ctx := context.Background()
+
+	resourcePath := strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName"))
+
+	// One host key per test run. Real deployments load this from the portal
+	// keyvault; the test just needs any RSA pubkey the KnownHosts helper
+	// can render.
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hostPub, err := cryptossh.NewPublicKey(&priv.PublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedKnownHostLine := knownhosts.Line([]string{"eastus.admin.aro.azure.com"}, hostPub)
+
+	type test struct {
+		name              string
+		systemDataHeader  string
+		body              interface{}
+		contentType       string // "" => header omitted
+		omitHostKey       bool
+		omitClusterDoc    bool
+		injectPortalError error
+		wantStatusCode    int
+		wantError         string
+		wantUsername      string
+		wantMaster        int
+	}
+
+	for _, tt := range []*test{
+		{
+			name:             "master 0 issued by SRE",
+			systemDataHeader: `{"lastModifiedBy":"sre@redhat.com"}`,
+			body:             &adminSSHRequest{Master: 0},
+			contentType:      "application/json",
+			wantStatusCode:   http.StatusOK,
+			wantUsername:     "sre@redhat.com",
+			wantMaster:       0,
+		},
+		{
+			name:             "master 2 issued by SRE",
+			systemDataHeader: `{"lastModifiedBy":"sre@redhat.com"}`,
+			body:             &adminSSHRequest{Master: 2},
+			contentType:      "application/json",
+			wantStatusCode:   http.StatusOK,
+			wantUsername:     "sre@redhat.com",
+			wantMaster:       2,
+		},
+		{
+			name:             "falls back to createdBy when lastModifiedBy is empty",
+			systemDataHeader: `{"createdBy":"creator@redhat.com"}`,
+			body:             &adminSSHRequest{Master: 1},
+			contentType:      "application/json",
+			wantStatusCode:   http.StatusOK,
+			wantUsername:     "creator@redhat.com",
+			wantMaster:       1,
+		},
+		{
+			name:             "missing SystemData header returns 400",
+			systemDataHeader: "",
+			body:             &adminSSHRequest{Master: 0},
+			contentType:      "application/json",
+			wantStatusCode:   http.StatusBadRequest,
+			wantError:        "400: InvalidParameter: : The caller identity could not be determined from the request.",
+		},
+		{
+			name:             "portal host key unavailable returns 503",
+			systemDataHeader: `{"lastModifiedBy":"sre@redhat.com"}`,
+			body:             &adminSSHRequest{Master: 0},
+			contentType:      "application/json",
+			omitHostKey:      true,
+			wantStatusCode:   http.StatusServiceUnavailable,
+			wantError:        "503: InternalServerError: : Portal SSH host key is not available; the SSH endpoint is disabled.",
+		},
+		{
+			name:             "wrong Content-Type returns 415",
+			systemDataHeader: `{"lastModifiedBy":"sre@redhat.com"}`,
+			body:             &adminSSHRequest{Master: 0},
+			contentType:      "text/plain",
+			wantStatusCode:   http.StatusUnsupportedMediaType,
+			wantError:        "415: UnsupportedMediaType: : The content media type 'text/plain' is not supported. Only 'application/json' is supported.",
+		},
+		{
+			name:             "master out of range returns 400",
+			systemDataHeader: `{"lastModifiedBy":"sre@redhat.com"}`,
+			body:             &adminSSHRequest{Master: 3},
+			contentType:      "application/json",
+			wantStatusCode:   http.StatusBadRequest,
+			wantError:        "400: InvalidParameter: master: master must be 0, 1, or 2.",
+		},
+		{
+			name:              "cosmos create failure surfaces 500",
+			systemDataHeader:  `{"lastModifiedBy":"sre@redhat.com"}`,
+			body:              &adminSSHRequest{Master: 0},
+			contentType:       "application/json",
+			injectPortalError: errors.New("simulated cosmos write failure"),
+			wantStatusCode:    http.StatusInternalServerError,
+			wantError:         "500: InternalServerError: : simulated cosmos write failure",
+		},
+		{
+			name:             "cluster not found returns 404 without minting a portal document",
+			systemDataHeader: `{"lastModifiedBy":"sre@redhat.com"}`,
+			body:             &adminSSHRequest{Master: 0},
+			contentType:      "application/json",
+			omitClusterDoc:   true,
+			wantStatusCode:   http.StatusNotFound,
+			wantError:        "404: ResourceNotFound: : The Resource 'openshiftclusters/resourcename' under resource group 'resourcegroup' was not found.",
+		},
+		{
+			name:             "identity with shell metacharacters returns 400",
+			systemDataHeader: `{"lastModifiedBy":"evil;rm -rf@redhat.com"}`,
+			body:             &adminSSHRequest{Master: 0},
+			contentType:      "application/json",
+			wantStatusCode:   http.StatusBadRequest,
+			wantError:        "400: InvalidParameter: : The caller identity contains unsupported characters.",
+		},
+		{
+			name:             "empty local-part identity returns 400",
+			systemDataHeader: `{"lastModifiedBy":"@contoso"}`,
+			body:             &adminSSHRequest{Master: 0},
+			contentType:      "application/json",
+			wantStatusCode:   http.StatusBadRequest,
+			wantError:        "400: InvalidParameter: : The caller identity contains unsupported characters.",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ti := newTestInfra(t).WithPortal().WithOpenShiftClusters()
+			defer ti.done()
+
+			if !tt.omitClusterDoc {
+				ti.fixture.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
+					Key: resourcePath,
+					OpenShiftCluster: &api.OpenShiftCluster{
+						ID:   resourcePath,
+						Name: "resourceName",
+						Type: "Microsoft.RedHatOpenShift/openshiftClusters",
+					},
+				})
+				if err := ti.buildFixtures(nil); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			f, err := NewFrontend(ctx, ti.auditLog, ti.log, ti.otelAudit, ti.env, ti.dbGroup, api.APIs, &noop.Noop{}, &noop.Noop{}, nil, nil, nil, nil, nil, nil, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !tt.omitHostKey {
+				f.portalSSHHostPubKey = hostPub
+			}
+
+			if tt.injectPortalError != nil {
+				ti.portalClient.SetError(tt.injectPortalError)
+			}
+
+			go f.Run(ctx, nil, nil)
+
+			header := http.Header{}
+			if tt.systemDataHeader != "" {
+				header.Set("X-Ms-Arm-Resource-System-Data", tt.systemDataHeader)
+			}
+			if tt.contentType != "" {
+				header.Set("Content-Type", tt.contentType)
+			}
+
+			resp, b, err := ti.request(http.MethodPost,
+				"https://server/admin"+resourcePath+"/ssh/newelevated",
+				header, tt.body)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if tt.injectPortalError != nil {
+				ti.portalClient.SetError(nil)
+			}
+
+			if tt.wantError != "" {
+				if err := validateResponse(resp, b, tt.wantStatusCode, tt.wantError, nil); err != nil {
+					t.Error(err)
+				}
+				docs, listErr := ti.portalClient.ListAll(ctx, nil)
+				if listErr != nil {
+					t.Fatal(listErr)
+				}
+				if len(docs.PortalDocuments) != 0 {
+					t.Errorf("expected 0 portal documents persisted, got %d", len(docs.PortalDocuments))
+				}
+				return
+			}
+
+			if resp.StatusCode != tt.wantStatusCode {
+				t.Fatalf("unexpected status code %d, wanted %d: %s", resp.StatusCode, tt.wantStatusCode, string(b))
+			}
+
+			var got adminSSHResponse
+			if err := json.Unmarshal(b, &got); err != nil {
+				t.Fatalf("response is not a valid adminSSHResponse: %v\nbody: %s", err, string(b))
+			}
+			if got.Password != firstPortalUUID {
+				t.Errorf("response Password: got %q, want %q", got.Password, firstPortalUUID)
+			}
+			// Command must pin the injected host key; the LHS-of-@ username
+			// is what the portal SSH proxy'll match on PasswordCallback.
+			wantUserPrefix := strings.SplitN(tt.wantUsername, "@", 2)[0]
+			if !strings.Contains(got.Command, expectedKnownHostLine) {
+				t.Errorf("response Command missing KnownHosts pin\ncommand: %s\nwant substring: %s", got.Command, expectedKnownHostLine)
+			}
+			if !strings.Contains(got.Command, wantUserPrefix+"@eastus.admin.aro.azure.com") {
+				t.Errorf("response Command missing %q@host suffix\ncommand: %s", wantUserPrefix, got.Command)
+			}
+
+			docs, err := ti.portalClient.ListAll(ctx, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(docs.PortalDocuments) != 1 {
+				t.Fatalf("expected 1 portal document persisted, got %d", len(docs.PortalDocuments))
+			}
+			doc := docs.PortalDocuments[0]
+			if doc.ID != firstPortalUUID {
+				t.Errorf("portal doc ID: got %q, want %q", doc.ID, firstPortalUUID)
+			}
+			if doc.Portal == nil {
+				t.Fatal("portal doc has nil Portal payload")
+			}
+			if doc.Portal.ID != resourcePath {
+				t.Errorf("portal doc Portal.ID: got %q, want %q", doc.Portal.ID, resourcePath)
+			}
+			if doc.Portal.Username != tt.wantUsername {
+				t.Errorf("portal doc Portal.Username: got %q, want %q", doc.Portal.Username, tt.wantUsername)
+			}
+			if doc.Portal.SSH == nil {
+				t.Fatal("portal doc Portal.SSH is nil")
+			}
+			if doc.Portal.SSH.Master != tt.wantMaster {
+				t.Errorf("portal doc SSH.Master: got %d, want %d", doc.Portal.SSH.Master, tt.wantMaster)
+			}
+			if doc.Portal.SSH.Authenticated {
+				t.Errorf("portal doc SSH.Authenticated: got true, want false")
+			}
+			if doc.Portal.Kubeconfig != nil {
+				t.Errorf("portal doc Portal.Kubeconfig should be nil, got %+v", doc.Portal.Kubeconfig)
+			}
+			if doc.TTL != 60 {
+				t.Errorf("portal doc TTL: got %d seconds, want 60 (1m)", doc.TTL)
+			}
+		})
+	}
+}

--- a/pkg/frontend/admin_openshiftcluster_ssh_test.go
+++ b/pkg/frontend/admin_openshiftcluster_ssh_test.go
@@ -13,11 +13,18 @@ import (
 	"strings"
 	"testing"
 
+	mgmtcompute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
+	"github.com/sirupsen/logrus"
+	"go.uber.org/mock/gomock"
 	cryptossh "golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/knownhosts"
 
 	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/env"
+	"github.com/Azure/ARO-RP/pkg/frontend/adminactions"
 	"github.com/Azure/ARO-RP/pkg/metrics/noop"
+	mock_adminactions "github.com/Azure/ARO-RP/pkg/util/mocks/adminactions"
+	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 	testdatabase "github.com/Azure/ARO-RP/test/database"
 )
 
@@ -47,6 +54,7 @@ func TestAdminOpenShiftClusterSSHNewElevated(t *testing.T) {
 		contentType       string // "" => header omitted
 		omitHostKey       bool
 		omitClusterDoc    bool
+		azureMock         func(*mock_adminactions.MockAzureActions)
 		injectPortalError error
 		wantStatusCode    int
 		wantError         string
@@ -60,27 +68,36 @@ func TestAdminOpenShiftClusterSSHNewElevated(t *testing.T) {
 			systemDataHeader: `{"lastModifiedBy":"sre@redhat.com"}`,
 			body:             &adminSSHRequest{Master: 0},
 			contentType:      "application/json",
-			wantStatusCode:   http.StatusOK,
-			wantUsername:     "sre@redhat.com",
-			wantMaster:       0,
+			azureMock: func(a *mock_adminactions.MockAzureActions) {
+				a.EXPECT().GetVirtualMachine(gomock.Any(), "test-cluster", "aro-infra-master-0", mgmtcompute.InstanceView).Return(sshMasterVM("PowerState/running"), nil)
+			},
+			wantStatusCode: http.StatusOK,
+			wantUsername:   "sre@redhat.com",
+			wantMaster:     0,
 		},
 		{
 			name:             "master 2 issued by SRE",
 			systemDataHeader: `{"lastModifiedBy":"sre@redhat.com"}`,
 			body:             &adminSSHRequest{Master: 2},
 			contentType:      "application/json",
-			wantStatusCode:   http.StatusOK,
-			wantUsername:     "sre@redhat.com",
-			wantMaster:       2,
+			azureMock: func(a *mock_adminactions.MockAzureActions) {
+				a.EXPECT().GetVirtualMachine(gomock.Any(), "test-cluster", "aro-infra-master-2", mgmtcompute.InstanceView).Return(sshMasterVM("PowerState/running"), nil)
+			},
+			wantStatusCode: http.StatusOK,
+			wantUsername:   "sre@redhat.com",
+			wantMaster:     2,
 		},
 		{
 			name:             "falls back to createdBy when lastModifiedBy is empty",
 			systemDataHeader: `{"createdBy":"creator@redhat.com"}`,
 			body:             &adminSSHRequest{Master: 1},
 			contentType:      "application/json",
-			wantStatusCode:   http.StatusOK,
-			wantUsername:     "creator@redhat.com",
-			wantMaster:       1,
+			azureMock: func(a *mock_adminactions.MockAzureActions) {
+				a.EXPECT().GetVirtualMachine(gomock.Any(), "test-cluster", "aro-infra-master-1", mgmtcompute.InstanceView).Return(sshMasterVM("PowerState/running"), nil)
+			},
+			wantStatusCode: http.StatusOK,
+			wantUsername:   "creator@redhat.com",
+			wantMaster:     1,
 		},
 		{
 			name:             "missing SystemData header returns 400",
@@ -116,10 +133,13 @@ func TestAdminOpenShiftClusterSSHNewElevated(t *testing.T) {
 			wantError:        "400: InvalidParameter: master: master must be 0, 1, or 2.",
 		},
 		{
-			name:              "cosmos create failure surfaces 500",
-			systemDataHeader:  `{"lastModifiedBy":"sre@redhat.com"}`,
-			body:              &adminSSHRequest{Master: 0},
-			contentType:       "application/json",
+			name:             "cosmos create failure surfaces 500",
+			systemDataHeader: `{"lastModifiedBy":"sre@redhat.com"}`,
+			body:             &adminSSHRequest{Master: 0},
+			contentType:      "application/json",
+			azureMock: func(a *mock_adminactions.MockAzureActions) {
+				a.EXPECT().GetVirtualMachine(gomock.Any(), "test-cluster", "aro-infra-master-0", mgmtcompute.InstanceView).Return(sshMasterVM("PowerState/running"), nil)
+			},
 			injectPortalError: errors.New("simulated cosmos write failure"),
 			wantStatusCode:    http.StatusInternalServerError,
 			wantError:         "500: InternalServerError: : simulated cosmos write failure",
@@ -149,10 +169,41 @@ func TestAdminOpenShiftClusterSSHNewElevated(t *testing.T) {
 			wantStatusCode:   http.StatusBadRequest,
 			wantError:        "400: InvalidParameter: : The caller identity contains unsupported characters.",
 		},
+		{
+			name:             "deallocated master returns 400",
+			systemDataHeader: `{"lastModifiedBy":"sre@redhat.com"}`,
+			body:             &adminSSHRequest{Master: 1},
+			contentType:      "application/json",
+			azureMock: func(a *mock_adminactions.MockAzureActions) {
+				a.EXPECT().GetVirtualMachine(gomock.Any(), "test-cluster", "aro-infra-master-1", mgmtcompute.InstanceView).Return(sshMasterVM("PowerState/deallocated"), nil)
+			},
+			wantStatusCode: http.StatusBadRequest,
+			wantError:      "400: InvalidParameter: master: master-1 is not running (PowerState/deallocated); power it on or choose a running master.",
+		},
+		{
+			name:             "azure power-state lookup error is non-fatal",
+			systemDataHeader: `{"lastModifiedBy":"sre@redhat.com"}`,
+			body:             &adminSSHRequest{Master: 0},
+			contentType:      "application/json",
+			azureMock: func(a *mock_adminactions.MockAzureActions) {
+				a.EXPECT().GetVirtualMachine(gomock.Any(), "test-cluster", "aro-infra-master-0", mgmtcompute.InstanceView).Return(mgmtcompute.VirtualMachine{}, errors.New("azure boom"))
+			},
+			wantStatusCode: http.StatusOK,
+			wantUsername:   "sre@redhat.com",
+			wantMaster:     0,
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			ti := newTestInfra(t).WithPortal().WithOpenShiftClusters()
+			controller := gomock.NewController(t)
+			defer controller.Finish()
+
+			ti := newTestInfra(t).WithPortal().WithOpenShiftClusters().WithSubscriptions()
 			defer ti.done()
+
+			azureActions := mock_adminactions.NewMockAzureActions(controller)
+			if tt.azureMock != nil {
+				tt.azureMock(azureActions)
+			}
 
 			if !tt.omitClusterDoc {
 				ti.fixture.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
@@ -161,6 +212,21 @@ func TestAdminOpenShiftClusterSSHNewElevated(t *testing.T) {
 						ID:   resourcePath,
 						Name: "resourceName",
 						Type: "Microsoft.RedHatOpenShift/openshiftClusters",
+						Properties: api.OpenShiftClusterProperties{
+							InfraID: "aro-infra",
+							ClusterProfile: api.ClusterProfile{
+								ResourceGroupID: "/subscriptions/" + mockSubID + "/resourceGroups/test-cluster",
+							},
+						},
+					},
+				})
+				ti.fixture.AddSubscriptionDocuments(&api.SubscriptionDocument{
+					ID: mockSubID,
+					Subscription: &api.Subscription{
+						State: api.SubscriptionStateRegistered,
+						Properties: &api.SubscriptionProperties{
+							TenantID: mockSubID,
+						},
 					},
 				})
 				if err := ti.buildFixtures(nil); err != nil {
@@ -168,7 +234,10 @@ func TestAdminOpenShiftClusterSSHNewElevated(t *testing.T) {
 				}
 			}
 
-			f, err := NewFrontend(ctx, ti.auditLog, ti.log, ti.otelAudit, ti.env, ti.dbGroup, api.APIs, &noop.Noop{}, &noop.Noop{}, nil, nil, nil, nil, nil, nil, nil)
+			f, err := NewFrontend(ctx, ti.auditLog, ti.log, ti.otelAudit, ti.env, ti.dbGroup, api.APIs, &noop.Noop{}, &noop.Noop{}, nil, nil, nil, nil,
+				func(*logrus.Entry, env.Interface, *api.OpenShiftCluster, *api.SubscriptionDocument) (adminactions.AzureActions, error) {
+					return azureActions, nil
+				}, nil, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -273,5 +342,19 @@ func TestAdminOpenShiftClusterSSHNewElevated(t *testing.T) {
 				t.Errorf("portal doc TTL: got %d seconds, want 60 (1m)", doc.TTL)
 			}
 		})
+	}
+}
+
+func sshMasterVM(powerCode string) mgmtcompute.VirtualMachine {
+	statuses := []mgmtcompute.InstanceViewStatus{
+		{Code: pointerutils.ToPtr("ProvisioningState/succeeded")},
+		{Code: pointerutils.ToPtr(powerCode)},
+	}
+	return mgmtcompute.VirtualMachine{
+		VirtualMachineProperties: &mgmtcompute.VirtualMachineProperties{
+			InstanceView: &mgmtcompute.VirtualMachineInstanceView{
+				Statuses: &statuses,
+			},
+		},
 	}
 }

--- a/pkg/frontend/admin_openshiftcluster_ssh_test.go
+++ b/pkg/frontend/admin_openshiftcluster_ssh_test.go
@@ -13,11 +13,12 @@ import (
 	"strings"
 	"testing"
 
-	mgmtcompute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
 	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 	cryptossh "golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/knownhosts"
+
+	mgmtcompute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/env"

--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -20,6 +20,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	chiMiddlewares "github.com/go-chi/chi/v5/middleware"
 	"github.com/sirupsen/logrus"
+	cryptossh "golang.org/x/crypto/ssh"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -114,6 +115,10 @@ type frontend struct {
 	// portalServingCert pins the portal binary's serving cert as the CA
 	// bundle in admin-issued kubeconfigs. nil => kubeconfig endpoints 503.
 	portalServingCert *x509.Certificate
+
+	// portalSSHHostPubKey pins the portal binary's SSH host key in the
+	// KnownHosts line returned by the admin SSH endpoint. nil => 503.
+	portalSSHHostPubKey cryptossh.PublicKey
 
 	l net.Listener
 	s *http.Server
@@ -274,6 +279,17 @@ func NewFrontend(ctx context.Context,
 		baseLog.WithError(certErr).Warning("portal serving cert not available; admin kubeconfig endpoints will return 503")
 	} else {
 		f.portalServingCert = cert
+	}
+
+	// Admin SSH endpoint pins the portal binary's SSH host key. Same 503
+	// fallback pattern as the kubeconfig cert above.
+	sshCtx, sshCancel := context.WithTimeout(ctx, 30*time.Second)
+	sshPub, sshErr := loadPortalSSHHostPubKey(sshCtx, _env)
+	sshCancel()
+	if sshErr != nil {
+		baseLog.WithError(sshErr).Warning("portal ssh host key not available; admin ssh endpoint will return 503")
+	} else {
+		f.portalSSHHostPubKey = sshPub
 	}
 
 	f.ready.Store(true)
@@ -489,6 +505,10 @@ func (f *frontend) chiAuthenticatedRoutes(router chi.Router) {
 				// in its ACIS manifest.
 				r.Post("/kubeconfig/new", f.postAdminOpenShiftClusterKubeconfigNew)
 				r.Post("/kubeconfig/newelevated", f.postAdminOpenShiftClusterKubeconfigNewElevated)
+
+				// SSH token consumed by the portal binary's SSH reverse
+				// proxy. JIT-gated in its ACIS manifest.
+				r.Post("/ssh/newelevated", f.postAdminOpenShiftClusterSSHNewElevated)
 			})
 		})
 


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-26233](https://redhat.atlassian.net/browse/ARO-26233) — https://redhat.atlassian.net/browse/ARO-26233

### What this PR does / why we need it:

Adds an admin RP endpoint `POST /admin/{resourceID}/ssh/newelevated` that mints
per-request SSH credentials for the portal binary's SSH reverse proxy. The
response mirrors the portal binary's `ssh.New` response byte-for-byte
(`{command, password}` JSON), and the RP writes a `PortalDocument` with
`Portal.SSH{Master}` and a 60s TTL; the portal binary's SSH `PasswordCallback`
then authorises the follow-up TCP connect against that stored document.

Elevation is JIT-gated by the ACIS manifest that fronts `/newelevated` (same
pattern as `/kubeconfig/newelevated`, #4949); the RP does **not** do an
in-process AAD group check. This gives SREs SSH parity with the portal UI via
Geneva Actions. The portal SSH host public key is loaded once at frontend
startup from the portal keyvault (secret `portal-sshkey`, RSA PKCS#1); on
failure the endpoint returns 503 and the RP still starts.

### Test plan for issue:

- **Unit:** `TestAdminOpenShiftClusterSSHNewElevated` — 8 subtests covering
  master 0/1/2, missing host key → 503, wrong Content-Type → 415, master out of
  range → 400, and Cosmos write failure → 500.
- **Manual (local dev RP):** live mint → HTTP 200 with `{command, password}`;
  `PortalDocument` written to Cosmos (`ttl=60`, `portal.ssh.master`,
  `authenticated` unset); IfxAudit `adminOp` event = Success; password is **not**
  logged; portal SSH host key loaded from keyvault.
- **Manual e2e (dev cluster):** the minted credential is consumed by the
  **unchanged** portal SSH reverse proxy (`pkg/portal/ssh`) and yields a real
  interactive shell on `master-0`.

### Is there any documentation that needs to be updated for this PR?

No — this mirrors the existing portal SSH flow (same `PortalDocument` shape, same
proxy consumer); there is no new operator-facing doc surface. Tech-debt/N-A.

### How do you know this will function as expected in production?

- The endpoint emits the **same** `PortalDocument` shape the portal SSH proxy
  already consumes, so the data path is exercised by existing, unchanged code.
- Every call emits an IfxAudit `adminOp` event for the admin audit trail.
- Failure modes are handled explicitly: missing portal host key → 503 (RP still
  starts), invalid `master` → 400, Cosmos write failure → 500. The SSH bearer
  password is never written to logs.

---

<sub>Authoring assisted by GitHub Copilot.</sub>
