### PR TITLE
operator: do not update dnsmasq configs when endpoint properties are invalid

### DIFF
--- a/pkg/operator/controllers/dnsmasq/cluster_controller.go
+++ b/pkg/operator/controllers/dnsmasq/cluster_controller.go
@@ -6,6 +6,7 @@ package dnsmasq
 import (
 	"context"
 	"fmt"
+	"net/netip"
 
 	"github.com/sirupsen/logrus"
 
@@ -84,6 +85,13 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, request ctrl.Request)
 		return reconcile.Result{}, err
 	}
 
+	err = validateDnsmasqProperties(instance)
+	if err != nil {
+		r.Log.Error(err)
+		r.SetDegraded(ctx, err)
+		return reconcile.Result{}, err
+	}
+
 	err = reconcileMachineConfigs(ctx, instance, r.ch, r.Client, allowReconcile, restartDnsmasq, mcps.Items...)
 	if err != nil {
 		r.Log.Error(err)
@@ -110,6 +118,28 @@ func (r *ClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			builder.WithPredicates(clusterVersionPredicate),
 		).
 		Complete(r)
+}
+
+func validateDnsmasqProperties(instance *arov1alpha1.Cluster) error {
+	validateIP := func(name, value string) error {
+		if _, err := netip.ParseAddr(value); err != nil {
+			return fmt.Errorf("invalid %s %q", name, value)
+		}
+		return nil
+	}
+
+	if err := validateIP("apiIntIP", instance.Spec.APIIntIP); err != nil {
+		return err
+	}
+	if err := validateIP("ingressIP", instance.Spec.IngressIP); err != nil {
+		return err
+	}
+	if len(instance.Spec.GatewayDomains) > 0 {
+		if err := validateIP("gatewayPrivateEndpointIP", instance.Spec.GatewayPrivateEndpointIP); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func reconcileMachineConfigs(ctx context.Context, instance *arov1alpha1.Cluster, ch clienthelper.Interface, c client.Client, allowReconcile bool, restartDnsmasq bool, mcps ...mcv1.MachineConfigPool) error {

--- a/pkg/operator/controllers/dnsmasq/cluster_controller.go
+++ b/pkg/operator/controllers/dnsmasq/cluster_controller.go
@@ -116,7 +116,7 @@ func (r *ClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 func validateDnsmasqProperties(instance *arov1alpha1.Cluster) error {
 	validateIP := func(name, value string) error {
 		if _, err := netip.ParseAddr(value); err != nil {
-			return fmt.Errorf("invalid %s %q", name, value)
+			return fmt.Errorf("invalid %s: %w", name, err)
 		}
 		return nil
 	}

--- a/pkg/operator/controllers/dnsmasq/cluster_controller.go
+++ b/pkg/operator/controllers/dnsmasq/cluster_controller.go
@@ -85,13 +85,6 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, request ctrl.Request)
 		return reconcile.Result{}, err
 	}
 
-	err = validateDnsmasqProperties(instance)
-	if err != nil {
-		r.Log.Error(err)
-		r.SetDegraded(ctx, err)
-		return reconcile.Result{}, err
-	}
-
 	err = reconcileMachineConfigs(ctx, instance, r.ch, r.Client, allowReconcile, restartDnsmasq, mcps.Items...)
 	if err != nil {
 		r.Log.Error(err)
@@ -143,6 +136,10 @@ func validateDnsmasqProperties(instance *arov1alpha1.Cluster) error {
 }
 
 func reconcileMachineConfigs(ctx context.Context, instance *arov1alpha1.Cluster, ch clienthelper.Interface, c client.Client, allowReconcile bool, restartDnsmasq bool, mcps ...mcv1.MachineConfigPool) error {
+	err := validateDnsmasqProperties(instance)
+	if err != nil {
+		return err
+	}
 	var resources []kruntime.Object
 	for _, mcp := range mcps {
 		resource, err := dnsmasqMachineConfig(instance.Spec.Domain, instance.Spec.APIIntIP, instance.Spec.IngressIP, mcp.Name, instance.Spec.GatewayDomains, instance.Spec.GatewayPrivateEndpointIP, restartDnsmasq)
@@ -158,7 +155,7 @@ func reconcileMachineConfigs(ctx context.Context, instance *arov1alpha1.Cluster,
 		resources = append(resources, resource)
 	}
 
-	err := dynamichelper.Prepare(resources)
+	err = dynamichelper.Prepare(resources)
 	if err != nil {
 		return err
 	}

--- a/pkg/operator/controllers/dnsmasq/cluster_controller_test.go
+++ b/pkg/operator/controllers/dnsmasq/cluster_controller_test.go
@@ -89,6 +89,11 @@ func TestClusterReconciler(t *testing.T) {
 						},
 					},
 					Spec: arov1alpha1.ClusterSpec{
+						Domain:                   "cluster.location.aroapp.io",
+						APIIntIP:                 "10.0.0.1",
+						IngressIP:                "10.0.0.2",
+						GatewayDomains:           []string{"example.com"},
+						GatewayPrivateEndpointIP: "10.0.1.0",
 						OperatorFlags: arov1alpha1.OperatorFlags{
 							operator.DnsmasqEnabled:      operator.FlagTrue,
 							operator.ForceReconciliation: operator.FlagTrue,
@@ -111,6 +116,11 @@ func TestClusterReconciler(t *testing.T) {
 						Conditions: defaultConditions,
 					},
 					Spec: arov1alpha1.ClusterSpec{
+						Domain:                   "cluster.location.aroapp.io",
+						APIIntIP:                 "10.0.0.1",
+						IngressIP:                "10.0.0.2",
+						GatewayDomains:           []string{"example.com"},
+						GatewayPrivateEndpointIP: "10.0.1.0",
 						OperatorFlags: arov1alpha1.OperatorFlags{
 							operator.DnsmasqEnabled:      operator.FlagTrue,
 							operator.ForceReconciliation: operator.FlagTrue,
@@ -173,6 +183,11 @@ func TestClusterReconciler(t *testing.T) {
 						Conditions: defaultConditions,
 					},
 					Spec: arov1alpha1.ClusterSpec{
+						Domain:                   "cluster.location.aroapp.io",
+						APIIntIP:                 "10.0.0.1",
+						IngressIP:                "10.0.0.2",
+						GatewayDomains:           []string{"example.com"},
+						GatewayPrivateEndpointIP: "10.0.1.0",
 						OperatorFlags: arov1alpha1.OperatorFlags{
 							operator.DnsmasqEnabled: operator.FlagTrue,
 						},
@@ -214,6 +229,11 @@ func TestClusterReconciler(t *testing.T) {
 						Conditions: defaultConditions,
 					},
 					Spec: arov1alpha1.ClusterSpec{
+						Domain:                   "cluster.location.aroapp.io",
+						APIIntIP:                 "10.0.0.1",
+						IngressIP:                "10.0.0.2",
+						GatewayDomains:           []string{"example.com"},
+						GatewayPrivateEndpointIP: "10.0.1.0",
 						OperatorFlags: arov1alpha1.OperatorFlags{
 							operator.DnsmasqEnabled: operator.FlagTrue,
 						},
@@ -257,6 +277,11 @@ func TestClusterReconciler(t *testing.T) {
 						Conditions: defaultConditions,
 					},
 					Spec: arov1alpha1.ClusterSpec{
+						Domain:                   "cluster.location.aroapp.io",
+						APIIntIP:                 "10.0.0.1",
+						IngressIP:                "10.0.0.2",
+						GatewayDomains:           []string{"example.com"},
+						GatewayPrivateEndpointIP: "10.0.1.0",
 						OperatorFlags: arov1alpha1.OperatorFlags{
 							operator.DnsmasqEnabled: operator.FlagTrue,
 						},
@@ -309,6 +334,11 @@ func TestClusterReconciler(t *testing.T) {
 						Conditions: defaultConditions,
 					},
 					Spec: arov1alpha1.ClusterSpec{
+						Domain:                   "cluster.location.aroapp.io",
+						APIIntIP:                 "10.0.0.1",
+						IngressIP:                "10.0.0.2",
+						GatewayDomains:           []string{"example.com"},
+						GatewayPrivateEndpointIP: "10.0.1.0",
 						OperatorFlags: arov1alpha1.OperatorFlags{
 							operator.DnsmasqEnabled: operator.FlagTrue,
 						},
@@ -358,6 +388,11 @@ func TestClusterReconciler(t *testing.T) {
 						Conditions: defaultConditions,
 					},
 					Spec: arov1alpha1.ClusterSpec{
+						Domain:                   "cluster.location.aroapp.io",
+						APIIntIP:                 "10.0.0.1",
+						IngressIP:                "10.0.0.2",
+						GatewayDomains:           []string{"example.com"},
+						GatewayPrivateEndpointIP: "10.0.1.0",
 						OperatorFlags: arov1alpha1.OperatorFlags{
 							operator.DnsmasqEnabled: operator.FlagTrue,
 						},
@@ -394,6 +429,237 @@ func TestClusterReconciler(t *testing.T) {
 			request:        ctrl.Request{},
 			wantErrMsg:     "",
 			wantConditions: defaultConditions,
+		},
+		{
+			name: "empty APIIntIP returns error",
+			objects: []client.Object{
+				&arov1alpha1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Status: arov1alpha1.ClusterStatus{
+						Conditions: defaultConditions,
+					},
+					Spec: arov1alpha1.ClusterSpec{
+						Domain:                   "cluster.location.aroapp.io",
+						IngressIP:                "10.0.0.2",
+						GatewayDomains:           []string{"example.com"},
+						GatewayPrivateEndpointIP: "10.0.1.0",
+						OperatorFlags: arov1alpha1.OperatorFlags{
+							operator.DnsmasqEnabled:      operator.FlagTrue,
+							operator.ForceReconciliation: operator.FlagTrue,
+						},
+					},
+				},
+				&mcv1.MachineConfigPool{
+					ObjectMeta: metav1.ObjectMeta{Name: "master"},
+					Status:     mcv1.MachineConfigPoolStatus{},
+					Spec:       mcv1.MachineConfigPoolSpec{},
+				},
+			},
+			wantCreated: map[string]int{},
+			wantUpdated: map[string]int{},
+			request:     ctrl.Request{},
+			wantErrMsg:  `invalid apiIntIP ""`,
+			wantConditions: []operatorv1.OperatorCondition{
+				defaultAvailable, defaultProgressing, {
+					Type:               "DnsmasqClusterControllerDegraded",
+					Status:             "True",
+					Message:            `invalid apiIntIP ""`,
+					LastTransitionTime: transitionTime,
+				},
+			},
+		},
+		{
+			name: "empty IngressIP returns error",
+			objects: []client.Object{
+				&arov1alpha1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Status: arov1alpha1.ClusterStatus{
+						Conditions: defaultConditions,
+					},
+					Spec: arov1alpha1.ClusterSpec{
+						Domain:                   "cluster.location.aroapp.io",
+						APIIntIP:                 "10.0.0.1",
+						GatewayDomains:           []string{"example.com"},
+						GatewayPrivateEndpointIP: "10.0.1.0",
+						OperatorFlags: arov1alpha1.OperatorFlags{
+							operator.DnsmasqEnabled:      operator.FlagTrue,
+							operator.ForceReconciliation: operator.FlagTrue,
+						},
+					},
+				},
+				&mcv1.MachineConfigPool{
+					ObjectMeta: metav1.ObjectMeta{Name: "master"},
+					Status:     mcv1.MachineConfigPoolStatus{},
+					Spec:       mcv1.MachineConfigPoolSpec{},
+				},
+			},
+			wantCreated: map[string]int{},
+			wantUpdated: map[string]int{},
+			request:     ctrl.Request{},
+			wantErrMsg:  `invalid ingressIP ""`,
+			wantConditions: []operatorv1.OperatorCondition{
+				defaultAvailable, defaultProgressing, {
+					Type:               "DnsmasqClusterControllerDegraded",
+					Status:             "True",
+					Message:            `invalid ingressIP ""`,
+					LastTransitionTime: transitionTime,
+				},
+			},
+		},
+		{
+			name: "empty GatewayPrivateEndpointIP with gateway domains returns error",
+			objects: []client.Object{
+				&arov1alpha1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Status: arov1alpha1.ClusterStatus{
+						Conditions: defaultConditions,
+					},
+					Spec: arov1alpha1.ClusterSpec{
+						Domain:         "cluster.location.aroapp.io",
+						APIIntIP:       "10.0.0.1",
+						IngressIP:      "10.0.0.2",
+						GatewayDomains: []string{"example.com"},
+						OperatorFlags: arov1alpha1.OperatorFlags{
+							operator.DnsmasqEnabled:      operator.FlagTrue,
+							operator.ForceReconciliation: operator.FlagTrue,
+						},
+					},
+				},
+				&mcv1.MachineConfigPool{
+					ObjectMeta: metav1.ObjectMeta{Name: "master"},
+					Status:     mcv1.MachineConfigPoolStatus{},
+					Spec:       mcv1.MachineConfigPoolSpec{},
+				},
+			},
+			wantCreated: map[string]int{},
+			wantUpdated: map[string]int{},
+			request:     ctrl.Request{},
+			wantErrMsg:  `invalid gatewayPrivateEndpointIP ""`,
+			wantConditions: []operatorv1.OperatorCondition{
+				defaultAvailable, defaultProgressing, {
+					Type:               "DnsmasqClusterControllerDegraded",
+					Status:             "True",
+					Message:            `invalid gatewayPrivateEndpointIP ""`,
+					LastTransitionTime: transitionTime,
+				},
+			},
+		},
+		{
+			name: "invalid APIIntIP returns error",
+			objects: []client.Object{
+				&arov1alpha1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Status: arov1alpha1.ClusterStatus{
+						Conditions: defaultConditions,
+					},
+					Spec: arov1alpha1.ClusterSpec{
+						Domain:                   "cluster.location.aroapp.io",
+						APIIntIP:                 "not-an-ip",
+						IngressIP:                "10.0.0.2",
+						GatewayDomains:           []string{"example.com"},
+						GatewayPrivateEndpointIP: "10.0.1.0",
+						OperatorFlags: arov1alpha1.OperatorFlags{
+							operator.DnsmasqEnabled:      operator.FlagTrue,
+							operator.ForceReconciliation: operator.FlagTrue,
+						},
+					},
+				},
+				&mcv1.MachineConfigPool{
+					ObjectMeta: metav1.ObjectMeta{Name: "master"},
+					Status:     mcv1.MachineConfigPoolStatus{},
+					Spec:       mcv1.MachineConfigPoolSpec{},
+				},
+			},
+			wantCreated: map[string]int{},
+			wantUpdated: map[string]int{},
+			request:     ctrl.Request{},
+			wantErrMsg:  `invalid apiIntIP "not-an-ip"`,
+			wantConditions: []operatorv1.OperatorCondition{
+				defaultAvailable, defaultProgressing, {
+					Type:               "DnsmasqClusterControllerDegraded",
+					Status:             "True",
+					Message:            `invalid apiIntIP "not-an-ip"`,
+					LastTransitionTime: transitionTime,
+				},
+			},
+		},
+		{
+			name: "invalid IngressIP returns error",
+			objects: []client.Object{
+				&arov1alpha1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Status: arov1alpha1.ClusterStatus{
+						Conditions: defaultConditions,
+					},
+					Spec: arov1alpha1.ClusterSpec{
+						Domain:                   "cluster.location.aroapp.io",
+						APIIntIP:                 "10.0.0.1",
+						IngressIP:                "not-an-ip",
+						GatewayDomains:           []string{"example.com"},
+						GatewayPrivateEndpointIP: "10.0.1.0",
+						OperatorFlags: arov1alpha1.OperatorFlags{
+							operator.DnsmasqEnabled:      operator.FlagTrue,
+							operator.ForceReconciliation: operator.FlagTrue,
+						},
+					},
+				},
+				&mcv1.MachineConfigPool{
+					ObjectMeta: metav1.ObjectMeta{Name: "master"},
+					Status:     mcv1.MachineConfigPoolStatus{},
+					Spec:       mcv1.MachineConfigPoolSpec{},
+				},
+			},
+			wantCreated: map[string]int{},
+			wantUpdated: map[string]int{},
+			request:     ctrl.Request{},
+			wantErrMsg:  `invalid ingressIP "not-an-ip"`,
+			wantConditions: []operatorv1.OperatorCondition{
+				defaultAvailable, defaultProgressing, {
+					Type:               "DnsmasqClusterControllerDegraded",
+					Status:             "True",
+					Message:            `invalid ingressIP "not-an-ip"`,
+					LastTransitionTime: transitionTime,
+				},
+			},
+		},
+		{
+			name: "invalid GatewayPrivateEndpointIP returns error",
+			objects: []client.Object{
+				&arov1alpha1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Status: arov1alpha1.ClusterStatus{
+						Conditions: defaultConditions,
+					},
+					Spec: arov1alpha1.ClusterSpec{
+						Domain:                   "cluster.location.aroapp.io",
+						APIIntIP:                 "10.0.0.1",
+						IngressIP:                "10.0.0.2",
+						GatewayDomains:           []string{"example.com"},
+						GatewayPrivateEndpointIP: "not-an-ip",
+						OperatorFlags: arov1alpha1.OperatorFlags{
+							operator.DnsmasqEnabled:      operator.FlagTrue,
+							operator.ForceReconciliation: operator.FlagTrue,
+						},
+					},
+				},
+				&mcv1.MachineConfigPool{
+					ObjectMeta: metav1.ObjectMeta{Name: "master"},
+					Status:     mcv1.MachineConfigPoolStatus{},
+					Spec:       mcv1.MachineConfigPoolSpec{},
+				},
+			},
+			wantCreated: map[string]int{},
+			wantUpdated: map[string]int{},
+			request:     ctrl.Request{},
+			wantErrMsg:  `invalid gatewayPrivateEndpointIP "not-an-ip"`,
+			wantConditions: []operatorv1.OperatorCondition{
+				defaultAvailable, defaultProgressing, {
+					Type:               "DnsmasqClusterControllerDegraded",
+					Status:             "True",
+					Message:            `invalid gatewayPrivateEndpointIP "not-an-ip"`,
+					LastTransitionTime: transitionTime,
+				},
+			},
 		},
 	}
 

--- a/pkg/operator/controllers/dnsmasq/cluster_controller_test.go
+++ b/pkg/operator/controllers/dnsmasq/cluster_controller_test.go
@@ -458,12 +458,12 @@ func TestClusterReconciler(t *testing.T) {
 			wantCreated: map[string]int{},
 			wantUpdated: map[string]int{},
 			request:     ctrl.Request{},
-			wantErrMsg:  `invalid apiIntIP ""`,
+			wantErrMsg:  `invalid apiIntIP: ParseAddr(""): unable to parse IP`,
 			wantConditions: []operatorv1.OperatorCondition{
 				defaultAvailable, defaultProgressing, {
 					Type:               "DnsmasqClusterControllerDegraded",
 					Status:             "True",
-					Message:            `invalid apiIntIP ""`,
+					Message:            `invalid apiIntIP: ParseAddr(""): unable to parse IP`,
 					LastTransitionTime: transitionTime,
 				},
 			},
@@ -496,12 +496,12 @@ func TestClusterReconciler(t *testing.T) {
 			wantCreated: map[string]int{},
 			wantUpdated: map[string]int{},
 			request:     ctrl.Request{},
-			wantErrMsg:  `invalid ingressIP ""`,
+			wantErrMsg:  `invalid ingressIP: ParseAddr(""): unable to parse IP`,
 			wantConditions: []operatorv1.OperatorCondition{
 				defaultAvailable, defaultProgressing, {
 					Type:               "DnsmasqClusterControllerDegraded",
 					Status:             "True",
-					Message:            `invalid ingressIP ""`,
+					Message:            `invalid ingressIP: ParseAddr(""): unable to parse IP`,
 					LastTransitionTime: transitionTime,
 				},
 			},
@@ -534,12 +534,12 @@ func TestClusterReconciler(t *testing.T) {
 			wantCreated: map[string]int{},
 			wantUpdated: map[string]int{},
 			request:     ctrl.Request{},
-			wantErrMsg:  `invalid gatewayPrivateEndpointIP ""`,
+			wantErrMsg:  `invalid gatewayPrivateEndpointIP: ParseAddr(""): unable to parse IP`,
 			wantConditions: []operatorv1.OperatorCondition{
 				defaultAvailable, defaultProgressing, {
 					Type:               "DnsmasqClusterControllerDegraded",
 					Status:             "True",
-					Message:            `invalid gatewayPrivateEndpointIP ""`,
+					Message:            `invalid gatewayPrivateEndpointIP: ParseAddr(""): unable to parse IP`,
 					LastTransitionTime: transitionTime,
 				},
 			},
@@ -573,12 +573,12 @@ func TestClusterReconciler(t *testing.T) {
 			wantCreated: map[string]int{},
 			wantUpdated: map[string]int{},
 			request:     ctrl.Request{},
-			wantErrMsg:  `invalid apiIntIP "not-an-ip"`,
+			wantErrMsg:  `invalid apiIntIP: ParseAddr("not-an-ip"): unable to parse IP`,
 			wantConditions: []operatorv1.OperatorCondition{
 				defaultAvailable, defaultProgressing, {
 					Type:               "DnsmasqClusterControllerDegraded",
 					Status:             "True",
-					Message:            `invalid apiIntIP "not-an-ip"`,
+					Message:            `invalid apiIntIP: ParseAddr("not-an-ip"): unable to parse IP`,
 					LastTransitionTime: transitionTime,
 				},
 			},
@@ -612,12 +612,12 @@ func TestClusterReconciler(t *testing.T) {
 			wantCreated: map[string]int{},
 			wantUpdated: map[string]int{},
 			request:     ctrl.Request{},
-			wantErrMsg:  `invalid ingressIP "not-an-ip"`,
+			wantErrMsg:  `invalid ingressIP: ParseAddr("not-an-ip"): unable to parse IP`,
 			wantConditions: []operatorv1.OperatorCondition{
 				defaultAvailable, defaultProgressing, {
 					Type:               "DnsmasqClusterControllerDegraded",
 					Status:             "True",
-					Message:            `invalid ingressIP "not-an-ip"`,
+					Message:            `invalid ingressIP: ParseAddr("not-an-ip"): unable to parse IP`,
 					LastTransitionTime: transitionTime,
 				},
 			},
@@ -651,12 +651,12 @@ func TestClusterReconciler(t *testing.T) {
 			wantCreated: map[string]int{},
 			wantUpdated: map[string]int{},
 			request:     ctrl.Request{},
-			wantErrMsg:  `invalid gatewayPrivateEndpointIP "not-an-ip"`,
+			wantErrMsg:  `invalid gatewayPrivateEndpointIP: ParseAddr("not-an-ip"): unable to parse IP`,
 			wantConditions: []operatorv1.OperatorCondition{
 				defaultAvailable, defaultProgressing, {
 					Type:               "DnsmasqClusterControllerDegraded",
 					Status:             "True",
-					Message:            `invalid gatewayPrivateEndpointIP "not-an-ip"`,
+					Message:            `invalid gatewayPrivateEndpointIP: ParseAddr("not-an-ip"): unable to parse IP`,
 					LastTransitionTime: transitionTime,
 				},
 			},

--- a/pkg/operator/controllers/dnsmasq/machineconfig_controller_test.go
+++ b/pkg/operator/controllers/dnsmasq/machineconfig_controller_test.go
@@ -98,6 +98,46 @@ func TestMachineConfigReconciler(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "missing IngressIP returns error",
+			objects: []client.Object{
+				&arov1alpha1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Status: arov1alpha1.ClusterStatus{
+						Conditions: defaultConditions,
+					},
+					Spec: arov1alpha1.ClusterSpec{
+						Domain:                   "cluster.location.aroapp.io",
+						APIIntIP:                 "10.0.0.1",
+						GatewayDomains:           []string{"example.com"},
+						GatewayPrivateEndpointIP: "10.0.1.0",
+						OperatorFlags: arov1alpha1.OperatorFlags{
+							operator.DnsmasqEnabled:      operator.FlagTrue,
+							operator.ForceReconciliation: operator.FlagTrue,
+						},
+					},
+				},
+				&mcv1.MachineConfigPool{
+					ObjectMeta: metav1.ObjectMeta{Name: "custom"},
+					Status:     mcv1.MachineConfigPoolStatus{},
+					Spec:       mcv1.MachineConfigPoolSpec{},
+				},
+			},
+			request: ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Name: "99-custom-aro-dns",
+				},
+			},
+			wantErrMsg: `invalid ingressIP ""`,
+			wantConditions: []operatorv1.OperatorCondition{
+				defaultAvailable, defaultProgressing, {
+					Type:               MachineConfigControllerName + "ControllerDegraded",
+					Status:             "True",
+					Message:            `invalid ingressIP ""`,
+					LastTransitionTime: transitionTime,
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -167,6 +207,11 @@ func TestMachineConfigReconcilerNotUpgrading(t *testing.T) {
 						Conditions: defaultConditions,
 					},
 					Spec: arov1alpha1.ClusterSpec{
+						Domain:                   "cluster.location.aroapp.io",
+						APIIntIP:                 "10.0.0.1",
+						IngressIP:                "10.0.0.2",
+						GatewayDomains:           []string{"example.com"},
+						GatewayPrivateEndpointIP: "10.0.1.0",
 						OperatorFlags: arov1alpha1.OperatorFlags{
 							operator.DnsmasqEnabled: operator.FlagTrue,
 						},
@@ -200,6 +245,11 @@ func TestMachineConfigReconcilerNotUpgrading(t *testing.T) {
 						Conditions: defaultConditions,
 					},
 					Spec: arov1alpha1.ClusterSpec{
+						Domain:                   "cluster.location.aroapp.io",
+						APIIntIP:                 "10.0.0.1",
+						IngressIP:                "10.0.0.2",
+						GatewayDomains:           []string{"example.com"},
+						GatewayPrivateEndpointIP: "10.0.1.0",
 						OperatorFlags: arov1alpha1.OperatorFlags{
 							operator.DnsmasqEnabled: operator.FlagTrue,
 						},
@@ -235,6 +285,11 @@ func TestMachineConfigReconcilerNotUpgrading(t *testing.T) {
 						Conditions: defaultConditions,
 					},
 					Spec: arov1alpha1.ClusterSpec{
+						Domain:                   "cluster.location.aroapp.io",
+						APIIntIP:                 "10.0.0.1",
+						IngressIP:                "10.0.0.2",
+						GatewayDomains:           []string{"example.com"},
+						GatewayPrivateEndpointIP: "10.0.1.0",
 						OperatorFlags: arov1alpha1.OperatorFlags{
 							operator.DnsmasqEnabled:      operator.FlagTrue,
 							operator.ForceReconciliation: operator.FlagTrue,
@@ -355,6 +410,11 @@ func TestMachineConfigReconcilerClusterUpgrading(t *testing.T) {
 						},
 					},
 					Spec: arov1alpha1.ClusterSpec{
+						Domain:                   "cluster.location.aroapp.io",
+						APIIntIP:                 "10.0.0.1",
+						IngressIP:                "10.0.0.2",
+						GatewayDomains:           []string{"example.com"},
+						GatewayPrivateEndpointIP: "10.0.1.0",
 						OperatorFlags: arov1alpha1.OperatorFlags{
 							operator.DnsmasqEnabled: operator.FlagTrue,
 						},
@@ -381,6 +441,11 @@ func TestMachineConfigReconcilerClusterUpgrading(t *testing.T) {
 						Conditions: defaultConditions,
 					},
 					Spec: arov1alpha1.ClusterSpec{
+						Domain:                   "cluster.location.aroapp.io",
+						APIIntIP:                 "10.0.0.1",
+						IngressIP:                "10.0.0.2",
+						GatewayDomains:           []string{"example.com"},
+						GatewayPrivateEndpointIP: "10.0.1.0",
 						OperatorFlags: arov1alpha1.OperatorFlags{
 							operator.DnsmasqEnabled: operator.FlagTrue,
 						},
@@ -414,6 +479,11 @@ func TestMachineConfigReconcilerClusterUpgrading(t *testing.T) {
 						Conditions: defaultConditions,
 					},
 					Spec: arov1alpha1.ClusterSpec{
+						Domain:                   "cluster.location.aroapp.io",
+						APIIntIP:                 "10.0.0.1",
+						IngressIP:                "10.0.0.2",
+						GatewayDomains:           []string{"example.com"},
+						GatewayPrivateEndpointIP: "10.0.1.0",
 						OperatorFlags: arov1alpha1.OperatorFlags{
 							operator.DnsmasqEnabled: operator.FlagTrue,
 						},
@@ -451,6 +521,11 @@ func TestMachineConfigReconcilerClusterUpgrading(t *testing.T) {
 						Conditions: defaultConditions,
 					},
 					Spec: arov1alpha1.ClusterSpec{
+						Domain:                   "cluster.location.aroapp.io",
+						APIIntIP:                 "10.0.0.1",
+						IngressIP:                "10.0.0.2",
+						GatewayDomains:           []string{"example.com"},
+						GatewayPrivateEndpointIP: "10.0.1.0",
 						OperatorFlags: arov1alpha1.OperatorFlags{
 							operator.DnsmasqEnabled: operator.FlagTrue,
 						},

--- a/pkg/operator/controllers/dnsmasq/machineconfig_controller_test.go
+++ b/pkg/operator/controllers/dnsmasq/machineconfig_controller_test.go
@@ -128,12 +128,12 @@ func TestMachineConfigReconciler(t *testing.T) {
 					Name: "99-custom-aro-dns",
 				},
 			},
-			wantErrMsg: `invalid ingressIP ""`,
+			wantErrMsg: `invalid ingressIP: ParseAddr(""): unable to parse IP`,
 			wantConditions: []operatorv1.OperatorCondition{
 				defaultAvailable, defaultProgressing, {
 					Type:               MachineConfigControllerName + "ControllerDegraded",
 					Status:             "True",
-					Message:            `invalid ingressIP ""`,
+					Message:            `invalid ingressIP: ParseAddr(""): unable to parse IP`,
 					LastTransitionTime: transitionTime,
 				},
 			},

--- a/pkg/operator/controllers/dnsmasq/machineconfigpool_controller_test.go
+++ b/pkg/operator/controllers/dnsmasq/machineconfigpool_controller_test.go
@@ -105,6 +105,49 @@ func TestMachineConfigPoolReconciler(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "missing IngressIP returns error",
+			objects: []client.Object{
+				&arov1alpha1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Status: arov1alpha1.ClusterStatus{
+						Conditions: defaultConditions,
+					},
+					Spec: arov1alpha1.ClusterSpec{
+						Domain:                   "cluster.location.aroapp.io",
+						APIIntIP:                 "10.0.0.1",
+						GatewayDomains:           []string{"example.com"},
+						GatewayPrivateEndpointIP: "10.0.1.0",
+						OperatorFlags: arov1alpha1.OperatorFlags{
+							operator.DnsmasqEnabled:      operator.FlagTrue,
+							operator.ForceReconciliation: operator.FlagTrue,
+						},
+					},
+				},
+				&mcv1.MachineConfigPool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "custom",
+						Finalizers: []string{MachineConfigPoolControllerName},
+					},
+					Status: mcv1.MachineConfigPoolStatus{},
+					Spec:   mcv1.MachineConfigPoolSpec{},
+				},
+			},
+			request: ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Name: "custom",
+				},
+			},
+			wantErrMsg: `invalid ingressIP ""`,
+			wantConditions: []operatorv1.OperatorCondition{
+				defaultAvailable, defaultProgressing, {
+					Type:               MachineConfigPoolControllerName + "ControllerDegraded",
+					Status:             "True",
+					Message:            `invalid ingressIP ""`,
+					LastTransitionTime: transitionTime,
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -245,6 +288,11 @@ func TestMachineConfigPoolReconcilerNotUpgrading(t *testing.T) {
 						Conditions: defaultConditions,
 					},
 					Spec: arov1alpha1.ClusterSpec{
+						Domain:                   "cluster.location.aroapp.io",
+						APIIntIP:                 "10.0.0.1",
+						IngressIP:                "10.0.0.2",
+						GatewayDomains:           []string{"example.com"},
+						GatewayPrivateEndpointIP: "10.0.1.0",
 						OperatorFlags: arov1alpha1.OperatorFlags{
 							operator.DnsmasqEnabled: operator.FlagTrue,
 						},
@@ -281,6 +329,11 @@ func TestMachineConfigPoolReconcilerNotUpgrading(t *testing.T) {
 						Conditions: defaultConditions,
 					},
 					Spec: arov1alpha1.ClusterSpec{
+						Domain:                   "cluster.location.aroapp.io",
+						APIIntIP:                 "10.0.0.1",
+						IngressIP:                "10.0.0.2",
+						GatewayDomains:           []string{"example.com"},
+						GatewayPrivateEndpointIP: "10.0.1.0",
 						OperatorFlags: arov1alpha1.OperatorFlags{
 							operator.DnsmasqEnabled: operator.FlagTrue,
 						},
@@ -319,6 +372,11 @@ func TestMachineConfigPoolReconcilerNotUpgrading(t *testing.T) {
 						Conditions: defaultConditions,
 					},
 					Spec: arov1alpha1.ClusterSpec{
+						Domain:                   "cluster.location.aroapp.io",
+						APIIntIP:                 "10.0.0.1",
+						IngressIP:                "10.0.0.2",
+						GatewayDomains:           []string{"example.com"},
+						GatewayPrivateEndpointIP: "10.0.1.0",
 						OperatorFlags: arov1alpha1.OperatorFlags{
 							operator.DnsmasqEnabled:      operator.FlagTrue,
 							operator.ForceReconciliation: operator.FlagTrue,
@@ -432,6 +490,11 @@ func TestMachineConfigPoolReconcilerClusterUpgrading(t *testing.T) {
 						Conditions: defaultConditions,
 					},
 					Spec: arov1alpha1.ClusterSpec{
+						Domain:                   "cluster.location.aroapp.io",
+						APIIntIP:                 "10.0.0.1",
+						IngressIP:                "10.0.0.2",
+						GatewayDomains:           []string{"example.com"},
+						GatewayPrivateEndpointIP: "10.0.1.0",
 						OperatorFlags: arov1alpha1.OperatorFlags{
 							operator.DnsmasqEnabled: operator.FlagTrue,
 						},
@@ -468,6 +531,11 @@ func TestMachineConfigPoolReconcilerClusterUpgrading(t *testing.T) {
 						Conditions: defaultConditions,
 					},
 					Spec: arov1alpha1.ClusterSpec{
+						Domain:                   "cluster.location.aroapp.io",
+						APIIntIP:                 "10.0.0.1",
+						IngressIP:                "10.0.0.2",
+						GatewayDomains:           []string{"example.com"},
+						GatewayPrivateEndpointIP: "10.0.1.0",
 						OperatorFlags: arov1alpha1.OperatorFlags{
 							operator.DnsmasqEnabled: operator.FlagTrue,
 						},

--- a/pkg/operator/controllers/dnsmasq/machineconfigpool_controller_test.go
+++ b/pkg/operator/controllers/dnsmasq/machineconfigpool_controller_test.go
@@ -138,12 +138,12 @@ func TestMachineConfigPoolReconciler(t *testing.T) {
 					Name: "custom",
 				},
 			},
-			wantErrMsg: `invalid ingressIP ""`,
+			wantErrMsg: `invalid ingressIP: ParseAddr(""): unable to parse IP`,
 			wantConditions: []operatorv1.OperatorCondition{
 				defaultAvailable, defaultProgressing, {
 					Type:               MachineConfigPoolControllerName + "ControllerDegraded",
 					Status:             "True",
-					Message:            `invalid ingressIP ""`,
+					Message:            `invalid ingressIP: ParseAddr(""): unable to parse IP`,
 					LastTransitionTime: transitionTime,
 				},
 			},


### PR DESCRIPTION
### Which issue this PR addresses:

Further defense-in-depth for [ARO-28341](https://redhat.atlassian.net/browse/ARO-28341)

### What this PR does / why we need it:

Updates the ARO Operator dnsmasq controllers to fail quickly and loudly if any of the "endpoint" properties (apiIntIP, ingressIP, gatewayPrivateEndpointIP when gatewayDomains are present) are missing or invalid. While the various components responsible for writing these fields to the in-cluster resource have been updated to ensure they do not pass nil/invalid values in other changes, this will ensure that should these fields be invalid for whatever reason, we do not write those invalid values to dnsmasq.conf. 

### Test plan for issue:

- [X] Unit tests were added/updated for this and all unit tests pass
- [x] End-to-end tests still pass

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

Above testing and validation