### PR TITLE
Fix mismerge in MIMO Actuator tests

### DIFF
--- a/pkg/mimo/actuator/service_test.go
+++ b/pkg/mimo/actuator/service_test.go
@@ -431,9 +431,7 @@ func TestActuatorGoesReadyEvenIfNoWork(t *testing.T) {
 		Create()
 	r.NoError(err)
 
-	wg := &sync.WaitGroup{}
-	wg.Add(1)
-	act := &fakeActuator{waitOnProcess: wg}
+	act := &fakeActuator{}
 	svc := NewService(_env, log, nil, dbs, m)
 	svc.workerMaxStartupDelay = 0
 	svc.taskPollTime = time.Millisecond
@@ -457,9 +455,6 @@ func TestActuatorGoesReadyEvenIfNoWork(t *testing.T) {
 	r.EventuallyWithT(func(collect *assert.CollectT) {
 		require.True(collect, svc.checkReady())
 	}, time.Second, time.Millisecond)
-
-	// Let the Actuator poll process run once
-	act.waitOnProcess.Wait()
 
 	// Once it goes ready, stop the service
 	close(stop)


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes a mismerge between https://github.com/Azure/ARO-RP/pull/4966 and #4998

### What this PR does / why we need it:
Removes a flake fix that is no longer required since there aren't workers to stop since the Actuator now checks if it could do any work before spawning them.

### Test plan for issue:
Test fix

### Is there any documentation that needs to be updated for this PR?

N/A

### How do you know this will function as expected in production? 

N/A
