### PR TITLE
[ARO-28783] Improve HolmesGPT system prompt for safety and investigation quality

### DIFF
--- a/docs/holmes-investigation.md
+++ b/docs/holmes-investigation.md
@@ -52,7 +52,7 @@ When an investigation request arrives, the RP ensures the `holmes-system` namesp
 
 3. **Pod** (`holmes-investigate-{id}`) — Runs:
    ```
-   python holmes_cli.py ask "<question>" -n --model=<Model> --config=/etc/holmes/config.yaml
+   python holmes_cli.py ask "<question>" -n --model=<Model> --config=/etc/holmes/config.yaml --system-prompt-additions "<instructions>"
    ```
    - Image from `holmesConfig.Image` (default: `version.HolmesImage(acrDomain)`)
    - `ActiveDeadlineSeconds` from `holmesConfig.DefaultTimeout`

--- a/pkg/hive/investigate.go
+++ b/pkg/hive/investigate.go
@@ -141,7 +141,19 @@ func (hr *clusterManager) InvestigateCluster(ctx context.Context, hiveNamespace 
 					Image:           holmesConfig.Image,
 					ImagePullPolicy: corev1.PullAlways,
 					Command:         []string{"python", "holmes_cli.py"},
-					Args:            []string{"ask", question, "-n", "--model=" + holmesConfig.Model, "--config=/etc/holmes/config.yaml"},
+					Args: []string{
+						"ask", question, "-n",
+						"--model=" + holmesConfig.Model,
+						"--config=/etc/holmes/config.yaml",
+						"--system-prompt-additions",
+						"You are an automated SRE diagnostic tool investigating an OpenShift cluster. " +
+							"You MUST NOT ask the user any questions — the user cannot respond. " +
+							"If the question is vague or unclear, treat it as: check overall cluster health including nodes, pods, events, and resource utilization across all platform namespaces. " +
+							"To find platform namespaces, first run: kubectl get namespaces -o name | grep openshift- — then check pods and events in those namespaces. " +
+							"Never use -A or --all-namespaces flags as they cause out-of-memory on large clusters. Always use -n <namespace> for specific namespaces. " +
+							"Do not inspect non-openshift namespaces unless the user explicitly names one. " +
+							"Provide concrete findings with evidence, never ask for more information.",
+					},
 					Env: []corev1.EnvVar{
 						{
 							Name:  "AZURE_AD_TOKEN_AUTH",


### PR DESCRIPTION
## Summary

Add `--system-prompt-additions` to the Holmes CLI args to prevent the LLM from asking clarifying questions in the non-interactive investigation environment.

## Problem

Holmes investigations sometimes produce LLM output containing clarifying questions ("Could you provide more details about...?") instead of directly investigating with available tools. The existing `-n` flag only disables the interactive REPL loop — it does not change the LLM's system prompt.

## Fix

Add `--system-prompt-additions` with instructions telling the LLM it's in an automated, non-interactive environment and must never ask questions, always using its best judgment with available tools.

## Test plan

- [x] `make fmt` passes
- [x] `go build ./pkg/hive/...` passes
- [x] Unit tests pass
- [x] Manual: `hack/test-holmes-investigate.sh` — verify output contains direct investigation results, not clarifying questions