### PR TITLE
add nodejs-20 and nodejs-22 to ACR mirror list for Dockerfile.autorest and portal build

### DIFF
--- a/cmd/aro/mirror.go
+++ b/cmd/aro/mirror.go
@@ -154,6 +154,10 @@ func mirror(ctx context.Context, _log *logrus.Entry) error {
 		"registry.access.redhat.com/ubi8/nodejs-18:latest",
 		// https://catalog.redhat.com/software/containers/ubi9/nodejs-18/62e8e7ed22d1d3c2dfe2ca01
 		"registry.access.redhat.com/ubi9/nodejs-18:latest",
+		// https://catalog.redhat.com/software/containers/ubi9/nodejs-20/
+		"registry.access.redhat.com/ubi9/nodejs-20:latest",
+		// https://catalog.redhat.com/software/containers/ubi9/nodejs-22/
+		"registry.access.redhat.com/ubi9/nodejs-22:latest",
 
 		// https://quay.io/repository/app-sre/managed-upgrade-operator?tab=tags
 		// https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/data/services/osd-operators/cicd/saas/saas-managed-upgrade-operator.yaml?ref_type=heads


### PR DESCRIPTION
### Which issue this PR addresses:

 - Adds `ubi9/nodejs-20` and `ubi9/nodejs-22` to the ACR mirror list in `cmd/aro/mirror.go`
  - `nodejs-20` is needed by `Dockerfile.autorest`
  - `nodejs-22` is needed by `Dockerfile.ci-rp` and `Dockerfile.portal_lint` (for the upcoming React 19 upgrade)
  - Existing `nodejs-18` entries are kept until the React 19 PR merges