### PR TITLE
fix: disable crossplane/core toolset in Holmes config

### DIFF
--- a/pkg/hive/staticresources/holmes-config.yaml
+++ b/pkg/hive/staticresources/holmes-config.yaml
@@ -124,5 +124,7 @@ toolsets:
     enabled: false
   inspektor-gadget/tcpdump:
     enabled: false
+  crossplane/core:
+    enabled: false
   kubevela/core:
     enabled: false


### PR DESCRIPTION
## Summary
- Disable the `crossplane/core` toolset in the Holmes investigation config since Crossplane is not installed on ARO clusters
- The prerequisite check (`kubectl api-resources --api-group=pkg.crossplane.io`) always fails with exit code 1, adding noise to investigation output

Jira: [ARO-28784](https://redhat.atlassian.net/browse/ARO-28784)

## Test plan
- [x] `make fmt` passes
- [x] `go build ./pkg/hive/...` passes
- [x] Run Holmes investigation and verify no `crossplane/core` prerequisite failure in output