### PR TITLE
ARO-28167: support control plane resize zone topologies

### DIFF
--- a/pkg/frontend/admin_openshiftcluster_resize_validation_helpers.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_validation_helpers.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -22,10 +23,15 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/frontend/adminactions"
+	"github.com/Azure/ARO-RP/pkg/util/azurezones"
 	"github.com/Azure/ARO-RP/pkg/util/stringutils"
 )
 
+type zoneTopology string
+
 const (
+	controlPlaneReplicaCount = azurezones.CONTROL_PLANE_MACHINE_COUNT
+
 	machineNamespace           = "openshift-machine-api"
 	machineLabelClusterAPIRole = "machine.openshift.io/cluster-api-machine-role"
 	machineLabelZone           = "machine.openshift.io/zone"
@@ -34,6 +40,10 @@ const (
 
 	nodeLabelInstanceType     = "node.kubernetes.io/instance-type"
 	nodeLabelBetaInstanceType = "beta.kubernetes.io/instance-type"
+
+	zoneTopologyRegional   zoneTopology = "regional"
+	zoneTopologySingleZone zoneTopology = "single-zone"
+	zoneTopologyThreeZone  zoneTopology = "three-zone"
 )
 
 type machineValidationData struct {
@@ -125,8 +135,8 @@ func getClusterMachines(ctx context.Context, kubeActions adminactions.KubeAction
 }
 
 func validateClusterMachines(log *logrus.Entry, machines map[string]machineValidationData) (map[string]machineValidationData, error) {
-	if len(machines) != 3 {
-		return nil, fmt.Errorf("expected 3 machines, got %d", len(machines))
+	if len(machines) != controlPlaneReplicaCount {
+		return nil, fmt.Errorf("expected %d machines, got %d", controlPlaneReplicaCount, len(machines))
 	}
 
 	var validationErrs []error
@@ -145,7 +155,7 @@ func validateClusterMachines(log *logrus.Entry, machines map[string]machineValid
 		}
 
 		if machine.labelZone != machine.specZone {
-			err := fmt.Errorf("machine %v has a mismatch between label zone %v and spec zone %v. These values should match", name, machine.labelZone, machine.specZone)
+			err := fmt.Errorf("machine %s has a mismatch between label zone %s and spec zone %s. These values should match", name, machine.labelZone, machine.specZone)
 			log.Info(err)
 			validationErrs = append(validationErrs, err)
 			continue
@@ -178,7 +188,7 @@ func validateClusterMachines(log *logrus.Entry, machines map[string]machineValid
 		return nil, err
 	}
 
-	err := validateZoneDistribution(filteredMachines, func(m machineValidationData) string { return m.specZone })
+	_, err := classifyZoneTopology(filteredMachines, func(m machineValidationData) string { return m.specZone })
 	if err != nil {
 		return nil, err
 	}
@@ -196,6 +206,10 @@ func getAzureVMs(log *logrus.Entry, ctx context.Context, azureAction adminaction
 
 		vm, err := azureAction.GetVirtualMachine(ctx, clusterRGName, machineName, mgmtcompute.InstanceView)
 		if err != nil {
+			// A VM lookup failure means we could not inspect that machine at all, so
+			// fail fast instead of returning a partial validation result. In contrast,
+			// power-state mismatches are aggregated below because the VM was fetched
+			// successfully and we can still report all unhealthy instances together.
 			return nil, api.NewCloudError(
 				http.StatusInternalServerError,
 				api.CloudErrorCodeInternalServerError,
@@ -217,13 +231,6 @@ func getAzureVMs(log *logrus.Entry, ctx context.Context, azureAction adminaction
 			vmZones = *vm.Zones
 		}
 
-		if len(vmZones) == 0 {
-			err := fmt.Errorf("azure VM %v has no availability zone configured", machineName)
-			log.Info(err)
-			validationErrs = append(validationErrs, err)
-			continue
-		}
-
 		err = validateVMPowerState(log, vmStatuses, machineName)
 		if err != nil {
 			validationErrs = append(validationErrs, err)
@@ -234,10 +241,16 @@ func getAzureVMs(log *logrus.Entry, ctx context.Context, azureAction adminaction
 			vmSize = string(vm.HardwareProfile.VMSize)
 		}
 
+		zone := ""
+		if len(vmZones) > 0 {
+			zone = vmZones[0]
+		}
+		// An absent Azure zone intentionally represents a regional VM.
+
 		masterVM := azureVMValidationData{
 			vmSize: vmSize,
 			status: vmStatuses,
-			zone:   vmZones[0],
+			zone:   zone,
 		}
 
 		masterVMs[machineName] = masterVM
@@ -247,7 +260,7 @@ func getAzureVMs(log *logrus.Entry, ctx context.Context, azureAction adminaction
 		return nil, err
 	}
 
-	err := validateZoneDistribution(masterVMs, func(m azureVMValidationData) string { return m.zone })
+	_, err := classifyZoneTopology(masterVMs, func(m azureVMValidationData) string { return m.zone })
 	if err != nil {
 		return nil, err
 	}
@@ -260,20 +273,20 @@ func validateClusterMachinesAndVMs(log *logrus.Entry, ocMachines map[string]mach
 
 	for name, machineSpec := range ocMachines {
 		if _, ok := azureVMs[name]; !ok {
-			err := fmt.Errorf("machine %v not found in Azure resources", name)
+			err := fmt.Errorf("machine %s not found in Azure resources", name)
 			log.Info(err)
 			validationErrs = append(validationErrs, err)
 			continue
 		}
 
 		if machineSpec.specZone != azureVMs[name].zone {
-			err := fmt.Errorf("machine %v has zone %v in its spec, however Azure VM is running in zone %v", name, machineSpec.specZone, azureVMs[name].zone)
+			err := fmt.Errorf("machine %s has zone %s in its spec, however Azure VM is running in zone %s", name, machineSpec.specZone, azureVMs[name].zone)
 			log.Info(err)
 			validationErrs = append(validationErrs, err)
 		}
 
 		if machineSpec.size != azureVMs[name].vmSize {
-			err := fmt.Errorf("machine %v has size %v in its spec, however Azure VM is running a %v VM", name, machineSpec.size, azureVMs[name].vmSize)
+			err := fmt.Errorf("machine %s has size %s in its spec, however Azure VM is running a %s VM", name, machineSpec.size, azureVMs[name].vmSize)
 			log.Info(err)
 			validationErrs = append(validationErrs, err)
 		}
@@ -304,25 +317,45 @@ func validateClusterMachinesAndNodes(log *logrus.Entry, ocMachines map[string]ma
 	return errors.Join(validationErrs...)
 }
 
-func validateZoneDistribution[T any](items map[string]T, getZone func(T) string) error {
-	if len(items) != 3 {
-		return fmt.Errorf("expected 3 items, got %d", len(items))
+// classifyZoneTopology validates the supported control-plane placement shapes.
+// It is generic so the same rules can be applied to Machines, VMs, and capacity
+// reservations without translating them into a resize-specific data structure.
+func classifyZoneTopology[T any](items map[string]T, getZone func(T) string) (zoneTopology, error) {
+	if len(items) != controlPlaneReplicaCount {
+		return "", fmt.Errorf("expected %d items, got %d", controlPlaneReplicaCount, len(items))
 	}
 
-	zones := make(map[string]bool, 3)
+	zones := make(map[string]bool, controlPlaneReplicaCount)
 	for _, item := range items {
 		zones[getZone(item)] = true
 	}
 
-	if len(zones) != 3 {
-		return fmt.Errorf("items must be spread across 3 different zones, found %d zone(s)", len(zones))
+	if len(zones) == 1 {
+		// One empty zone is regional; one explicit zone is single-zone.
+		if zones[""] {
+			return zoneTopologyRegional, nil
+		}
+		return zoneTopologySingleZone, nil
 	}
 
-	return nil
+	if len(zones) == controlPlaneReplicaCount && !zones[""] {
+		// Three-zone placement requires every replica to have a distinct explicit zone.
+		return zoneTopologyThreeZone, nil
+	}
+
+	zoneNames := make([]string, 0, len(zones))
+	for zone := range zones {
+		zoneNames = append(zoneNames, zone)
+	}
+	// Sort zones to keep validation errors deterministic across map iterations.
+	sort.Strings(zoneNames)
+	return "", fmt.Errorf("items have unsupported mixed zone topology: zones %q", zoneNames)
 }
 
 func validateVMPowerState(log *logrus.Entry, vmStatuses []string, vmName string) error {
-	if len(vmStatuses) != 2 { // We only expect 2 power states: ProvisioningState and PowerState ... if we have more or less statuses than that, the VM is not valid
+	// We require at least the provisioning and power states; any additional
+	// statuses are validated below and rejected if unexpected.
+	if len(vmStatuses) < 2 {
 		err := fmt.Errorf("expected 2 statuses for VM %s, but found %d: %s", vmName, len(vmStatuses), strings.Join(vmStatuses, ", "))
 		log.Info(err)
 		return err
@@ -398,12 +431,14 @@ func validateClusterNodes(log *logrus.Entry, ctx context.Context, kubeActions ad
 		}
 	}
 
-	if len(controlPlaneNodesFound) != 3 {
+	if len(controlPlaneNodesFound) != controlPlaneReplicaCount {
 		nodeNames := make([]string, 0, len(controlPlaneNodesFound))
 		for name := range controlPlaneNodesFound {
 			nodeNames = append(nodeNames, name)
 		}
-		err := fmt.Errorf("expected 3 control plane nodes, found %d: [%s]", len(controlPlaneNodesFound), strings.Join(nodeNames, ", "))
+		// Sort node names so count-mismatch errors stay deterministic.
+		sort.Strings(nodeNames)
+		err := fmt.Errorf("expected %d control plane nodes, found %d: [%s]", controlPlaneReplicaCount, len(controlPlaneNodesFound), strings.Join(nodeNames, ", "))
 		log.Info(err)
 		validationErrs = append(validationErrs, err)
 	}

--- a/pkg/frontend/admin_openshiftcluster_resize_validation_helpers.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_validation_helpers.go
@@ -41,6 +41,9 @@ const (
 	nodeLabelInstanceType     = "node.kubernetes.io/instance-type"
 	nodeLabelBetaInstanceType = "beta.kubernetes.io/instance-type"
 
+	// SRE-facing label for the raw empty-zone sentinel; not a zoneTopology value.
+	zoneDisplayRegionalNoZone = "regional/no-zone"
+
 	zoneTopologyRegional  zoneTopology = "regional"
 	zoneTopologyThreeZone zoneTopology = "three-zone"
 )
@@ -62,6 +65,21 @@ type azureVMValidationData struct {
 type nodeValidationData struct {
 	nodeInstanceType string
 	betaInstanceType string
+}
+
+func describeZone(zone string) string {
+	if zone == "" {
+		return zoneDisplayRegionalNoZone
+	}
+	return zone
+}
+
+func describeZones(zones []string) []string {
+	displayZones := make([]string, 0, len(zones))
+	for _, zone := range zones {
+		displayZones = append(displayZones, describeZone(zone))
+	}
+	return displayZones
 }
 
 func unmarshalAzureMachineProviderSpec(machine *machinev1beta1.Machine) (*machinev1beta1.AzureMachineProviderSpec, error) {
@@ -154,7 +172,7 @@ func validateClusterMachines(log *logrus.Entry, machines map[string]machineValid
 		}
 
 		if machine.labelZone != machine.specZone {
-			err := fmt.Errorf("machine %s has a mismatch between label zone %s and spec zone %s. These values should match", name, machine.labelZone, machine.specZone)
+			err := fmt.Errorf("machine %s has a mismatch between label zone %s and spec zone %s. These values should match", name, describeZone(machine.labelZone), describeZone(machine.specZone))
 			log.Info(err)
 			validationErrs = append(validationErrs, err)
 			continue
@@ -279,7 +297,7 @@ func validateClusterMachinesAndVMs(log *logrus.Entry, ocMachines map[string]mach
 		}
 
 		if machineSpec.specZone != azureVMs[name].zone {
-			err := fmt.Errorf("machine %s has zone %s in its spec, however Azure VM is running in zone %s", name, machineSpec.specZone, azureVMs[name].zone)
+			err := fmt.Errorf("machine %s has zone %s in its spec, however Azure VM is running in zone %s", name, describeZone(machineSpec.specZone), describeZone(azureVMs[name].zone))
 			log.Info(err)
 			validationErrs = append(validationErrs, err)
 		}
@@ -352,7 +370,7 @@ func classifyZoneTopology[T any](items map[string]T, getZone func(T) string) (zo
 	}
 	// Sort zones to keep validation errors deterministic across map iterations.
 	sort.Strings(zoneNames)
-	return "", fmt.Errorf("items have unsupported mixed zone topology: zones %q", zoneNames)
+	return "", fmt.Errorf("items have unsupported mixed zone topology: zones %q", describeZones(zoneNames))
 }
 
 func validateVMPowerState(log *logrus.Entry, vmStatuses []string, vmName string) error {

--- a/pkg/frontend/admin_openshiftcluster_resize_validation_helpers.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_validation_helpers.go
@@ -41,9 +41,8 @@ const (
 	nodeLabelInstanceType     = "node.kubernetes.io/instance-type"
 	nodeLabelBetaInstanceType = "beta.kubernetes.io/instance-type"
 
-	zoneTopologyRegional   zoneTopology = "regional"
-	zoneTopologySingleZone zoneTopology = "single-zone"
-	zoneTopologyThreeZone  zoneTopology = "three-zone"
+	zoneTopologyRegional  zoneTopology = "regional"
+	zoneTopologyThreeZone zoneTopology = "three-zone"
 )
 
 type machineValidationData struct {
@@ -317,7 +316,7 @@ func validateClusterMachinesAndNodes(log *logrus.Entry, ocMachines map[string]ma
 	return errors.Join(validationErrs...)
 }
 
-// classifyZoneTopology validates the supported control-plane placement shapes.
+// classifyZoneTopology validates the recognized control-plane placement shapes.
 // It is generic so the same rules can be applied to Machines, VMs, and capacity
 // reservations without translating them into a resize-specific data structure.
 func classifyZoneTopology[T any](items map[string]T, getZone func(T) string) (zoneTopology, error) {
@@ -326,16 +325,20 @@ func classifyZoneTopology[T any](items map[string]T, getZone func(T) string) (zo
 	}
 
 	zones := make(map[string]bool, controlPlaneReplicaCount)
+	var soleZone string
 	for _, item := range items {
-		zones[getZone(item)] = true
+		soleZone = getZone(item)
+		zones[soleZone] = true
 	}
 
 	if len(zones) == 1 {
-		// One empty zone is regional; one explicit zone is single-zone.
-		if zones[""] {
+		// One empty zone is regional; one explicit zone is a single-zone layout,
+		// which resizecontrolplane must reject explicitly instead of treating as
+		// a mixed or regional topology.
+		if soleZone == "" {
 			return zoneTopologyRegional, nil
 		}
-		return zoneTopologySingleZone, nil
+		return "", fmt.Errorf("single-zone control plane topology is unsupported for resize validation: zones [%q]", soleZone)
 	}
 
 	if len(zones) == controlPlaneReplicaCount && !zones[""] {

--- a/pkg/frontend/admin_openshiftcluster_resize_validation_helpers_test.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_validation_helpers_test.go
@@ -45,14 +45,14 @@ func TestClassifyZoneTopology(t *testing.T) {
 			wantTopology: zoneTopologyThreeZone,
 		},
 		{
-			name: "valid - single zone",
+			name: "invalid - single zone",
 			items: map[string]string{
 				"item1": "1",
 				"item2": "1",
 				"item3": "1",
 			},
-			getZone:      func(s string) string { return s },
-			wantTopology: zoneTopologySingleZone,
+			getZone: func(s string) string { return s },
+			wantErr: `single-zone control plane topology is unsupported for resize validation: zones ["1"]`,
 		},
 		{
 			name: "valid - regional",
@@ -487,13 +487,13 @@ func TestValidateClusterMachines(t *testing.T) {
 			wantCount: 3,
 		},
 		{
-			name: "success - 3 machines in one zone",
+			name: "failure - 3 machines in one zone",
 			machines: map[string]machineValidationData{
 				"master-0": {labelZone: "1", specZone: "1", size: "Standard_D8s_v3", phase: "Running", labelInstanceType: "Standard_D8s_v3"},
 				"master-1": {labelZone: "1", specZone: "1", size: "Standard_D8s_v3", phase: "Running", labelInstanceType: "Standard_D8s_v3"},
 				"master-2": {labelZone: "1", specZone: "1", size: "Standard_D8s_v3", phase: "Running", labelInstanceType: "Standard_D8s_v3"},
 			},
-			wantCount: 3,
+			wantErr: `single-zone control plane topology is unsupported for resize validation: zones ["1"]`,
 		},
 		{
 			name: "success - 3 regional machines",
@@ -860,14 +860,14 @@ func TestGetAzureVMs(t *testing.T) {
 			wantCount: 3, // All 3 master VMs
 		},
 		{
-			name:     "success - 3 master VMs in one zone",
+			name:     "failure - 3 master VMs in one zone",
 			machines: createMachinesMap("master-0", "master-1", "master-2"),
 			mocks: func(a *mock_adminactions.MockAzureActions) {
 				for _, name := range []string{"master-0", "master-1", "master-2"} {
 					a.EXPECT().GetVirtualMachine(ctx, "test-cluster", name, mgmtcompute.InstanceView).Return(createAzureVM([]string{"1"}), nil)
 				}
 			},
-			wantCount: 3,
+			wantErr: `single-zone control plane topology is unsupported for resize validation: zones ["1"]`,
 		},
 		{
 			name:     "success - 3 regional master VMs with empty zones",

--- a/pkg/frontend/admin_openshiftcluster_resize_validation_helpers_test.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_validation_helpers_test.go
@@ -26,21 +26,43 @@ import (
 	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
-func TestValidateZoneDistribution(t *testing.T) {
+func TestClassifyZoneTopology(t *testing.T) {
 	for _, tt := range []struct {
-		name    string
-		items   map[string]string
-		getZone func(string) string
-		wantErr string
+		name         string
+		items        map[string]string
+		getZone      func(string) string
+		wantTopology zoneTopology
+		wantErr      string
 	}{
 		{
-			name: "valid - 3 items in 3 different zones",
+			name: "valid - three zones",
 			items: map[string]string{
 				"item1": "1",
 				"item2": "2",
 				"item3": "3",
 			},
-			getZone: func(s string) string { return s },
+			getZone:      func(s string) string { return s },
+			wantTopology: zoneTopologyThreeZone,
+		},
+		{
+			name: "valid - single zone",
+			items: map[string]string{
+				"item1": "1",
+				"item2": "1",
+				"item3": "1",
+			},
+			getZone:      func(s string) string { return s },
+			wantTopology: zoneTopologySingleZone,
+		},
+		{
+			name: "valid - regional",
+			items: map[string]string{
+				"item1": "",
+				"item2": "",
+				"item3": "",
+			},
+			getZone:      func(s string) string { return s },
+			wantTopology: zoneTopologyRegional,
 		},
 		{
 			name: "invalid - only 2 items",
@@ -70,17 +92,17 @@ func TestValidateZoneDistribution(t *testing.T) {
 				"item3": "2",
 			},
 			getZone: func(s string) string { return s },
-			wantErr: "items must be spread across 3 different zones, found 2 zone(s)",
+			wantErr: `items have unsupported mixed zone topology: zones ["1" "2"]`,
 		},
 		{
-			name: "invalid - 3 items but all in same zone",
+			name: "invalid - zonal and regional items",
 			items: map[string]string{
 				"item1": "1",
-				"item2": "1",
-				"item3": "1",
+				"item2": "",
+				"item3": "",
 			},
 			getZone: func(s string) string { return s },
-			wantErr: "items must be spread across 3 different zones, found 1 zone(s)",
+			wantErr: `items have unsupported mixed zone topology: zones ["" "1"]`,
 		},
 		{
 			name:    "invalid - empty map",
@@ -90,8 +112,11 @@ func TestValidateZoneDistribution(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateZoneDistribution(tt.items, tt.getZone)
+			topology, err := classifyZoneTopology(tt.items, tt.getZone)
 			utilerror.AssertErrorMessage(t, err, tt.wantErr)
+			if topology != tt.wantTopology {
+				t.Errorf("expected topology %q, got %q", tt.wantTopology, topology)
+			}
 		})
 	}
 }
@@ -117,6 +142,39 @@ func TestValidateClusterMachinesAndVMs(t *testing.T) {
 				"master-1": {zone: "2", vmSize: "Standard_D8s_v3"},
 				"master-2": {zone: "3", vmSize: "Standard_D8s_v3"},
 			},
+		},
+		{
+			name: "valid - regional machines match regional Azure VMs",
+			ocMachines: map[string]machineValidationData{
+				"master-0": {size: "Standard_D8s_v3"},
+				"master-1": {size: "Standard_D8s_v3"},
+				"master-2": {size: "Standard_D8s_v3"},
+			},
+			azureVMs: map[string]azureVMValidationData{
+				"master-0": {vmSize: "Standard_D8s_v3"},
+				"master-1": {vmSize: "Standard_D8s_v3"},
+				"master-2": {vmSize: "Standard_D8s_v3"},
+			},
+		},
+		{
+			name: "invalid - zonal machine and regional Azure VM",
+			ocMachines: map[string]machineValidationData{
+				"master-0": {specZone: "1", size: "Standard_D8s_v3"},
+			},
+			azureVMs: map[string]azureVMValidationData{
+				"master-0": {vmSize: "Standard_D8s_v3"},
+			},
+			wantErrStrings: []string{"machine master-0 has zone 1 in its spec, however Azure VM is running in zone "},
+		},
+		{
+			name: "invalid - regional machine and zonal Azure VM",
+			ocMachines: map[string]machineValidationData{
+				"master-0": {size: "Standard_D8s_v3"},
+			},
+			azureVMs: map[string]azureVMValidationData{
+				"master-0": {zone: "1", vmSize: "Standard_D8s_v3"},
+			},
+			wantErrStrings: []string{"machine master-0 has zone  in its spec, however Azure VM is running in zone 1"},
 		},
 		{
 			name: "invalid - machine not found in Azure",
@@ -429,6 +487,24 @@ func TestValidateClusterMachines(t *testing.T) {
 			wantCount: 3,
 		},
 		{
+			name: "success - 3 machines in one zone",
+			machines: map[string]machineValidationData{
+				"master-0": {labelZone: "1", specZone: "1", size: "Standard_D8s_v3", phase: "Running", labelInstanceType: "Standard_D8s_v3"},
+				"master-1": {labelZone: "1", specZone: "1", size: "Standard_D8s_v3", phase: "Running", labelInstanceType: "Standard_D8s_v3"},
+				"master-2": {labelZone: "1", specZone: "1", size: "Standard_D8s_v3", phase: "Running", labelInstanceType: "Standard_D8s_v3"},
+			},
+			wantCount: 3,
+		},
+		{
+			name: "success - 3 regional machines",
+			machines: map[string]machineValidationData{
+				"master-0": {size: "Standard_D8s_v3", phase: "Running", labelInstanceType: "Standard_D8s_v3"},
+				"master-1": {size: "Standard_D8s_v3", phase: "Running", labelInstanceType: "Standard_D8s_v3"},
+				"master-2": {size: "Standard_D8s_v3", phase: "Running", labelInstanceType: "Standard_D8s_v3"},
+			},
+			wantCount: 3,
+		},
+		{
 			name: "failure - not 3 machines",
 			machines: map[string]machineValidationData{
 				"master-0": {labelZone: "1", specZone: "1", size: "Standard_D8s_v3", phase: "Running", labelInstanceType: "Standard_D8s_v3"},
@@ -461,7 +537,7 @@ func TestValidateClusterMachines(t *testing.T) {
 				"master-1": {labelZone: "2", specZone: "2", size: "Standard_D8s_v3", phase: "Running", labelInstanceType: "Standard_D8s_v3"},
 				"master-2": {labelZone: "1", specZone: "1", size: "Standard_D8s_v3", phase: "Running", labelInstanceType: "Standard_D8s_v3"},
 			},
-			wantErr: "items must be spread across 3 different zones, found 2 zone(s)",
+			wantErr: `items have unsupported mixed zone topology: zones ["1" "2"]`,
 		},
 		{
 			name: "failure - machine with nil phase",
@@ -602,14 +678,14 @@ func TestValidateVMPowerState(t *testing.T) {
 			wantErr: "expected 2 statuses for VM master-0, but found 1: PowerState/running",
 		},
 		{
-			name: "failure - 3 statuses",
+			name: "failure - unexpected extra status",
 			vmStatuses: []string{
 				"ProvisioningState/succeeded",
 				"PowerState/running",
 				"ExtraStatus/unexpected",
 			},
 			vmName:  "master-0",
-			wantErr: "expected 2 statuses for VM master-0, but found 3: ProvisioningState/succeeded, PowerState/running, ExtraStatus/unexpected",
+			wantErr: "found unexpected statuses for VM master-0: ExtraStatus/unexpected",
 		},
 		{
 			name:       "failure - empty statuses",
@@ -698,6 +774,22 @@ func TestGetAzureVMs(t *testing.T) {
 		}
 		return machines
 	}
+	createAzureVM := func(zones []string) mgmtcompute.VirtualMachine {
+		return mgmtcompute.VirtualMachine{
+			VirtualMachineProperties: &mgmtcompute.VirtualMachineProperties{
+				HardwareProfile: &mgmtcompute.HardwareProfile{
+					VMSize: mgmtcompute.VirtualMachineSizeTypesStandardD8sV3,
+				},
+				InstanceView: &mgmtcompute.VirtualMachineInstanceView{
+					Statuses: &[]mgmtcompute.InstanceViewStatus{
+						{Code: pointerutils.ToPtr("ProvisioningState/succeeded")},
+						{Code: pointerutils.ToPtr("PowerState/running")},
+					},
+				},
+			},
+			Zones: &zones,
+		}
+	}
 
 	for _, tt := range []struct {
 		name      string
@@ -728,7 +820,8 @@ func TestGetAzureVMs(t *testing.T) {
 							},
 						},
 						Zones: &zones0,
-					}, nil)
+					}, nil,
+				)
 
 				a.EXPECT().GetVirtualMachine(ctx, "test-cluster", "master-1", mgmtcompute.InstanceView).Return(
 					mgmtcompute.VirtualMachine{
@@ -744,7 +837,8 @@ func TestGetAzureVMs(t *testing.T) {
 							},
 						},
 						Zones: &zones1,
-					}, nil)
+					}, nil,
+				)
 
 				a.EXPECT().GetVirtualMachine(ctx, "test-cluster", "master-2", mgmtcompute.InstanceView).Return(
 					mgmtcompute.VirtualMachine{
@@ -760,63 +854,52 @@ func TestGetAzureVMs(t *testing.T) {
 							},
 						},
 						Zones: &zones2,
-					}, nil)
+					}, nil,
+				)
 			},
 			wantCount: 3, // All 3 master VMs
+		},
+		{
+			name:     "success - 3 master VMs in one zone",
+			machines: createMachinesMap("master-0", "master-1", "master-2"),
+			mocks: func(a *mock_adminactions.MockAzureActions) {
+				for _, name := range []string{"master-0", "master-1", "master-2"} {
+					a.EXPECT().GetVirtualMachine(ctx, "test-cluster", name, mgmtcompute.InstanceView).Return(createAzureVM([]string{"1"}), nil)
+				}
+			},
+			wantCount: 3,
+		},
+		{
+			name:     "success - 3 regional master VMs with empty zones",
+			machines: createMachinesMap("master-0", "master-1", "master-2"),
+			mocks: func(a *mock_adminactions.MockAzureActions) {
+				for _, name := range []string{"master-0", "master-1", "master-2"} {
+					a.EXPECT().GetVirtualMachine(ctx, "test-cluster", name, mgmtcompute.InstanceView).Return(createAzureVM([]string{}), nil)
+				}
+			},
+			wantCount: 3,
+		},
+		{
+			name:     "success - 3 regional master VMs with nil zones",
+			machines: createMachinesMap("master-0", "master-1", "master-2"),
+			mocks: func(a *mock_adminactions.MockAzureActions) {
+				for _, name := range []string{"master-0", "master-1", "master-2"} {
+					vm := createAzureVM(nil)
+					vm.Zones = nil
+					a.EXPECT().GetVirtualMachine(ctx, "test-cluster", name, mgmtcompute.InstanceView).Return(vm, nil)
+				}
+			},
+			wantCount: 3,
 		},
 		{
 			name:     "failure - VM not found in Azure",
 			machines: createMachinesMap("master-0"),
 			mocks: func(a *mock_adminactions.MockAzureActions) {
 				a.EXPECT().GetVirtualMachine(ctx, "test-cluster", "master-0", mgmtcompute.InstanceView).Return(
-					mgmtcompute.VirtualMachine{}, fmt.Errorf("VM not found"))
+					mgmtcompute.VirtualMachine{}, fmt.Errorf("VM not found"),
+				)
 			},
 			wantErr: "500: InternalServerError: controlPlaneVM/master-0: failed to get Azure VM master-0: VM not found",
-		},
-		{
-			name:     "failure - VM with no zones",
-			machines: createMachinesMap("master-0"),
-			mocks: func(a *mock_adminactions.MockAzureActions) {
-				emptyZones := []string{}
-				a.EXPECT().GetVirtualMachine(ctx, "test-cluster", "master-0", mgmtcompute.InstanceView).Return(
-					mgmtcompute.VirtualMachine{
-						VirtualMachineProperties: &mgmtcompute.VirtualMachineProperties{
-							HardwareProfile: &mgmtcompute.HardwareProfile{
-								VMSize: mgmtcompute.VirtualMachineSizeTypesStandardD8sV3,
-							},
-							InstanceView: &mgmtcompute.VirtualMachineInstanceView{
-								Statuses: &[]mgmtcompute.InstanceViewStatus{
-									{Code: pointerutils.ToPtr("ProvisioningState/succeeded")},
-									{Code: pointerutils.ToPtr("PowerState/running")},
-								},
-							},
-						},
-						Zones: &emptyZones,
-					}, nil)
-			},
-			wantErr: "azure VM master-0 has no availability zone configured",
-		},
-		{
-			name:     "failure - VM with nil zones",
-			machines: createMachinesMap("master-0"),
-			mocks: func(a *mock_adminactions.MockAzureActions) {
-				a.EXPECT().GetVirtualMachine(ctx, "test-cluster", "master-0", mgmtcompute.InstanceView).Return(
-					mgmtcompute.VirtualMachine{
-						VirtualMachineProperties: &mgmtcompute.VirtualMachineProperties{
-							HardwareProfile: &mgmtcompute.HardwareProfile{
-								VMSize: mgmtcompute.VirtualMachineSizeTypesStandardD8sV3,
-							},
-							InstanceView: &mgmtcompute.VirtualMachineInstanceView{
-								Statuses: &[]mgmtcompute.InstanceViewStatus{
-									{Code: pointerutils.ToPtr("ProvisioningState/succeeded")},
-									{Code: pointerutils.ToPtr("PowerState/running")},
-								},
-							},
-						},
-						Zones: nil,
-					}, nil)
-			},
-			wantErr: "azure VM master-0 has no availability zone configured",
 		},
 		{
 			name:     "failure - wrong zone distribution (only 2 zones)",
@@ -840,7 +923,8 @@ func TestGetAzureVMs(t *testing.T) {
 							},
 						},
 						Zones: &zones0,
-					}, nil)
+					}, nil,
+				)
 
 				a.EXPECT().GetVirtualMachine(ctx, "test-cluster", "master-1", mgmtcompute.InstanceView).Return(
 					mgmtcompute.VirtualMachine{
@@ -856,7 +940,8 @@ func TestGetAzureVMs(t *testing.T) {
 							},
 						},
 						Zones: &zones1,
-					}, nil)
+					}, nil,
+				)
 
 				a.EXPECT().GetVirtualMachine(ctx, "test-cluster", "master-2", mgmtcompute.InstanceView).Return(
 					mgmtcompute.VirtualMachine{
@@ -872,9 +957,10 @@ func TestGetAzureVMs(t *testing.T) {
 							},
 						},
 						Zones: &zones2,
-					}, nil)
+					}, nil,
+				)
 			},
-			wantErr: "items must be spread across 3 different zones, found 2 zone(s)",
+			wantErr: `items have unsupported mixed zone topology: zones ["1" "2"]`,
 		},
 		{
 			name:     "handles nil InstanceView gracefully",
@@ -894,7 +980,8 @@ func TestGetAzureVMs(t *testing.T) {
 							InstanceView: nil, // nil InstanceView
 						},
 						Zones: &zones0,
-					}, nil)
+					}, nil,
+				)
 
 				a.EXPECT().GetVirtualMachine(ctx, "test-cluster", "master-1", mgmtcompute.InstanceView).Return(
 					mgmtcompute.VirtualMachine{
@@ -910,7 +997,8 @@ func TestGetAzureVMs(t *testing.T) {
 							},
 						},
 						Zones: &zones1,
-					}, nil)
+					}, nil,
+				)
 
 				a.EXPECT().GetVirtualMachine(ctx, "test-cluster", "master-2", mgmtcompute.InstanceView).Return(
 					mgmtcompute.VirtualMachine{
@@ -926,7 +1014,8 @@ func TestGetAzureVMs(t *testing.T) {
 							},
 						},
 						Zones: &zones2,
-					}, nil)
+					}, nil,
+				)
 			},
 			wantErr: "expected 2 statuses for VM master-0, but found 0: ",
 		},
@@ -950,7 +1039,8 @@ func TestGetAzureVMs(t *testing.T) {
 							},
 						},
 						Zones: &zones0,
-					}, nil)
+					}, nil,
+				)
 
 				a.EXPECT().GetVirtualMachine(ctx, "test-cluster", "master-1", mgmtcompute.InstanceView).Return(
 					mgmtcompute.VirtualMachine{
@@ -966,7 +1056,8 @@ func TestGetAzureVMs(t *testing.T) {
 							},
 						},
 						Zones: &zones1,
-					}, nil)
+					}, nil,
+				)
 
 				a.EXPECT().GetVirtualMachine(ctx, "test-cluster", "master-2", mgmtcompute.InstanceView).Return(
 					mgmtcompute.VirtualMachine{
@@ -982,7 +1073,8 @@ func TestGetAzureVMs(t *testing.T) {
 							},
 						},
 						Zones: &zones2,
-					}, nil)
+					}, nil,
+				)
 			},
 			wantErr: "expected 2 statuses for VM master-0, but found 0: ",
 		},
@@ -1007,7 +1099,8 @@ func TestGetAzureVMs(t *testing.T) {
 							},
 						},
 						Zones: &zones0,
-					}, nil)
+					}, nil,
+				)
 
 				a.EXPECT().GetVirtualMachine(ctx, "test-cluster", "master-1", mgmtcompute.InstanceView).Return(
 					mgmtcompute.VirtualMachine{
@@ -1023,7 +1116,8 @@ func TestGetAzureVMs(t *testing.T) {
 							},
 						},
 						Zones: &zones1,
-					}, nil)
+					}, nil,
+				)
 
 				a.EXPECT().GetVirtualMachine(ctx, "test-cluster", "master-2", mgmtcompute.InstanceView).Return(
 					mgmtcompute.VirtualMachine{
@@ -1039,7 +1133,8 @@ func TestGetAzureVMs(t *testing.T) {
 							},
 						},
 						Zones: &zones2,
-					}, nil)
+					}, nil,
+				)
 			},
 			wantCount: 3, // All 3 VMs are added, but master-0 will have empty vmSize
 		},

--- a/pkg/frontend/admin_openshiftcluster_resize_validation_helpers_test.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_validation_helpers_test.go
@@ -102,7 +102,7 @@ func TestClassifyZoneTopology(t *testing.T) {
 				"item3": "",
 			},
 			getZone: func(s string) string { return s },
-			wantErr: `items have unsupported mixed zone topology: zones ["" "1"]`,
+			wantErr: `items have unsupported mixed zone topology: zones ["regional/no-zone" "1"]`,
 		},
 		{
 			name:    "invalid - empty map",
@@ -164,7 +164,7 @@ func TestValidateClusterMachinesAndVMs(t *testing.T) {
 			azureVMs: map[string]azureVMValidationData{
 				"master-0": {vmSize: "Standard_D8s_v3"},
 			},
-			wantErrStrings: []string{"machine master-0 has zone 1 in its spec, however Azure VM is running in zone "},
+			wantErrStrings: []string{"machine master-0 has zone 1 in its spec, however Azure VM is running in zone regional/no-zone"},
 		},
 		{
 			name: "invalid - regional machine and zonal Azure VM",
@@ -174,7 +174,7 @@ func TestValidateClusterMachinesAndVMs(t *testing.T) {
 			azureVMs: map[string]azureVMValidationData{
 				"master-0": {zone: "1", vmSize: "Standard_D8s_v3"},
 			},
-			wantErrStrings: []string{"machine master-0 has zone  in its spec, however Azure VM is running in zone 1"},
+			wantErrStrings: []string{"machine master-0 has zone regional/no-zone in its spec, however Azure VM is running in zone 1"},
 		},
 		{
 			name: "invalid - machine not found in Azure",
@@ -520,6 +520,15 @@ func TestValidateClusterMachines(t *testing.T) {
 				"master-2": {labelZone: "3", specZone: "3", size: "Standard_D8s_v3", phase: "Running", labelInstanceType: "Standard_D8s_v3"},
 			},
 			wantErr: "machine master-0 has a mismatch between label zone 1 and spec zone 2",
+		},
+		{
+			name: "failure - zone mismatch between regional label and zonal spec",
+			machines: map[string]machineValidationData{
+				"master-0": {labelZone: "", specZone: "1", size: "Standard_D8s_v3", phase: "Running", labelInstanceType: "Standard_D8s_v3"},
+				"master-1": {labelZone: "2", specZone: "2", size: "Standard_D8s_v3", phase: "Running", labelInstanceType: "Standard_D8s_v3"},
+				"master-2": {labelZone: "3", specZone: "3", size: "Standard_D8s_v3", phase: "Running", labelInstanceType: "Standard_D8s_v3"},
+			},
+			wantErr: "machine master-0 has a mismatch between label zone regional/no-zone and spec zone 1",
 		},
 		{
 			name: "failure - multiple zone mismatches",


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-28167](https://redhat.atlassian.net/browse/ARO-28167)

### What this PR does / why we need it:

This PR updates `resizecontrolplane` pre-validation to distinguish regional/no-zone, single-zone, and three-zone control-plane layouts instead of treating a coherent single-zone layout like a supported zonal topology.

Regional/no-zone and three-zone layouts remain supported. A coherent single-zone layout is now recognized separately and rejected as an explicit stop condition, while mixed or partial layouts continue to fail closed.

### Test plan for issue:

- `make fmt`
- `git diff --check`
- `make lint-go`
- `make unit-test-go`
- `go test -count=1 ./pkg/frontend/...`
- `make test-go`
- Updated unit tests cover `classifyZoneTopology`, `validateClusterMachines`, and `getAzureVMs` for regional/no-zone, three-zone, and single-zone-stop behavior
- Not executed: live validation against real ARO clusters in regional/no-zone, single-zone, and three-zone regions

### Is there any documentation that needs to be updated for this PR?

No repo documentation change is needed. This is a validation-contract update in `resizecontrolplane`; the Jira story and PR description were updated to reflect that single-zone is an explicit unsupported state.

### How do you know this will function as expected in production? 

This is a narrow, fail-closed validation change that stops unsupported topologies before a resize operation can proceed. The behavior is covered at the topology classifier, machine validation, and Azure VM validation layers so the same single-zone shape is rejected consistently across the precheck inputs.
