### PR TITLE
[ARO-28866] Improve resource usage of MIMO Scheduler

### DIFF
--- a/pkg/mimo/scheduler/helpers_test.go
+++ b/pkg/mimo/scheduler/helpers_test.go
@@ -15,10 +15,12 @@ type fakeScheduler struct {
 	hasRan        bool
 	whileRunning  func()
 	waitOnProcess *sync.WaitGroup
+	calls         int
 }
 
 func (f *fakeScheduler) AddMaintenanceTasks(_ map[api.MIMOTaskID]tasks.MaintenanceTask) {}
 func (f *fakeScheduler) Process(_ context.Context) (bool, error) {
+	f.calls++
 	if f.hasRan {
 		return false, nil
 	}
@@ -26,6 +28,8 @@ func (f *fakeScheduler) Process(_ context.Context) (bool, error) {
 		f.whileRunning()
 	}
 	f.hasRan = true
-	f.waitOnProcess.Done()
+	if f.waitOnProcess != nil {
+		f.waitOnProcess.Done()
+	}
 	return true, nil
 }

--- a/pkg/mimo/scheduler/service.go
+++ b/pkg/mimo/scheduler/service.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"iter"
 	"log"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"net/http"
 	"slices"
@@ -54,8 +54,9 @@ var (
 )
 
 type service struct {
-	baseLog *logrus.Entry
-	env     env.Interface
+	baseLog     *logrus.Entry
+	env         env.Interface
+	randFloat64 func() float64
 
 	dbGroup schedulerDBs
 
@@ -110,8 +111,9 @@ type schedulerDBs interface {
 
 func NewService(env env.Interface, log *logrus.Entry, dbg schedulerDBs, m metrics.Emitter) *service {
 	s := &service{
-		env:     env,
-		baseLog: log,
+		env:         env,
+		baseLog:     log,
+		randFloat64: rand.Float64,
 
 		dbGroup: dbg,
 
@@ -415,7 +417,7 @@ func (s *service) worker(stop <-chan struct{}, id string) {
 
 	// This determines how far offset into the startup delay as well as the
 	// unconditional reconcile interval this worker will run
-	delayFraction := rand.Float64()
+	delayFraction := s.randFloat64()
 
 	delay := time.Second * time.Duration(s.workerMaxStartupDelay.Seconds()*delayFraction)
 	log := s.baseLog.WithFields(logrus.Fields{"scheduleID": id})

--- a/pkg/mimo/scheduler/service.go
+++ b/pkg/mimo/scheduler/service.go
@@ -473,17 +473,17 @@ out:
 			// unconditionally. Missing the marker (e.g. when buckets update)
 			// means it should be run.
 			shouldReevaluateSchedule, hasMarker := s.scheduleShouldBeReevaluated.Load(id)
-			reevalulateUnconditionally := false
+			reevaluateUnconditionally := false
 			lastRunTime, hasRun := s.scheduleLastRunTime.Load(id)
 			if hasRun {
-				reevalulateUnconditionally = shouldReevaluateUnconditionally(
+				reevaluateUnconditionally = shouldReevaluateUnconditionally(
 					now, lastRunTime, s.scheduleUnconditionalReconcileInterval, delayFraction)
 			}
 
 			// If we don't need to reevaluate it because the schedule/buckets
 			// updated, and we aren't due to unconditionally reevaluate it, skip
 			// this time.
-			if (!shouldReevaluateSchedule && hasMarker) && !reevalulateUnconditionally {
+			if (!shouldReevaluateSchedule && hasMarker) && !reevaluateUnconditionally {
 				return
 			}
 

--- a/pkg/mimo/scheduler/service.go
+++ b/pkg/mimo/scheduler/service.go
@@ -17,6 +17,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/puzpuzpuz/xsync/v4"
 	"github.com/sirupsen/logrus"
 
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
@@ -38,16 +39,17 @@ type Runnable interface {
 }
 
 var (
-	defaultWorkerMaxStartupDelay          = 60 * time.Second
-	defaultServiceInterval                = 180 * time.Second
-	defaultReadinessDelay                 = 2 * time.Minute
-	defaultSchedulePollInterval           = 30 * time.Second
-	defaultSchedulePollReadinessInterval  = 90 * time.Second
-	defaultChangefeedInteval              = 10 * time.Second
-	defaultChangefeedReadinessInterval    = time.Minute
-	defaultBucketRefreshInterval          = 10 * time.Second
-	defaultBucketRefreshTTL               = 60 * time.Second
-	defaultBucketRefreshReadinessInterval = defaultBucketRefreshTTL
+	defaultWorkerMaxStartupDelay                  = 60 * time.Second
+	defaultServiceInterval                        = 180 * time.Second
+	defaultReadinessDelay                         = 2 * time.Minute
+	defaultSchedulePollInterval                   = 30 * time.Second
+	defaultSchedulePollReadinessInterval          = 90 * time.Second
+	defaultScheduleUnconditionalReconcileInterval = 60 * time.Minute
+	defaultChangefeedInteval                      = 10 * time.Second
+	defaultChangefeedReadinessInterval            = time.Minute
+	defaultBucketRefreshInterval                  = 10 * time.Second
+	defaultBucketRefreshTTL                       = 60 * time.Second
+	defaultBucketRefreshReadinessInterval         = defaultBucketRefreshTTL
 )
 
 type service struct {
@@ -74,18 +76,22 @@ type service struct {
 	lastBucketUpdate   atomic.Value // time.Time
 	startTime          time.Time
 
-	workerMaxStartupDelay          time.Duration // Maximum interval before a worker starts
-	interval                       time.Duration // Interval between service runs
-	schedulePollInterval           time.Duration // Interval between updates to Schedules
-	schedulePollReadinessInterval  time.Duration // Time that the Schedules should have been updated within to be ready
-	changefeedInterval             time.Duration // Interval between changefeed runs (updates to cluster docs + subscriptions)
-	bucketRefreshInterval          time.Duration
-	bucketRefreshTTL               time.Duration // TTL for worker PoolWorker documents
-	bucketRefreshReadinessInterval time.Duration
-	changefeedReadinessInterval    time.Duration // Time that the changefeed should have been changed within to be healthy
-	readinessDelay                 time.Duration // Minimal time until the service will allow itself to be marked ready
+	workerMaxStartupDelay                  time.Duration // Maximum interval before a worker starts
+	interval                               time.Duration // Interval between service runs
+	schedulePollInterval                   time.Duration // Interval between updates to Schedules
+	schedulePollReadinessInterval          time.Duration // Time that the Schedules should have been updated within to be ready
+	scheduleUnconditionalReconcileInterval time.Duration // Interval between times that a Schedule is reconciled unconditionally
+	changefeedInterval                     time.Duration // Interval between changefeed runs (updates to cluster docs + subscriptions)
+	bucketRefreshInterval                  time.Duration
+	bucketRefreshTTL                       time.Duration // TTL for worker PoolWorker documents
+	bucketRefreshReadinessInterval         time.Duration
+	changefeedReadinessInterval            time.Duration // Time that the changefeed should have been changed within to be healthy
+	readinessDelay                         time.Duration // Minimal time until the service will allow itself to be marked ready
 
 	tasks map[api.MIMOTaskID]tasks.MaintenanceTask
+
+	scheduleShouldBeReevaluated *xsync.Map[string, bool]
+	scheduleLastRunTime         *xsync.Map[string, time.Time]
 
 	serveHealthz  bool
 	emitHeartbeat bool
@@ -117,18 +123,22 @@ func NewService(env env.Interface, log *logrus.Entry, dbg schedulerDBs, m metric
 		workerMaxStartupDelay: defaultWorkerMaxStartupDelay,
 		newScheduler:          NewSchedulerForSchedule,
 
-		changefeedBatchSize:            50,
-		interval:                       defaultServiceInterval,
-		changefeedInterval:             defaultChangefeedInteval,
-		changefeedReadinessInterval:    defaultChangefeedReadinessInterval,
-		bucketRefreshInterval:          defaultBucketRefreshInterval,
-		bucketRefreshTTL:               defaultBucketRefreshTTL,
-		bucketRefreshReadinessInterval: defaultBucketRefreshReadinessInterval,
-		readinessDelay:                 defaultReadinessDelay,
-		schedulePollInterval:           defaultSchedulePollInterval,
-		schedulePollReadinessInterval:  defaultSchedulePollReadinessInterval,
+		changefeedBatchSize:                    50,
+		interval:                               defaultServiceInterval,
+		changefeedInterval:                     defaultChangefeedInteval,
+		changefeedReadinessInterval:            defaultChangefeedReadinessInterval,
+		bucketRefreshInterval:                  defaultBucketRefreshInterval,
+		bucketRefreshTTL:                       defaultBucketRefreshTTL,
+		bucketRefreshReadinessInterval:         defaultBucketRefreshReadinessInterval,
+		readinessDelay:                         defaultReadinessDelay,
+		schedulePollInterval:                   defaultSchedulePollInterval,
+		schedulePollReadinessInterval:          defaultSchedulePollReadinessInterval,
+		scheduleUnconditionalReconcileInterval: defaultScheduleUnconditionalReconcileInterval,
 
 		subs: changefeed.NewSubscriptionsChangefeedCache(m, false),
+
+		scheduleShouldBeReevaluated: xsync.NewMap[string, bool](),
+		scheduleLastRunTime:         xsync.NewMap[string, time.Time](),
 
 		serveHealthz:  true,
 		emitHeartbeat: true,
@@ -221,6 +231,9 @@ func (s *service) Run(_ctx context.Context, stop <-chan struct{}, done chan<- st
 			if len(i) > 0 {
 				s.lastBucketUpdate.Store(s.env.Now())
 			}
+			// If we have a bucket update, mark all schedules as needing to be
+			// reevaluated by deleting the markers
+			s.scheduleShouldBeReevaluated.Clear()
 		}, stop, cancel, waitForFirstBucketUpdate,
 	)
 
@@ -339,8 +352,17 @@ func (s *service) poll(ctx context.Context, oldDocs map[string]*api.MaintenanceS
 
 	s.baseLog.Debugf("updating %d schedules", len(docMap))
 
-	for _, cluster := range docMap {
-		s.b.UpsertDoc(cluster)
+	for _, schedule := range docMap {
+		oldDoc, docExists := s.b.Doc(strings.ToLower(schedule.ID))
+		if !docExists {
+			// If this schedule is new, reevaluate it
+			s.scheduleShouldBeReevaluated.Store(strings.ToLower(schedule.ID), true)
+		} else if schedule.Timestamp != oldDoc.Timestamp {
+			// If the changed timestamp is different, reevaluate the schedule
+			s.scheduleShouldBeReevaluated.Store(strings.ToLower(schedule.ID), true)
+		}
+
+		s.b.UpsertDoc(schedule)
 	}
 
 	// Store when we last fetched the schedules
@@ -387,7 +409,11 @@ func (s *service) checkReady() bool {
 func (s *service) worker(stop <-chan struct{}, id string) {
 	defer recover.Panic(s.baseLog)
 
-	delay := time.Second * time.Duration(s.workerMaxStartupDelay.Seconds()*rand.Float64())
+	// This determines how far offset into the startup delay as well as the
+	// unconditional reconcile interval this worker will run
+	delayFraction := rand.Float64()
+
+	delay := time.Second * time.Duration(s.workerMaxStartupDelay.Seconds()*delayFraction)
 	log := s.baseLog.WithFields(logrus.Fields{"scheduleID": id})
 	log.Debugf("starting worker for %s in %s...", id, delay.String())
 
@@ -439,6 +465,27 @@ func (s *service) worker(stop <-chan struct{}, id string) {
 out:
 	for !s.stopping.Load() {
 		func() {
+			// Check if this schedule has updated or if we should run it again
+			// unconditionally. Missing the marker (e.g. when buckets update)
+			// means it should be run.
+			shouldReevaluateSchedule, hasMarker := s.scheduleShouldBeReevaluated.LoadAndStore(id, false)
+
+			reevalulateUnconditionally := false
+			// Store the run time as we want to start at the same time every
+			// interval, not interval+eval time
+			lastRunTime, hasRun := s.scheduleLastRunTime.LoadAndStore(id, s.env.Now())
+			if hasRun {
+				reevalulateUnconditionally = shouldReevaluateUnconditionally(
+					s.env.Now(), lastRunTime, s.scheduleUnconditionalReconcileInterval, delayFraction)
+			}
+
+			// If we don't need to reevaluate it because the schedule/buckets
+			// updated, and we aren't due to unconditionally reevaluate it, skip
+			// this time.
+			if (!shouldReevaluateSchedule && hasMarker) && !reevalulateUnconditionally {
+				return
+			}
+
 			s.workerCount.Add(1)
 			s.m.EmitGauge("mimo.scheduler.workers.active.count", int64(s.workerCount.Load()), nil)
 			defer func() {
@@ -461,4 +508,18 @@ out:
 		}
 	}
 	log.Debugf("worker for %s finished", id)
+}
+
+func shouldReevaluateUnconditionally(now time.Time, lastRunTime time.Time, interval time.Duration, delayFraction float64) bool {
+	return now.After(lastRunTime.
+		// Add the interval (e.g. the default 60 minutes)
+		Add(interval).
+		// Offset this schedule delayFraction amount into the interval (e.g. so
+		// a 60 minute interval and a schedule with a 0.5 delayFraction will run
+		// at startup and then 90 minutes later, then every 60 minutes
+		// thereafter). The microsecond is removed to make it inclusive (e.g. 00:00
+		// to 59:59 for the 1hr example)
+		Add((interval - time.Microsecond) * time.Duration(delayFraction)).
+		// Make it now >= by removing a microsecond
+		Add(-time.Microsecond))
 }

--- a/pkg/mimo/scheduler/service.go
+++ b/pkg/mimo/scheduler/service.go
@@ -12,6 +12,7 @@ import (
 	"math/rand"
 	"net"
 	"net/http"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -227,13 +228,16 @@ func (s *service) Run(_ctx context.Context, stop <-chan struct{}, done chan<- st
 	go buckets.StartBucketRefreshLoop(
 		_ctx, s.baseLog, api.PoolWorkerTypeMIMOScheduler,
 		s.bucketCount, s.bucketRefreshInterval, s.bucketRefreshTTL, dbPoolWorkers, func(i []int) {
-			s.buckets.Store(i)
+			old, ok := s.buckets.Load().([]int)
+			if !ok || !slices.Equal(old, i) {
+				s.buckets.Store(i)
+				// If we have a bucket update, mark all schedules as needing to be
+				// reevaluated by deleting the markers
+				s.scheduleShouldBeReevaluated.Clear()
+			}
 			if len(i) > 0 {
 				s.lastBucketUpdate.Store(s.env.Now())
 			}
-			// If we have a bucket update, mark all schedules as needing to be
-			// reevaluated by deleting the markers
-			s.scheduleShouldBeReevaluated.Clear()
 		}, stop, cancel, waitForFirstBucketUpdate,
 	)
 

--- a/pkg/mimo/scheduler/service.go
+++ b/pkg/mimo/scheduler/service.go
@@ -40,7 +40,7 @@ type Runnable interface {
 
 var (
 	defaultWorkerMaxStartupDelay                  = 60 * time.Second
-	defaultServiceInterval                        = 180 * time.Second
+	defaultServiceInterval                        = 15 * time.Second
 	defaultReadinessDelay                         = 2 * time.Minute
 	defaultSchedulePollInterval                   = 30 * time.Second
 	defaultSchedulePollReadinessInterval          = 90 * time.Second

--- a/pkg/mimo/scheduler/service.go
+++ b/pkg/mimo/scheduler/service.go
@@ -527,15 +527,15 @@ out:
 }
 
 func shouldReevaluateUnconditionally(now time.Time, lastRunTime time.Time, interval time.Duration, delayFraction float64) bool {
-	return now.After(lastRunTime.
-		// Add the interval (e.g. the default 60 minutes)
-		Add(interval).
+	// Add the interval (e.g. the default 60 minutes)
+	shiftInterval := interval +
 		// Offset this schedule delayFraction amount into the interval (e.g. so
 		// a 60 minute interval and a schedule with a 0.5 delayFraction will run
 		// at startup and then 90 minutes later, then every 60 minutes
 		// thereafter). The microsecond is removed to make it inclusive (e.g. 00:00
 		// to 59:59 for the 1hr example)
-		Add((interval - time.Microsecond) * time.Duration(delayFraction)).
+		time.Duration(float64(interval-time.Microsecond)*delayFraction) -
 		// Make it now >= by removing a microsecond
-		Add(-time.Microsecond))
+		time.Microsecond
+	return now.After(lastRunTime.Add(shiftInterval))
 }

--- a/pkg/mimo/scheduler/service.go
+++ b/pkg/mimo/scheduler/service.go
@@ -465,18 +465,19 @@ func (s *service) worker(stop <-chan struct{}, id string) {
 out:
 	for !s.stopping.Load() {
 		func() {
+			// Store the run time as we want to start at the same time every
+			// interval, not interval+eval time
+			now := s.env.Now()
+
 			// Check if this schedule has updated or if we should run it again
 			// unconditionally. Missing the marker (e.g. when buckets update)
 			// means it should be run.
-			shouldReevaluateSchedule, hasMarker := s.scheduleShouldBeReevaluated.LoadAndStore(id, false)
-
+			shouldReevaluateSchedule, hasMarker := s.scheduleShouldBeReevaluated.Load(id)
 			reevalulateUnconditionally := false
-			// Store the run time as we want to start at the same time every
-			// interval, not interval+eval time
-			lastRunTime, hasRun := s.scheduleLastRunTime.LoadAndStore(id, s.env.Now())
+			lastRunTime, hasRun := s.scheduleLastRunTime.Load(id)
 			if hasRun {
 				reevalulateUnconditionally = shouldReevaluateUnconditionally(
-					s.env.Now(), lastRunTime, s.scheduleUnconditionalReconcileInterval, delayFraction)
+					now, lastRunTime, s.scheduleUnconditionalReconcileInterval, delayFraction)
 			}
 
 			// If we don't need to reevaluate it because the schedule/buckets
@@ -499,6 +500,9 @@ out:
 			if err != nil {
 				log.Error(err)
 			}
+
+			s.scheduleLastRunTime.Store(id, now)
+			s.scheduleShouldBeReevaluated.Store(id, false)
 		}()
 
 		select {

--- a/pkg/mimo/scheduler/service.go
+++ b/pkg/mimo/scheduler/service.go
@@ -469,10 +469,11 @@ out:
 			// interval, not interval+eval time
 			now := s.env.Now()
 
-			// Check if this schedule has updated or if we should run it again
-			// unconditionally. Missing the marker (e.g. when buckets update)
-			// means it should be run.
-			shouldReevaluateSchedule, hasMarker := s.scheduleShouldBeReevaluated.Load(id)
+			// Check if this schedule has updated. Missing the marker (e.g. when
+			// buckets update) means it should be run. Replace it as false, we
+			// will reset any true value on failure.
+			shouldReevaluateSchedule, hasMarker := s.scheduleShouldBeReevaluated.LoadAndStore(id, false)
+			// Check if it's been long enough that we should run it unconditionally anyway.
 			reevaluateUnconditionally := false
 			lastRunTime, hasRun := s.scheduleLastRunTime.Load(id)
 			if hasRun {
@@ -499,10 +500,15 @@ out:
 			_, err := a.Process(context.Background())
 			if err != nil {
 				log.Error(err)
+				// On error, reset the previous reevaluation marker if it was true
+				if shouldReevaluateSchedule {
+					s.scheduleShouldBeReevaluated.Store(id, shouldReevaluateSchedule)
+				}
+			} else {
+				// Update the last scheduled run time if we succeeded, so
+				// failures will retry next loop.
+				s.scheduleLastRunTime.Store(id, now)
 			}
-
-			s.scheduleLastRunTime.Store(id, now)
-			s.scheduleShouldBeReevaluated.Store(id, false)
 		}()
 
 		select {

--- a/pkg/mimo/scheduler/service_test.go
+++ b/pkg/mimo/scheduler/service_test.go
@@ -905,7 +905,7 @@ func TestSchedulerDoesNotProcessConstantlyIfNoUpdates(t *testing.T) {
 			svc.serveHealthz = false
 			svc.emitHeartbeat = false
 			// This is called to get the random delay fraction
-			svc.randfloat64 = func() float64 { return tC.delayFraction }
+			svc.randFloat64 = func() float64 { return tC.delayFraction }
 			svc.newScheduler = func(_ env.Interface, _ *logrus.Entry, _ metrics.Emitter, _ getCachedScheduleDocFunc, _ getClustersFunc, _ schedulerDBs) (Scheduler, error) {
 				return sched, nil
 			}

--- a/pkg/mimo/scheduler/service_test.go
+++ b/pkg/mimo/scheduler/service_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/api/util/uuid"
 	"github.com/Azure/ARO-RP/pkg/database"
+	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
 	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/metrics"
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
@@ -604,6 +605,213 @@ func TestSchedulerServesBucket(t *testing.T) {
 				"resourceId":     strings.ToLower(api.ExampleOpenShiftClusterDocument().OpenShiftCluster.ID),
 				"subscriptionId": api.ExampleSubscriptionDocument().ID,
 				"resourceName":   "resourcename",
+			},
+			Value: 1,
+		},
+		// No running workers
+		{
+			MetricName: "mimo.scheduler.workers.active.count",
+			Dimensions: map[string]string{},
+			Value:      0,
+		},
+	}...)
+}
+
+func TestSchedulerServesBucketWhenChanges(t *testing.T) {
+	r := require.New(t)
+	ctx := t.Context()
+
+	m := testmetrics.NewFakeMetricsEmitter(t)
+	controller := gomock.NewController(t)
+	_env := mock_env.NewMockInterface(controller)
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	ourUUID := uuid.DefaultGenerator.Generate()
+
+	_env.EXPECT().Now().AnyTimes().DoAndReturn(func() time.Time {
+		now = now.Add(time.Millisecond)
+		return now
+	})
+
+	_, log := testlog.LogForTesting(t)
+	fixtures := testdatabase.NewFixture()
+	checker := testdatabase.NewChecker()
+	manifests, manifestsClient := testdatabase.NewFakeMaintenanceManifests(_env.Now)
+	schedules, _ := testdatabase.NewFakeMaintenanceSchedules()
+	clusters, _ := testdatabase.NewFakeOpenShiftClusters()
+	subscriptions, _ := testdatabase.NewFakeSubscriptions()
+	poolWorkers, poolWorkersClient := testdatabase.NewFakePoolWorkers(_env.Now, ourUUID)
+	dbs := database.NewDBGroup().
+		WithMaintenanceSchedules(schedules).
+		WithSubscriptions(subscriptions).
+		WithOpenShiftClusters(clusters).
+		WithPoolWorkers(poolWorkers).
+		WithMaintenanceManifests(manifests)
+
+	ownedCluster := api.ExampleOpenShiftClusterDocument()
+	ownedCluster.Bucket = 1
+
+	notInInitialBucketCluster := api.ExampleOpenShiftClusterDocument()
+	notInInitialBucketCluster.Bucket = 0
+	notInInitialBucketCluster.ID = "00000000-1111-0000-0000-000000000002"
+	notInInitialBucketCluster.Key = "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/resourcegroup2/providers/microsoft.redhatopenshift/openshiftclusters/resourcename2"
+	notInInitialBucketCluster.OpenShiftCluster.ID = "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/resourcegroup2/providers/microsoft.redhatopenshift/openshiftclusters/resourcename2"
+	notInInitialBucketCluster.ClusterResourceGroupIDKey = "/subscriptions/00000000-1111-0000-0000-000000000000/resourcegroups/clusterresourcegroup2"
+	notInInitialBucketCluster.ClientIDKey = "2"
+
+	poolWorkerMasterDoc := &api.PoolWorkerDocument{
+		ID:         string(api.PoolWorkerTypeMIMOScheduler),
+		WorkerType: api.PoolWorkerTypeMIMOScheduler,
+		PoolWorker: &api.PoolWorker{
+			// We only have bucket 1, the unowned cluster will not be served
+			Buckets: []string{"other", ourUUID, "other", "other"},
+		},
+		LeaseOwner:   "other",
+		LeaseExpires: 9999999999999,
+	}
+
+	fixtures.AddSubscriptionDocuments(api.ExampleSubscriptionDocument())
+	fixtures.AddOpenShiftClusterDocuments(ownedCluster, notInInitialBucketCluster)
+	fixtures.AddPoolWorkerDocuments(poolWorkerMasterDoc)
+
+	fixtures.AddMaintenanceScheduleDocuments(&api.MaintenanceScheduleDocument{
+		ID: "00000000-0000-0000-0000-000000000001",
+		MaintenanceSchedule: api.MaintenanceSchedule{
+			State:             api.MaintenanceScheduleStateEnabled,
+			MaintenanceTaskID: api.MIMOTaskID("0"),
+
+			Schedule:         "*-*-* *:15",
+			ScheduleAcross:   "0s",
+			LookForwardCount: 1,
+
+			Selectors: []*api.MaintenanceScheduleSelector{
+				{
+					Key:      string(SelectorDataKeySubscriptionState),
+					Operator: api.MaintenanceScheduleSelectorOperatorEq,
+					Value:    "Registered",
+				},
+			},
+		},
+	})
+
+	checker.AddMaintenanceManifestDocuments(&api.MaintenanceManifestDocument{
+		ID:                "07070707-0707-0707-0707-070707070001",
+		ClusterResourceID: strings.ToLower(api.ExampleOpenShiftClusterDocument().OpenShiftCluster.ID),
+		MaintenanceManifest: api.MaintenanceManifest{
+			State:             api.MaintenanceManifestStatePending,
+			MaintenanceTaskID: "0",
+			CreatedBySchedule: "00000000-0000-0000-0000-000000000001",
+			RunAfter:          time.Date(2026, 1, 1, 0, 15, 0, 0, time.UTC).Unix(),
+			RunBefore:         time.Date(2026, 1, 1, 1, 15, 0, 0, time.UTC).Unix(),
+		},
+	})
+
+	// Apply the fixture
+	err := fixtures.WithMaintenanceSchedules(schedules).
+		WithOpenShiftClusters(clusters).
+		WithSubscriptions(subscriptions).
+		WithPoolWorkers(poolWorkers).
+		Create()
+	r.NoError(err)
+
+	svc := NewService(_env, log, dbs, m)
+	svc.workerMaxStartupDelay = 0
+	svc.interval = 10 * time.Millisecond
+	svc.bucketRefreshInterval = 1 * time.Millisecond
+	svc.schedulePollInterval = 1 * time.Millisecond
+	svc.changefeedInterval = time.Millisecond
+	svc.readinessDelay = time.Millisecond
+	svc.serveHealthz = false
+	svc.emitHeartbeat = false
+
+	stop := make(chan struct{})
+	done := make(chan struct{})
+
+	go svc.Run(ctx, stop, done)
+
+	r.EventuallyWithT(func(collect *assert.CollectT) {
+		require.True(collect, svc.checkReady())
+	}, time.Second, time.Millisecond)
+
+	// Wait for our created manifest
+	r.EventuallyWithT(func(collect *assert.CollectT) {
+		require.Empty(collect, checker.CheckMaintenanceManifests(manifestsClient))
+	}, time.Second, time.Millisecond*10)
+
+	// Update the buckets so that the unowned cluster becomes owned
+	_, err = poolWorkersClient.Replace(ctx, string(api.PoolWorkerTypeMIMOScheduler), &api.PoolWorkerDocument{
+		ID:         string(api.PoolWorkerTypeMIMOScheduler),
+		WorkerType: api.PoolWorkerTypeMIMOScheduler,
+		PoolWorker: &api.PoolWorker{
+			// Now we own buckets 0 and 1
+			Buckets: []string{ourUUID, ourUUID, "other", "other"},
+		},
+		LeaseOwner:   "other",
+		LeaseExpires: 9999999999999,
+	}, &cosmosdb.Options{NoETag: true})
+	r.NoError(err)
+
+	checker.AddMaintenanceManifestDocuments(&api.MaintenanceManifestDocument{
+		ID:                "07070707-0707-0707-0707-070707070002",
+		ClusterResourceID: strings.ToLower(notInInitialBucketCluster.OpenShiftCluster.ID),
+		MaintenanceManifest: api.MaintenanceManifest{
+			State:             api.MaintenanceManifestStatePending,
+			MaintenanceTaskID: "0",
+			CreatedBySchedule: "00000000-0000-0000-0000-000000000001",
+			RunAfter:          time.Date(2026, 1, 1, 0, 15, 0, 0, time.UTC).Unix(),
+			RunBefore:         time.Date(2026, 1, 1, 1, 15, 0, 0, time.UTC).Unix(),
+		},
+	})
+
+	// Wait for our second created manifest
+	r.EventuallyWithT(func(collect *assert.CollectT) {
+		require.Empty(collect, checker.CheckMaintenanceManifests(manifestsClient))
+	}, time.Second, time.Millisecond*10)
+
+	// Close it after
+	close(stop)
+	<-done
+	r.Equal(int32(0), svc.workerCount.Load())
+
+	m.AssertFloats()
+	m.AssertGauges([]testmetrics.MetricsAssertion[int64]{
+		{
+			MetricName: "changefeed.caches.size",
+			Dimensions: map[string]string{
+				"name": "MaintenanceScheduleDocument",
+			},
+			Value: 1,
+		},
+		{
+			MetricName: "changefeed.caches.size",
+			Dimensions: map[string]string{
+				"name": "OpenShiftClusterDocument",
+			},
+			Value: 2,
+		},
+		{
+			MetricName: "changefeed.caches.size",
+			Dimensions: map[string]string{
+				"name": "SubscriptionDocument",
+			},
+			Value: 1,
+		},
+		{
+			MetricName: "mimo.scheduler.manifests.created",
+			Dimensions: map[string]string{
+				"resourceGroup":  "resourcegroup",
+				"resourceId":     strings.ToLower(api.ExampleOpenShiftClusterDocument().OpenShiftCluster.ID),
+				"subscriptionId": api.ExampleSubscriptionDocument().ID,
+				"resourceName":   "resourcename",
+			},
+			Value: 1,
+		},
+		{
+			MetricName: "mimo.scheduler.manifests.created",
+			Dimensions: map[string]string{
+				"resourceGroup":  "resourcegroup2",
+				"resourceId":     strings.ToLower(notInInitialBucketCluster.OpenShiftCluster.ID),
+				"subscriptionId": api.ExampleSubscriptionDocument().ID,
+				"resourceName":   "resourcename2",
 			},
 			Value: 1,
 		},

--- a/pkg/mimo/scheduler/service_test.go
+++ b/pkg/mimo/scheduler/service_test.go
@@ -833,19 +833,11 @@ func TestSchedulerDoesNotProcessConstantlyIfNoUpdates(t *testing.T) {
 	}{
 		{
 			// The delay fraction at 0.0 should have unconditional reconciles
-			// around 250ms, 500ms, 750ms, and 1s
+			// around 250ms, 500ms, 750ms, and one we probably won't run at 1s
 			desc:               "delay fraction at 0.0",
 			delayFraction:      0.0,
 			expectedLowerBound: 4,
 			expectedUpperBound: 6,
-		},
-		{
-			desc:          "delay fraction at 1.0",
-			delayFraction: 1.0,
-			// The delay fraction at 1.0 should have unconditional reconciles
-			// around 500ms, 750ms, and 1s
-			expectedLowerBound: 3,
-			expectedUpperBound: 5,
 		},
 		{
 			desc:          "delay fraction at 0.5",
@@ -854,6 +846,14 @@ func TestSchedulerDoesNotProcessConstantlyIfNoUpdates(t *testing.T) {
 			// around 375, 625ms, 875ms, and one we won't run at 1125ms
 			expectedLowerBound: 3,
 			expectedUpperBound: 5,
+		},
+		{
+			desc:          "delay fraction at 1.0",
+			delayFraction: 1.0,
+			// The delay fraction at 1.0 should have unconditional reconciles
+			// around 500ms, 750ms, and one we probably won't run at 1s
+			expectedLowerBound: 2,
+			expectedUpperBound: 4,
 		},
 	}
 	for _, tC := range testCases {

--- a/pkg/mimo/scheduler/service_test.go
+++ b/pkg/mimo/scheduler/service_test.go
@@ -825,97 +825,135 @@ func TestSchedulerServesBucketWhenChanges(t *testing.T) {
 }
 
 func TestSchedulerDoesNotProcessConstantlyIfNoUpdates(t *testing.T) {
-	r := require.New(t)
-	ctx := t.Context()
-
-	m := testmetrics.NewFakeMetricsEmitter(t)
-	controller := gomock.NewController(t)
-	_env := mock_env.NewMockInterface(controller)
-	_env.EXPECT().Now().AnyTimes().DoAndReturn(time.Now)
-
-	_, log := testlog.LogForTesting(t)
-	fixtures := testdatabase.NewFixture()
-	schedules, _ := testdatabase.NewFakeMaintenanceSchedules()
-	clusters, _ := testdatabase.NewFakeOpenShiftClusters()
-	subscriptions, _ := testdatabase.NewFakeSubscriptions()
-	poolWorkers, _ := testdatabase.NewFakePoolWorkers(_env.Now, uuid.DefaultGenerator.Generate())
-	dbs := database.NewDBGroup().
-		WithMaintenanceSchedules(schedules).
-		WithSubscriptions(subscriptions).
-		WithOpenShiftClusters(clusters).
-		WithPoolWorkers(poolWorkers)
-
-	fixtures.AddMaintenanceScheduleDocuments(&api.MaintenanceScheduleDocument{
-		ID: "00000000-0000-0000-0000-000000000000",
-		MaintenanceSchedule: api.MaintenanceSchedule{
-			State: api.MaintenanceScheduleStateEnabled,
+	testCases := []struct {
+		desc               string
+		delayFraction      float64
+		expectedLowerBound int
+		expectedUpperBound int
+	}{
+		{
+			// The delay fraction at 0.0 should have unconditional reconciles
+			// around 250ms, 500ms, 750ms, and 1s
+			desc:               "delay fraction at 0.0",
+			delayFraction:      0.0,
+			expectedLowerBound: 4,
+			expectedUpperBound: 6,
 		},
-	})
-
-	// Apply the fixture
-	err := fixtures.WithMaintenanceSchedules(schedules).
-		WithOpenShiftClusters(clusters).
-		WithSubscriptions(subscriptions).
-		Create()
-	r.NoError(err)
-
-	sched := &fakeScheduler{}
-
-	svc := NewService(_env, log, dbs, m)
-	svc.workerMaxStartupDelay = 0
-	svc.interval = time.Millisecond
-	svc.bucketRefreshInterval = time.Millisecond
-	svc.scheduleUnconditionalReconcileInterval = 250 * time.Millisecond
-	svc.schedulePollInterval = 1 * time.Millisecond
-	svc.changefeedInterval = time.Millisecond
-	svc.readinessDelay = time.Millisecond
-	svc.serveHealthz = false
-	svc.emitHeartbeat = false
-	svc.newScheduler = func(_ env.Interface, _ *logrus.Entry, _ metrics.Emitter, _ getCachedScheduleDocFunc, _ getClustersFunc, _ schedulerDBs) (Scheduler, error) {
-		return sched, nil
+		{
+			desc:          "delay fraction at 1.0",
+			delayFraction: 1.0,
+			// The delay fraction at 1.0 should have unconditional reconciles
+			// around 500ms, 750ms, and 1s
+			expectedLowerBound: 3,
+			expectedUpperBound: 5,
+		},
+		{
+			desc:          "delay fraction at 0.5",
+			delayFraction: 0.5,
+			// The delay fraction at 0.5 should have unconditional reconciles
+			// around 375, 625ms, 875ms, and one we won't run at 1125ms
+			expectedLowerBound: 3,
+			expectedUpperBound: 5,
+		},
 	}
-	stop := make(chan struct{})
-	done := make(chan struct{})
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			r := require.New(t)
+			ctx := t.Context()
 
-	go svc.Run(ctx, stop, done)
+			m := testmetrics.NewFakeMetricsEmitter(t)
+			controller := gomock.NewController(t)
+			_env := mock_env.NewMockInterface(controller)
+			_env.EXPECT().Now().AnyTimes().DoAndReturn(time.Now)
 
-	r.EventuallyWithT(func(collect *assert.CollectT) {
-		require.Equal(collect, 1, sched.calls)
-	}, time.Second, time.Millisecond)
+			_, log := testlog.LogForTesting(t)
+			fixtures := testdatabase.NewFixture()
+			schedules, _ := testdatabase.NewFakeMaintenanceSchedules()
+			clusters, _ := testdatabase.NewFakeOpenShiftClusters()
+			subscriptions, _ := testdatabase.NewFakeSubscriptions()
+			poolWorkers, _ := testdatabase.NewFakePoolWorkers(_env.Now, uuid.DefaultGenerator.Generate())
+			dbs := database.NewDBGroup().
+				WithMaintenanceSchedules(schedules).
+				WithSubscriptions(subscriptions).
+				WithOpenShiftClusters(clusters).
+				WithPoolWorkers(poolWorkers)
 
-	// Sleep for a second so that the loop will trigger the unconditional
-	// reevaluate condition
-	time.Sleep(time.Second)
+			fixtures.AddMaintenanceScheduleDocuments(&api.MaintenanceScheduleDocument{
+				ID: "00000000-0000-0000-0000-000000000000",
+				MaintenanceSchedule: api.MaintenanceSchedule{
+					State: api.MaintenanceScheduleStateEnabled,
+				},
+			})
 
-	// The scheduler should be called up to 4 additional times (due to the
-	// unconditional reconcile interval) because nothing has changed. Allow 4-6
-	// total calls to make timer delays in the goroutine or this test less
-	// likely to flake -- as long as it's not hundreds or remains at 1
-	r.GreaterOrEqual(sched.calls, 4)
-	r.LessOrEqual(sched.calls, 6)
+			// Apply the fixture
+			err := fixtures.WithMaintenanceSchedules(schedules).
+				WithOpenShiftClusters(clusters).
+				WithSubscriptions(subscriptions).
+				Create()
+			r.NoError(err)
 
-	close(stop)
+			sched := &fakeScheduler{}
 
-	// Then wait for the worker to stop
-	<-done
-	r.Equal(int32(0), svc.workerCount.Load())
+			svc := NewService(_env, log, dbs, m)
+			svc.workerMaxStartupDelay = 0
+			svc.interval = time.Millisecond
+			svc.bucketRefreshInterval = time.Millisecond
+			svc.scheduleUnconditionalReconcileInterval = 250 * time.Millisecond
+			svc.schedulePollInterval = 1 * time.Millisecond
+			svc.changefeedInterval = time.Millisecond
+			svc.readinessDelay = time.Millisecond
+			svc.serveHealthz = false
+			svc.emitHeartbeat = false
+			// This is called to get the random delay fraction
+			svc.randfloat64 = func() float64 { return tC.delayFraction }
+			svc.newScheduler = func(_ env.Interface, _ *logrus.Entry, _ metrics.Emitter, _ getCachedScheduleDocFunc, _ getClustersFunc, _ schedulerDBs) (Scheduler, error) {
+				return sched, nil
+			}
+			stop := make(chan struct{})
+			done := make(chan struct{})
 
-	m.AssertFloats()
-	m.AssertGauges([]testmetrics.MetricsAssertion[int64]{
-		{
-			MetricName: "changefeed.caches.size",
-			Dimensions: map[string]string{
-				"name": "MaintenanceScheduleDocument",
-			},
-			Value: 1,
-		},
-		// No running workers
-		{
-			MetricName: "mimo.scheduler.workers.active.count",
-			Dimensions: map[string]string{},
-			Value:      0,
-		},
-	}...)
+			go svc.Run(ctx, stop, done)
+
+			r.EventuallyWithT(func(collect *assert.CollectT) {
+				require.Equal(collect, 1, sched.calls)
+			}, time.Second, time.Millisecond)
+
+			// Sleep for a second so that the loop will trigger the unconditional
+			// reevaluate condition
+			time.Sleep(time.Second)
+
+			// The scheduler should be called according to the unconditional
+			// reconcile interval because nothing has changed. Allow a range of
+			// total calls to make timer delays in the goroutine or this test
+			// less likely to flake -- as long as it's not hundreds or remains
+			// at 1
+			r.GreaterOrEqual(sched.calls, tC.expectedLowerBound)
+			r.LessOrEqual(sched.calls, tC.expectedUpperBound)
+
+			close(stop)
+
+			// Then wait for the worker to stop
+			<-done
+			r.Equal(int32(0), svc.workerCount.Load())
+
+			m.AssertFloats()
+			m.AssertGauges([]testmetrics.MetricsAssertion[int64]{
+				{
+					MetricName: "changefeed.caches.size",
+					Dimensions: map[string]string{
+						"name": "MaintenanceScheduleDocument",
+					},
+					Value: 1,
+				},
+				// No running workers
+				{
+					MetricName: "mimo.scheduler.workers.active.count",
+					Dimensions: map[string]string{},
+					Value:      0,
+				},
+			}...)
+		})
+	}
 }
 
 func TestShouldReevaluateUnconditionally(t *testing.T) {
@@ -937,10 +975,26 @@ func TestShouldReevaluateUnconditionally(t *testing.T) {
 		},
 		{
 			desc:          "every 60 mins, it's been 59:59 mins, no delay",
-			now:           time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC),
-			lastRan:       time.Date(2026, 1, 1, 0, 59, 59, 0, time.UTC),
+			now:           time.Date(2026, 1, 1, 0, 59, 59, 0, time.UTC),
+			lastRan:       time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
 			interval:      time.Hour,
 			delayFraction: 0.0,
+			expectedValue: false,
+		},
+		{
+			desc:          "every 60 mins, it's been 90 mins, 50% delay",
+			now:           time.Date(2026, 1, 1, 1, 30, 0, 0, time.UTC),
+			lastRan:       time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+			interval:      time.Hour,
+			delayFraction: 0.5,
+			expectedValue: true,
+		},
+		{
+			desc:          "every 60 mins, it's been 89:59 mins, 50% delay",
+			now:           time.Date(2026, 1, 1, 1, 29, 59, 0, time.UTC),
+			lastRan:       time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+			interval:      time.Hour,
+			delayFraction: 0.5,
 			expectedValue: false,
 		},
 		{

--- a/pkg/mimo/scheduler/service_test.go
+++ b/pkg/mimo/scheduler/service_test.go
@@ -824,7 +824,7 @@ func TestSchedulerServesBucketWhenChanges(t *testing.T) {
 	}...)
 }
 
-func TestSchedulerDoesNotProcessIfNoUpdates(t *testing.T) {
+func TestSchedulerDoesNotProcessConstantlyIfNoUpdates(t *testing.T) {
 	r := require.New(t)
 	ctx := t.Context()
 
@@ -864,6 +864,7 @@ func TestSchedulerDoesNotProcessIfNoUpdates(t *testing.T) {
 	svc := NewService(_env, log, dbs, m)
 	svc.workerMaxStartupDelay = 0
 	svc.interval = time.Millisecond
+	svc.scheduleUnconditionalReconcileInterval = 250 * time.Millisecond
 	svc.schedulePollInterval = 1 * time.Millisecond
 	svc.changefeedInterval = time.Millisecond
 	svc.readinessDelay = time.Millisecond
@@ -881,10 +882,14 @@ func TestSchedulerDoesNotProcessIfNoUpdates(t *testing.T) {
 		require.Equal(collect, 1, sched.calls)
 	}, time.Second, time.Millisecond)
 
+	// Sleep for a second so that the loop will trigger the unconditional
+	// reevaluate condition
 	time.Sleep(time.Second)
 
-	// The scheduler should only be called once because nothing has changed
-	r.Equal(1, sched.calls)
+	// The scheduler should be called up to 4 additional times (due to the
+	// unconditional reconcile interval) because nothing has changed, add one to
+	// make it potentially less flaky -- as long as it's not hundreds
+	r.LessOrEqual(sched.calls, 6)
 
 	close(stop)
 
@@ -908,4 +913,54 @@ func TestSchedulerDoesNotProcessIfNoUpdates(t *testing.T) {
 			Value:      0,
 		},
 	}...)
+}
+
+func TestShouldReevaluateUnconditionally(t *testing.T) {
+	testCases := []struct {
+		desc          string
+		now           time.Time
+		lastRan       time.Time
+		interval      time.Duration
+		delayFraction float64
+		expectedValue bool
+	}{
+		{
+			desc:          "every 60 mins, it's been 60 mins, no delay",
+			now:           time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC),
+			lastRan:       time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+			interval:      time.Hour,
+			delayFraction: 0.0,
+			expectedValue: true,
+		},
+		{
+			desc:          "every 60 mins, it's been 59:59 mins, no delay",
+			now:           time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC),
+			lastRan:       time.Date(2026, 1, 1, 0, 59, 59, 0, time.UTC),
+			interval:      time.Hour,
+			delayFraction: 0.0,
+			expectedValue: false,
+		},
+		{
+			desc:          "every 60 mins, it's been 60 mins, 100% delay",
+			now:           time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC),
+			lastRan:       time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+			interval:      time.Hour,
+			delayFraction: 1.0,
+			expectedValue: false,
+		},
+		{
+			desc:          "every 60 mins, it's been 120 mins, 100% delay",
+			now:           time.Date(2026, 1, 1, 2, 0, 0, 0, time.UTC),
+			lastRan:       time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+			interval:      time.Hour,
+			delayFraction: 1.0,
+			expectedValue: true,
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			got := shouldReevaluateUnconditionally(tC.now, tC.lastRan, tC.interval, tC.delayFraction)
+			require.Equal(t, tC.expectedValue, got)
+		})
+	}
 }

--- a/pkg/mimo/scheduler/service_test.go
+++ b/pkg/mimo/scheduler/service_test.go
@@ -887,8 +887,10 @@ func TestSchedulerDoesNotProcessConstantlyIfNoUpdates(t *testing.T) {
 	time.Sleep(time.Second)
 
 	// The scheduler should be called up to 4 additional times (due to the
-	// unconditional reconcile interval) because nothing has changed, add one to
-	// make it potentially less flaky -- as long as it's not hundreds
+	// unconditional reconcile interval) because nothing has changed. Allow 4-6
+	// total calls to make timer delays in the goroutine or this test less
+	// likely to flake -- as long as it's not hundreds or remains at 1
+	r.GreaterOrEqual(sched.calls, 4)
 	r.LessOrEqual(sched.calls, 6)
 
 	close(stop)

--- a/pkg/mimo/scheduler/service_test.go
+++ b/pkg/mimo/scheduler/service_test.go
@@ -864,6 +864,7 @@ func TestSchedulerDoesNotProcessConstantlyIfNoUpdates(t *testing.T) {
 	svc := NewService(_env, log, dbs, m)
 	svc.workerMaxStartupDelay = 0
 	svc.interval = time.Millisecond
+	svc.bucketRefreshInterval = time.Millisecond
 	svc.scheduleUnconditionalReconcileInterval = 250 * time.Millisecond
 	svc.schedulePollInterval = 1 * time.Millisecond
 	svc.changefeedInterval = time.Millisecond

--- a/pkg/mimo/scheduler/service_test.go
+++ b/pkg/mimo/scheduler/service_test.go
@@ -823,3 +823,89 @@ func TestSchedulerServesBucketWhenChanges(t *testing.T) {
 		},
 	}...)
 }
+
+func TestSchedulerDoesNotProcessIfNoUpdates(t *testing.T) {
+	r := require.New(t)
+	ctx := t.Context()
+
+	m := testmetrics.NewFakeMetricsEmitter(t)
+	controller := gomock.NewController(t)
+	_env := mock_env.NewMockInterface(controller)
+	_env.EXPECT().Now().AnyTimes().DoAndReturn(time.Now)
+
+	_, log := testlog.LogForTesting(t)
+	fixtures := testdatabase.NewFixture()
+	schedules, _ := testdatabase.NewFakeMaintenanceSchedules()
+	clusters, _ := testdatabase.NewFakeOpenShiftClusters()
+	subscriptions, _ := testdatabase.NewFakeSubscriptions()
+	poolWorkers, _ := testdatabase.NewFakePoolWorkers(_env.Now, uuid.DefaultGenerator.Generate())
+	dbs := database.NewDBGroup().
+		WithMaintenanceSchedules(schedules).
+		WithSubscriptions(subscriptions).
+		WithOpenShiftClusters(clusters).
+		WithPoolWorkers(poolWorkers)
+
+	fixtures.AddMaintenanceScheduleDocuments(&api.MaintenanceScheduleDocument{
+		ID: "00000000-0000-0000-0000-000000000000",
+		MaintenanceSchedule: api.MaintenanceSchedule{
+			State: api.MaintenanceScheduleStateEnabled,
+		},
+	})
+
+	// Apply the fixture
+	err := fixtures.WithMaintenanceSchedules(schedules).
+		WithOpenShiftClusters(clusters).
+		WithSubscriptions(subscriptions).
+		Create()
+	r.NoError(err)
+
+	sched := &fakeScheduler{}
+
+	svc := NewService(_env, log, dbs, m)
+	svc.workerMaxStartupDelay = 0
+	svc.interval = time.Millisecond
+	svc.schedulePollInterval = 1 * time.Millisecond
+	svc.changefeedInterval = time.Millisecond
+	svc.readinessDelay = time.Millisecond
+	svc.serveHealthz = false
+	svc.emitHeartbeat = false
+	svc.newScheduler = func(_ env.Interface, _ *logrus.Entry, _ metrics.Emitter, _ getCachedScheduleDocFunc, _ getClustersFunc, _ schedulerDBs) (Scheduler, error) {
+		return sched, nil
+	}
+	stop := make(chan struct{})
+	done := make(chan struct{})
+
+	go svc.Run(ctx, stop, done)
+
+	r.EventuallyWithT(func(collect *assert.CollectT) {
+		require.Equal(collect, 1, sched.calls)
+	}, time.Second, time.Millisecond)
+
+	time.Sleep(time.Second)
+
+	// The scheduler should only be called once because nothing has changed
+	r.Equal(1, sched.calls)
+
+	close(stop)
+
+	// Then wait for the worker to stop
+	<-done
+	r.Equal(int32(0), svc.workerCount.Load())
+
+	m.AssertFloats()
+	m.AssertGauges([]testmetrics.MetricsAssertion[int64]{
+		{
+			MetricName: "changefeed.caches.size",
+			Dimensions: map[string]string{
+				"name": "MaintenanceScheduleDocument",
+			},
+			Value: 1,
+		},
+		// No running workers
+		{
+			MetricName: "mimo.scheduler.workers.active.count",
+			Dimensions: map[string]string{},
+			Value:      0,
+		},
+	}...)
+}


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-28866](https://redhat.atlassian.net/browse/ARO-28866)

### What this PR does / why we need it:

Updates the MIMO Scheduler to run a schedule update unconditionally every hour, otherwise only when the schedules or buckets change. This should keep the 'responsiveness' of manually updating schedules causing changes without hammering CosmosDB too much for it.

### Test plan for issue:

Unit tests

### Is there any documentation that needs to be updated for this PR?

N/A, user-facing behaviour should remain unchanged.

### How do you know this will function as expected in production? 

Tests :)
