### PR TITLE
[ARO-28927] Fix etchosts controller logic to cover all MCPs, not requeue on success, etc

### DIFF
--- a/cmd/aro/operator.go
+++ b/cmd/aro/operator.go
@@ -246,12 +246,12 @@ func operator(log *logrus.Entry) error {
 		}
 		if err = (etchosts.NewReconciler(
 			log.WithField("controller", etchosts.ControllerName),
-			client, dh)).SetupWithManager(mgr); err != nil {
+			client, ch)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", etchosts.ControllerName, err)
 		}
 		if err = (etchosts.NewClusterReconciler(
 			log.WithField("controller", etchosts.ClusterControllerName),
-			client, dh)).SetupWithManager(mgr); err != nil {
+			client, ch)).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller %s: %v", etchosts.ClusterControllerName, err)
 		}
 

--- a/pkg/operator/controllers/etchosts/cluster_controller.go
+++ b/pkg/operator/controllers/etchosts/cluster_controller.go
@@ -25,7 +25,7 @@ import (
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/base"
 	"github.com/Azure/ARO-RP/pkg/operator/predicates"
-	"github.com/Azure/ARO-RP/pkg/util/dynamichelper"
+	"github.com/Azure/ARO-RP/pkg/util/clienthelper"
 )
 
 const (
@@ -53,17 +53,17 @@ var (
 
 type EtcHostsClusterReconciler struct {
 	base.AROController
-	dh dynamichelper.Interface
+	ch clienthelper.Interface
 }
 
-func NewClusterReconciler(log *logrus.Entry, client client.Client, dh dynamichelper.Interface) *EtcHostsClusterReconciler {
+func NewClusterReconciler(log *logrus.Entry, client client.Client, ch clienthelper.Interface) *EtcHostsClusterReconciler {
 	return &EtcHostsClusterReconciler{
 		AROController: base.AROController{
 			Log:    log,
 			Client: client,
 			Name:   ClusterControllerName,
 		},
-		dh: dh,
+		ch: ch,
 	}
 }
 
@@ -87,8 +87,22 @@ func (r *EtcHostsClusterReconciler) Reconcile(ctx context.Context, request ctrl.
 		return reconcile.Result{}, err
 	}
 
+	// If we do not allow reconciliation right now, return.
+	//
+	// NOTE: Generally we would want to unconditionally create the
+	// MachineConfigs if they are missing, but since the etchosts functionality
+	// was rolled out when there are a substantial number of clusters, we don't
+	// want the flicking of this switch on older clusters to cause instant
+	// reboots. Hence, wait until we are allowed to reboot (mostly, before
+	// upgrades) if this is changed.
+	if !allowReconcile {
+		r.Log.Debug("reboot-causing reconciliation not allowed right now")
+		r.ClearConditions(ctx)
+		return reconcile.Result{}, nil
+	}
+
 	// EtchostsManaged = false, remove machine configs
-	if !instance.Spec.OperatorFlags.GetSimpleBoolean(operator.EtcHostsManaged) && allowReconcile {
+	if !instance.Spec.OperatorFlags.GetSimpleBoolean(operator.EtcHostsManaged) {
 		r.Log.Debug("etchosts managed is false, removing machine configs")
 		err = r.removeMachineConfig(ctx, etchostsMasterMCMetadata)
 		if kerrors.IsNotFound(err) {
@@ -126,67 +140,59 @@ func (r *EtcHostsClusterReconciler) Reconcile(ctx context.Context, request ctrl.
 	err = r.Client.Get(ctx, types.NamespacedName{Name: "master"}, mcp)
 	if kerrors.IsNotFound(err) {
 		r.Log.Debug(err)
-		r.ClearDegraded(ctx)
-		return reconcile.Result{}, nil
-	}
-	if err != nil {
+	} else if err != nil {
 		r.Log.Error(err)
 		r.SetDegraded(ctx, err)
 		return reconcile.Result{}, err
-	}
-	if mcp.GetDeletionTimestamp() != nil {
-		return reconcile.Result{}, nil
-	}
+	} else {
+		if mcp.GetDeletionTimestamp() != nil {
+			return reconcile.Result{}, nil
+		}
 
-	err = r.Client.Get(ctx, types.NamespacedName{Name: "99-master-aro-etc-hosts-gateway-domains"}, mc)
-	if kerrors.IsNotFound(err) {
-		r.Log.Debug("99-master-aro-etc-hosts-gateway-domains not found, creating it")
-		err = reconcileMachineConfigs(ctx, instance, "master", r.dh, allowReconcile, *mcp)
+		err = r.Client.Get(ctx, types.NamespacedName{Name: "99-master-aro-etc-hosts-gateway-domains"}, mc)
+		if kerrors.IsNotFound(err) {
+			err = reconcileMachineConfigs(ctx, instance, "master", r.ch, allowReconcile, *mcp)
+			if err != nil {
+				r.Log.Error(err)
+				r.SetDegraded(ctx, err)
+				return reconcile.Result{}, err
+			}
+		}
 		if err != nil {
 			r.Log.Error(err)
 			r.SetDegraded(ctx, err)
 			return reconcile.Result{}, err
 		}
-		r.ClearDegraded(ctx)
-		return reconcile.Result{Requeue: true}, nil
-	}
-	if err != nil {
-		r.Log.Error(err)
-		r.SetDegraded(ctx, err)
-		return reconcile.Result{}, err
 	}
 
 	// If 99-worker-aro-etc-hosts-gateway-domains doesn't exist, create it
 	err = r.Client.Get(ctx, types.NamespacedName{Name: "worker"}, mcp)
 	if kerrors.IsNotFound(err) {
-		r.ClearDegraded(ctx)
-		return reconcile.Result{}, nil
-	}
-	if err != nil {
+		r.Log.Debug(err)
+	} else if err != nil {
 		r.Log.Error(err)
 		r.SetDegraded(ctx, err)
 		return reconcile.Result{}, err
-	}
-	if mcp.GetDeletionTimestamp() != nil {
-		return reconcile.Result{}, nil
-	}
+	} else {
+		if mcp.GetDeletionTimestamp() != nil {
+			return reconcile.Result{}, nil
+		}
 
-	err = r.Client.Get(ctx, types.NamespacedName{Name: "99-worker-aro-etc-hosts-gateway-domains"}, mc)
-	if kerrors.IsNotFound(err) {
-		r.Log.Debug("99-worker-aro-etc-hosts-gateway-domains not found, creating it")
-		r.ClearDegraded(ctx)
-		err = reconcileMachineConfigs(ctx, instance, "worker", r.dh, allowReconcile, *mcp)
+		err = r.Client.Get(ctx, types.NamespacedName{Name: "99-worker-aro-etc-hosts-gateway-domains"}, mc)
+		if kerrors.IsNotFound(err) {
+			r.ClearDegraded(ctx)
+			err = reconcileMachineConfigs(ctx, instance, "worker", r.ch, allowReconcile, *mcp)
+			if err != nil {
+				r.Log.Error(err)
+				r.SetDegraded(ctx, err)
+				return reconcile.Result{}, err
+			}
+		}
 		if err != nil {
 			r.Log.Error(err)
 			r.SetDegraded(ctx, err)
 			return reconcile.Result{}, err
 		}
-		return reconcile.Result{Requeue: true}, nil
-	}
-	if err != nil {
-		r.Log.Error(err)
-		r.SetDegraded(ctx, err)
-		return reconcile.Result{}, err
 	}
 
 	r.ClearConditions(ctx)

--- a/pkg/operator/controllers/etchosts/cluster_controller.go
+++ b/pkg/operator/controllers/etchosts/cluster_controller.go
@@ -4,13 +4,14 @@ package etchosts
 // Licensed under the Apache License 2.0.
 
 import (
+	"cmp"
 	"context"
+	"slices"
 
 	"github.com/sirupsen/logrus"
 
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	configv1 "github.com/openshift/api/config/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -69,7 +70,6 @@ func NewClusterReconciler(log *logrus.Entry, client client.Client, ch clienthelp
 
 // Reconcile watches ARO EtcHosts MachineConfig objects, and if any changes, reconciles it
 func (r *EtcHostsClusterReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
-	r.Log.Debugf("reconcile MachineConfig openshift-machine-api/%s", request.Name)
 	instance, err := r.GetCluster(ctx)
 	if err != nil {
 		return reconcile.Result{}, err
@@ -104,26 +104,34 @@ func (r *EtcHostsClusterReconciler) Reconcile(ctx context.Context, request ctrl.
 	// EtchostsManaged = false, remove machine configs
 	if !instance.Spec.OperatorFlags.GetSimpleBoolean(operator.EtcHostsManaged) {
 		r.Log.Debug("etchosts managed is false, removing machine configs")
-		err = r.removeMachineConfig(ctx, etchostsMasterMCMetadata)
-		if kerrors.IsNotFound(err) {
-			r.ClearDegraded(ctx)
-			return reconcile.Result{}, nil
-		}
-		if err != nil {
-			r.Log.Error(err)
-			r.SetDegraded(ctx, err)
-			return reconcile.Result{}, err
-		}
 
-		err = r.removeMachineConfig(ctx, etchostsWorkerMCMetadata)
-		if kerrors.IsNotFound(err) {
-			r.ClearDegraded(ctx)
-			return reconcile.Result{}, nil
-		}
-		if err != nil {
-			r.Log.Error(err)
-			r.SetDegraded(ctx, err)
-			return reconcile.Result{}, err
+		continueToken := ""
+		for {
+			mcs := &mcv1.MachineConfigList{}
+			err := r.ch.List(ctx, mcs, client.Continue(continueToken))
+
+			if err != nil {
+				r.Log.Error(err)
+				r.SetDegraded(ctx, err)
+				return reconcile.Result{}, err
+			}
+
+			for _, mc := range mcs.Items {
+				// Filter down to our named etchosts machineconfigs
+				if etcHostsRegex.FindStringSubmatch(mc.Name) != nil {
+					err = r.ch.Delete(ctx, &mc)
+					if err != nil {
+						r.Log.Error(err)
+						r.SetDegraded(ctx, err)
+						return reconcile.Result{}, err
+					}
+				}
+			}
+
+			continueToken = mcs.Continue
+			if continueToken == "" {
+				break
+			}
 		}
 
 		r.ClearConditions(ctx)
@@ -131,68 +139,26 @@ func (r *EtcHostsClusterReconciler) Reconcile(ctx context.Context, request ctrl.
 		return reconcile.Result{}, nil
 	}
 
-	// EtchostsManaged = true, create machine configs if missing
+	// EtchostsManaged = true, create machine configs for all MCPs if missing
 	r.Log.Debug("running")
-	// If 99-master-aro-etc-hosts-gateway-domains doesn't exist, create it
-	mcp := &mcv1.MachineConfigPool{}
-	mc := &mcv1.MachineConfig{}
 
-	err = r.Client.Get(ctx, types.NamespacedName{Name: "master"}, mcp)
-	if kerrors.IsNotFound(err) {
-		r.Log.Debug(err)
-	} else if err != nil {
+	pools := &mcv1.MachineConfigPoolList{}
+	err = r.ch.List(ctx, pools)
+	if err != nil {
 		r.Log.Error(err)
 		r.SetDegraded(ctx, err)
 		return reconcile.Result{}, err
-	} else {
-		if mcp.GetDeletionTimestamp() != nil {
-			return reconcile.Result{}, nil
-		}
-
-		err = r.Client.Get(ctx, types.NamespacedName{Name: "99-master-aro-etc-hosts-gateway-domains"}, mc)
-		if kerrors.IsNotFound(err) {
-			err = reconcileMachineConfigs(ctx, instance, "master", r.ch, allowReconcile, *mcp)
-			if err != nil {
-				r.Log.Error(err)
-				r.SetDegraded(ctx, err)
-				return reconcile.Result{}, err
-			}
-		}
-		if err != nil {
-			r.Log.Error(err)
-			r.SetDegraded(ctx, err)
-			return reconcile.Result{}, err
-		}
 	}
 
-	// If 99-worker-aro-etc-hosts-gateway-domains doesn't exist, create it
-	err = r.Client.Get(ctx, types.NamespacedName{Name: "worker"}, mcp)
-	if kerrors.IsNotFound(err) {
-		r.Log.Debug(err)
-	} else if err != nil {
+	// Sort for test
+	slices.SortStableFunc(pools.Items, func(a, b mcv1.MachineConfigPool) int {
+		return cmp.Compare(a.Name, b.Name)
+	})
+	err = reconcileMachineConfigs(ctx, instance, r.ch, allowReconcile, pools.Items...)
+	if err != nil {
 		r.Log.Error(err)
 		r.SetDegraded(ctx, err)
 		return reconcile.Result{}, err
-	} else {
-		if mcp.GetDeletionTimestamp() != nil {
-			return reconcile.Result{}, nil
-		}
-
-		err = r.Client.Get(ctx, types.NamespacedName{Name: "99-worker-aro-etc-hosts-gateway-domains"}, mc)
-		if kerrors.IsNotFound(err) {
-			r.ClearDegraded(ctx)
-			err = reconcileMachineConfigs(ctx, instance, "worker", r.ch, allowReconcile, *mcp)
-			if err != nil {
-				r.Log.Error(err)
-				r.SetDegraded(ctx, err)
-				return reconcile.Result{}, err
-			}
-		}
-		if err != nil {
-			r.Log.Error(err)
-			r.SetDegraded(ctx, err)
-			return reconcile.Result{}, err
-		}
 	}
 
 	r.ClearConditions(ctx)
@@ -203,20 +169,17 @@ func (r *EtcHostsClusterReconciler) Reconcile(ctx context.Context, request ctrl.
 func (r *EtcHostsClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.Log.Info("starting etchosts-cluster controller")
 
-	etcHostsBuilder := ctrl.NewControllerManagedBy(mgr).
+	clusterVersionPredicate := predicate.NewPredicateFuncs(func(o client.Object) bool {
+		return o.GetName() == "version"
+	})
+
+	return ctrl.NewControllerManagedBy(mgr).
 		For(&arov1alpha1.Cluster{}, builder.WithPredicates(predicate.And(predicates.AROCluster, predicate.GenerationChangedPredicate{}))).
-		Watches(&mcv1.MachineConfigPool{},
-			&handler.EnqueueRequestForObject{},
-			builder.WithPredicates(predicate.GenerationChangedPredicate{}))
-
-	return etcHostsBuilder.
-		WithEventFilter(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.AnnotationChangedPredicate{}, predicate.LabelChangedPredicate{})).
 		Named(ClusterControllerName).
+		Watches(
+			&configv1.ClusterVersion{},
+			&handler.EnqueueRequestForObject{},
+			builder.WithPredicates(clusterVersionPredicate),
+		).
 		Complete(r)
-}
-
-func (r *EtcHostsClusterReconciler) removeMachineConfig(ctx context.Context, mc *mcv1.MachineConfig) error {
-	r.Log.Debugf("removing machine config %s", mc.Name)
-	err := r.Client.Delete(ctx, mc)
-	return err
 }

--- a/pkg/operator/controllers/etchosts/cluster_controller.go
+++ b/pkg/operator/controllers/etchosts/cluster_controller.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -98,7 +100,7 @@ func (r *EtcHostsClusterReconciler) Reconcile(ctx context.Context, request ctrl.
 				// Filter down to our named etchosts machineconfigs
 				if etcHostsRegex.FindStringSubmatch(mc.Name) != nil {
 					err = r.ch.Delete(ctx, &mc)
-					if err != nil {
+					if err != nil && !kerrors.IsNotFound(err) {
 						r.Log.Error(err)
 						r.SetDegraded(ctx, err)
 						return reconcile.Result{}, err
@@ -128,7 +130,7 @@ func (r *EtcHostsClusterReconciler) Reconcile(ctx context.Context, request ctrl.
 		return reconcile.Result{}, err
 	}
 
-	// Sort for test
+	// Sort so we reconcile in a deterministic order
 	slices.SortStableFunc(pools.Items, func(a, b mcv1.MachineConfigPool) int {
 		return cmp.Compare(a.Name, b.Name)
 	})
@@ -143,7 +145,13 @@ func (r *EtcHostsClusterReconciler) Reconcile(ctx context.Context, request ctrl.
 	return reconcile.Result{}, nil
 }
 
-// SetupWithManager setup our mananger to watch for changes to MCP and ARO Cluster obj
+// SetupWithManager setup our manager to watch for changes to the ARO Cluster
+// (for feature flag updates) and ClusterVersion (to perform changes on upgrade)
+// objects. We don't track MachineConfigPool creations because we cannot easily
+// tell if this is a newly created MCP (which we should make a MC for) or an
+// existing one that simply doesn't have an MC (e.g. we just enabled this
+// controller). Since there are generally only a few MCPs, we simply defer
+// creating these MCs to before an upgrade occurs.
 func (r *EtcHostsClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.Log.Info("starting etchosts-cluster controller")
 

--- a/pkg/operator/controllers/etchosts/cluster_controller.go
+++ b/pkg/operator/controllers/etchosts/cluster_controller.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	configv1 "github.com/openshift/api/config/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -20,6 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	configv1 "github.com/openshift/api/config/v1"
 	mcv1 "github.com/openshift/api/machineconfiguration/v1"
 
 	"github.com/Azure/ARO-RP/pkg/operator"
@@ -109,7 +109,6 @@ func (r *EtcHostsClusterReconciler) Reconcile(ctx context.Context, request ctrl.
 		for {
 			mcs := &mcv1.MachineConfigList{}
 			err := r.ch.List(ctx, mcs, client.Continue(continueToken))
-
 			if err != nil {
 				r.Log.Error(err)
 				r.SetDegraded(ctx, err)

--- a/pkg/operator/controllers/etchosts/cluster_controller.go
+++ b/pkg/operator/controllers/etchosts/cluster_controller.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -31,25 +29,6 @@ import (
 
 const (
 	ClusterControllerName = "EtcHostsCluster"
-)
-
-var (
-	etchostsMasterMCMetadata = &mcv1.MachineConfig{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "99-master-aro-etc-hosts-gateway-domains",
-		},
-		TypeMeta: metav1.TypeMeta{
-			Kind: "MachineConfig",
-		},
-	}
-	etchostsWorkerMCMetadata = &mcv1.MachineConfig{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "99-worker-aro-etc-hosts-gateway-domains",
-		},
-		TypeMeta: metav1.TypeMeta{
-			Kind: "MachineConfig",
-		},
-	}
 )
 
 type EtcHostsClusterReconciler struct {

--- a/pkg/operator/controllers/etchosts/cluster_controller.go
+++ b/pkg/operator/controllers/etchosts/cluster_controller.go
@@ -201,9 +201,6 @@ func (r *EtcHostsClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&arov1alpha1.Cluster{}, builder.WithPredicates(predicate.And(predicates.AROCluster, predicate.GenerationChangedPredicate{}))).
 		Watches(&mcv1.MachineConfigPool{},
 			&handler.EnqueueRequestForObject{},
-			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
-		Watches(&mcv1.MachineConfig{},
-			&handler.EnqueueRequestForObject{},
 			builder.WithPredicates(predicate.GenerationChangedPredicate{}))
 
 	return etcHostsBuilder.

--- a/pkg/operator/controllers/etchosts/cluster_controller_test.go
+++ b/pkg/operator/controllers/etchosts/cluster_controller_test.go
@@ -200,7 +200,7 @@ func TestReconcileEtcHostsCluster(t *testing.T) {
 			expectedLog: []testlog.ExpectedLogEntry{
 				{
 					"level": gomega.Equal(logrus.DebugLevel),
-					"msg":   gomega.Equal("allowing reconciliation of EtcHostsMachineConfig because reconciliation forced"),
+					"msg":   gomega.Equal("allowing reconciliation of EtcHostsCluster because reconciliation forced"),
 				},
 				{
 					"level": gomega.Equal(logrus.DebugLevel),
@@ -224,7 +224,7 @@ func TestReconcileEtcHostsCluster(t *testing.T) {
 			expectedLog: []testlog.ExpectedLogEntry{
 				{
 					"level": gomega.Equal(logrus.DebugLevel),
-					"msg":   gomega.Equal("allowing reconciliation of EtcHostsMachineConfig because reconciliation forced"),
+					"msg":   gomega.Equal("allowing reconciliation of EtcHostsCluster because reconciliation forced"),
 				},
 				{
 					"level": gomega.Equal(logrus.DebugLevel),
@@ -254,7 +254,7 @@ func TestReconcileEtcHostsCluster(t *testing.T) {
 			expectedLog: []testlog.ExpectedLogEntry{
 				{
 					"level": gomega.Equal(logrus.DebugLevel),
-					"msg":   gomega.Equal("allowing reconciliation of EtcHostsMachineConfig because reconciliation forced"),
+					"msg":   gomega.Equal("allowing reconciliation of EtcHostsCluster because reconciliation forced"),
 				},
 				{
 					"level": gomega.Equal(logrus.DebugLevel),
@@ -284,7 +284,7 @@ func TestReconcileEtcHostsCluster(t *testing.T) {
 			expectedLog: []testlog.ExpectedLogEntry{
 				{
 					"level": gomega.Equal(logrus.DebugLevel),
-					"msg":   gomega.Equal("allowing reconciliation of EtcHostsMachineConfig because reconciliation forced"),
+					"msg":   gomega.Equal("allowing reconciliation of EtcHostsCluster because reconciliation forced"),
 				},
 				{
 					"level": gomega.Equal(logrus.DebugLevel),
@@ -312,7 +312,7 @@ func TestReconcileEtcHostsCluster(t *testing.T) {
 			expectedLog: []testlog.ExpectedLogEntry{
 				{
 					"level": gomega.Equal(logrus.DebugLevel),
-					"msg":   gomega.Equal("allowing reconciliation of EtcHostsMachineConfig because reconciliation forced"),
+					"msg":   gomega.Equal("allowing reconciliation of EtcHostsCluster because reconciliation forced"),
 				},
 				{
 					"level": gomega.Equal(logrus.DebugLevel),
@@ -527,7 +527,7 @@ func TestReconcileEtcHostsCluster(t *testing.T) {
 				AROController: base.AROController{
 					Log:    logger,
 					Client: ch,
-					Name:   ControllerName,
+					Name:   ClusterControllerName,
 				},
 				ch: clienthelper.NewWithClient(logger, ch),
 			}

--- a/pkg/operator/controllers/etchosts/cluster_controller_test.go
+++ b/pkg/operator/controllers/etchosts/cluster_controller_test.go
@@ -154,6 +154,7 @@ func TestReconcileEtcHostsCluster(t *testing.T) {
 		name           string
 		objects        []client.Object
 		createdObjects map[string]int
+		updatedObjects map[string]int
 		deletedObjects map[string]int
 		expectedLog    []testlog.ExpectedLogEntry
 	}
@@ -191,14 +192,6 @@ func TestReconcileEtcHostsCluster(t *testing.T) {
 				},
 				{
 					"level": gomega.Equal(logrus.DebugLevel),
-					"msg":   gomega.Equal("removing machine config 99-master-aro-etc-hosts-gateway-domains"),
-				},
-				{
-					"level": gomega.Equal(logrus.DebugLevel),
-					"msg":   gomega.Equal("removing machine config 99-worker-aro-etc-hosts-gateway-domains"),
-				},
-				{
-					"level": gomega.Equal(logrus.DebugLevel),
 					"msg":   gomega.Equal("etchosts managed is false, machine configs removed"),
 				},
 			},
@@ -207,6 +200,10 @@ func TestReconcileEtcHostsCluster(t *testing.T) {
 			name: "etchosts controller enabled, managed true, mc exist",
 			objects: []client.Object{
 				clusterEtcHostsControllerEnabled, machinePoolMaster, machinePoolWorker, etchostsMasterMCMetadata, etchostsWorkerMCMetadata,
+			},
+			updatedObjects: map[string]int{
+				"MachineConfig//99-master-aro-etc-hosts-gateway-domains": 1,
+				"MachineConfig//99-worker-aro-etc-hosts-gateway-domains": 1,
 			},
 			expectedLog: []testlog.ExpectedLogEntry{
 				{
@@ -217,12 +214,23 @@ func TestReconcileEtcHostsCluster(t *testing.T) {
 					"level": gomega.Equal(logrus.DebugLevel),
 					"msg":   gomega.Equal("running"),
 				},
+				{
+					"level": gomega.Equal(logrus.InfoLevel),
+					"msg":   gomega.HavePrefix("Update MachineConfig.machineconfiguration.openshift.io/99-master-aro-etc-hosts-gateway-domains:"),
+				},
+				{
+					"level": gomega.Equal(logrus.InfoLevel),
+					"msg":   gomega.HavePrefix("Update MachineConfig.machineconfiguration.openshift.io/99-worker-aro-etc-hosts-gateway-domains:"),
+				},
 			},
 		},
 		{
 			name: "etchosts controller enabled, managed true, only master mc exist",
 			objects: []client.Object{
 				clusterEtcHostsControllerEnabled, machinePoolMaster, machinePoolWorker, etchostsMasterMCMetadata,
+			},
+			updatedObjects: map[string]int{
+				"MachineConfig//99-master-aro-etc-hosts-gateway-domains": 1,
 			},
 			createdObjects: map[string]int{
 				"MachineConfig//99-worker-aro-etc-hosts-gateway-domains": 1,
@@ -238,6 +246,10 @@ func TestReconcileEtcHostsCluster(t *testing.T) {
 				},
 				{
 					"level": gomega.Equal(logrus.InfoLevel),
+					"msg":   gomega.HavePrefix("Update MachineConfig.machineconfiguration.openshift.io/99-master-aro-etc-hosts-gateway-domains:"),
+				},
+				{
+					"level": gomega.Equal(logrus.InfoLevel),
 					"msg":   gomega.Equal("Create MachineConfig.machineconfiguration.openshift.io/99-worker-aro-etc-hosts-gateway-domains"),
 				},
 			},
@@ -246,6 +258,9 @@ func TestReconcileEtcHostsCluster(t *testing.T) {
 			name: "etchosts controller enabled, managed true, only worker mc exist",
 			objects: []client.Object{
 				clusterEtcHostsControllerEnabled, machinePoolMaster, machinePoolWorker, etchostsWorkerMCMetadata,
+			},
+			updatedObjects: map[string]int{
+				"MachineConfig//99-worker-aro-etc-hosts-gateway-domains": 1,
 			},
 			createdObjects: map[string]int{
 				"MachineConfig//99-master-aro-etc-hosts-gateway-domains": 1,
@@ -262,6 +277,10 @@ func TestReconcileEtcHostsCluster(t *testing.T) {
 				{
 					"level": gomega.Equal(logrus.InfoLevel),
 					"msg":   gomega.Equal("Create MachineConfig.machineconfiguration.openshift.io/99-master-aro-etc-hosts-gateway-domains"),
+				},
+				{
+					"level": gomega.Equal(logrus.InfoLevel),
+					"msg":   gomega.HavePrefix("Update MachineConfig.machineconfiguration.openshift.io/99-worker-aro-etc-hosts-gateway-domains:"),
 				},
 			},
 		},
@@ -321,14 +340,6 @@ func TestReconcileEtcHostsCluster(t *testing.T) {
 				},
 				{
 					"level": gomega.Equal(logrus.DebugLevel),
-					"msg":   gomega.Equal("removing machine config 99-master-aro-etc-hosts-gateway-domains"),
-				},
-				{
-					"level": gomega.Equal(logrus.DebugLevel),
-					"msg":   gomega.Equal("removing machine config 99-worker-aro-etc-hosts-gateway-domains"),
-				},
-				{
-					"level": gomega.Equal(logrus.DebugLevel),
 					"msg":   gomega.Equal("etchosts managed is false, machine configs removed"),
 				},
 			},
@@ -346,14 +357,26 @@ func TestReconcileEtcHostsCluster(t *testing.T) {
 			},
 		},
 		{
-			name: "etchosts controller enabled, managed true, force reconcile false, cluster updating, mc exist, no action",
+			name: "etchosts controller enabled, managed true, force reconcile false, cluster updating, mc exist, MCs updated",
 			objects: []client.Object{
 				clusterEtcHostsControllerEnabledForceReconcileFalse, clusterVersionUpdating, machinePoolMaster, machinePoolWorker, etchostsMasterMCMetadata, etchostsWorkerMCMetadata,
+			},
+			updatedObjects: map[string]int{
+				"MachineConfig//99-master-aro-etc-hosts-gateway-domains": 1,
+				"MachineConfig//99-worker-aro-etc-hosts-gateway-domains": 1,
 			},
 			expectedLog: []testlog.ExpectedLogEntry{
 				{
 					"level": gomega.Equal(logrus.DebugLevel),
 					"msg":   gomega.Equal("running"),
+				},
+				{
+					"level": gomega.Equal(logrus.InfoLevel),
+					"msg":   gomega.HavePrefix("Update MachineConfig.machineconfiguration.openshift.io/99-master-aro-etc-hosts-gateway-domains:"),
+				},
+				{
+					"level": gomega.Equal(logrus.InfoLevel),
+					"msg":   gomega.HavePrefix("Update MachineConfig.machineconfiguration.openshift.io/99-worker-aro-etc-hosts-gateway-domains:"),
 				},
 			},
 		},
@@ -370,9 +393,12 @@ func TestReconcileEtcHostsCluster(t *testing.T) {
 			},
 		},
 		{
-			name: "etchosts controller enabled, managed true, force reconcile false, cluster updating, only master mc exist, ensure worker mc",
+			name: "etchosts controller enabled, managed true, force reconcile false, cluster updating, only master mc exist, worker mc created",
 			objects: []client.Object{
 				clusterEtcHostsControllerEnabledForceReconcileFalse, clusterVersionUpdating, machinePoolMaster, machinePoolWorker, etchostsMasterMCMetadata,
+			},
+			updatedObjects: map[string]int{
+				"MachineConfig//99-master-aro-etc-hosts-gateway-domains": 1,
 			},
 			createdObjects: map[string]int{
 				"MachineConfig//99-worker-aro-etc-hosts-gateway-domains": 1,
@@ -381,6 +407,10 @@ func TestReconcileEtcHostsCluster(t *testing.T) {
 				{
 					"level": gomega.Equal(logrus.DebugLevel),
 					"msg":   gomega.Equal("running"),
+				},
+				{
+					"level": gomega.Equal(logrus.InfoLevel),
+					"msg":   gomega.HavePrefix("Update MachineConfig.machineconfiguration.openshift.io/99-master-aro-etc-hosts-gateway-domains:"),
 				},
 				{
 					"level": gomega.Equal(logrus.InfoLevel),
@@ -401,9 +431,12 @@ func TestReconcileEtcHostsCluster(t *testing.T) {
 			},
 		},
 		{
-			name: "etchosts controller enabled, managed true, force reconcile false, cluster updating, only worker mc exist, ensure master mc",
+			name: "etchosts controller enabled, managed true, force reconcile false, cluster updating, only worker mc exist, master mc created",
 			objects: []client.Object{
 				clusterEtcHostsControllerEnabledForceReconcileFalse, clusterVersionUpdating, machinePoolMaster, machinePoolWorker, etchostsWorkerMCMetadata,
+			},
+			updatedObjects: map[string]int{
+				"MachineConfig//99-worker-aro-etc-hosts-gateway-domains": 1,
 			},
 			createdObjects: map[string]int{
 				"MachineConfig//99-master-aro-etc-hosts-gateway-domains": 1,
@@ -416,6 +449,10 @@ func TestReconcileEtcHostsCluster(t *testing.T) {
 				{
 					"level": gomega.Equal(logrus.InfoLevel),
 					"msg":   gomega.Equal("Create MachineConfig.machineconfiguration.openshift.io/99-master-aro-etc-hosts-gateway-domains"),
+				},
+				{
+					"level": gomega.Equal(logrus.InfoLevel),
+					"msg":   gomega.HavePrefix("Update MachineConfig.machineconfiguration.openshift.io/99-worker-aro-etc-hosts-gateway-domains:"),
 				},
 			},
 		},
@@ -487,15 +524,7 @@ func TestReconcileEtcHostsCluster(t *testing.T) {
 				logger.Log(logrus.ErrorLevel, err)
 			}
 
-			logs := []testlog.ExpectedLogEntry{
-				{
-					"level": gomega.Equal(logrus.DebugLevel),
-					"msg":   gomega.Equal("reconcile MachineConfig openshift-machine-api/cluster"),
-				},
-			}
-			logs = append(logs, tt.expectedLog...)
-
-			err = testlog.AssertLoggingOutput(hook, logs)
+			err = testlog.AssertLoggingOutput(hook, tt.expectedLog)
 			if err != nil {
 				t.Error(err)
 			}
@@ -516,8 +545,12 @@ func TestReconcileEtcHostsCluster(t *testing.T) {
 				}
 			}
 
-			if len(updatedObjects) != 0 {
-				t.Error("no objects should be updated", updatedObjects)
+			errs, err = testclienthelper.CompareTally(tt.updatedObjects, updatedObjects)
+			if err != nil {
+				t.Error(err, "on updated objects")
+				for _, l := range errs {
+					t.Error(l)
+				}
 			}
 		})
 	}

--- a/pkg/operator/controllers/etchosts/cluster_controller_test.go
+++ b/pkg/operator/controllers/etchosts/cluster_controller_test.go
@@ -4,14 +4,10 @@ package etchosts
 // Licensed under the Apache License 2.0.
 
 import (
-	"context"
-	"io"
 	"testing"
 
+	"github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
-	logtest "github.com/sirupsen/logrus/hooks/test"
-	"github.com/stretchr/testify/assert"
-	"go.uber.org/mock/gomock"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -24,9 +20,10 @@ import (
 	"github.com/Azure/ARO-RP/pkg/operator"
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/base"
-	mock_dynamichelper "github.com/Azure/ARO-RP/pkg/util/mocks/dynamichelper"
+	"github.com/Azure/ARO-RP/pkg/util/clienthelper"
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
 	testclienthelper "github.com/Azure/ARO-RP/test/util/clienthelper"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 var (
@@ -77,7 +74,7 @@ var (
 			GatewayPrivateEndpointIP: "20.20.20.20",
 		},
 	}
-	clusterEtcHostsControllerEnabledReconcileFalse = &arov1alpha1.Cluster{
+	clusterEtcHostsControllerEnabledForceReconcileFalse = &arov1alpha1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: arov1alpha1.SingletonClusterName,
 		},
@@ -93,7 +90,7 @@ var (
 			GatewayPrivateEndpointIP: "20.20.20.20",
 		},
 	}
-	clusterEtcHostsControllerEnabledManagedFalseReconcileFalse = &arov1alpha1.Cluster{
+	clusterEtcHostsControllerEnabledManagedFalseForceReconcileFalse = &arov1alpha1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: arov1alpha1.SingletonClusterName,
 		},
@@ -154,11 +151,11 @@ var (
 
 func TestReconcileEtcHostsCluster(t *testing.T) {
 	type test struct {
-		name        string
-		objects     []client.Object
-		mocks       func(mdh *mock_dynamichelper.MockInterface)
-		expectedLog *logrus.Entry
-		wantRequeue bool
+		name           string
+		objects        []client.Object
+		createdObjects map[string]int
+		deletedObjects map[string]int
+		expectedLog    []testlog.ExpectedLogEntry
 	}
 
 	for _, tt := range []*test{
@@ -167,225 +164,361 @@ func TestReconcileEtcHostsCluster(t *testing.T) {
 			objects: []client.Object{
 				clusterEtcHostsControllerDisabled,
 			},
-			mocks: func(mdh *mock_dynamichelper.MockInterface) {
-				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil).Times(0)
+			expectedLog: []testlog.ExpectedLogEntry{
+				{
+					"level": gomega.Equal(logrus.DebugLevel),
+					"msg":   gomega.Equal("controller is disabled"),
+				},
 			},
-			expectedLog: &logrus.Entry{Level: logrus.DebugLevel, Message: "controller is disabled"},
-			wantRequeue: false,
 		},
 		{
 			name: "etchosts controller enabled, managed false",
 			objects: []client.Object{
 				clusterEtcHostsControllerEnabledManagedFalse, etchostsMasterMCMetadata, etchostsWorkerMCMetadata,
 			},
-			mocks: func(mdh *mock_dynamichelper.MockInterface) {
-				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil).Times(0)
+			deletedObjects: map[string]int{
+				"MachineConfig//99-master-aro-etc-hosts-gateway-domains": 1,
+				"MachineConfig//99-worker-aro-etc-hosts-gateway-domains": 1,
 			},
-			expectedLog: &logrus.Entry{Level: logrus.DebugLevel, Message: "etchosts managed is false, machine configs removed"},
-			wantRequeue: false,
+			expectedLog: []testlog.ExpectedLogEntry{
+				{
+					"level": gomega.Equal(logrus.DebugLevel),
+					"msg":   gomega.Equal("allowing reconciliation of EtcHostsMachineConfig because reconciliation forced"),
+				},
+				{
+					"level": gomega.Equal(logrus.DebugLevel),
+					"msg":   gomega.Equal("etchosts managed is false, removing machine configs"),
+				},
+				{
+					"level": gomega.Equal(logrus.DebugLevel),
+					"msg":   gomega.Equal("removing machine config 99-master-aro-etc-hosts-gateway-domains"),
+				},
+				{
+					"level": gomega.Equal(logrus.DebugLevel),
+					"msg":   gomega.Equal("removing machine config 99-worker-aro-etc-hosts-gateway-domains"),
+				},
+				{
+					"level": gomega.Equal(logrus.DebugLevel),
+					"msg":   gomega.Equal("etchosts managed is false, machine configs removed"),
+				},
+			},
 		},
 		{
 			name: "etchosts controller enabled, managed true, mc exist",
 			objects: []client.Object{
 				clusterEtcHostsControllerEnabled, machinePoolMaster, machinePoolWorker, etchostsMasterMCMetadata, etchostsWorkerMCMetadata,
 			},
-			mocks: func(mdh *mock_dynamichelper.MockInterface) {
-				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil).Times(0)
+			expectedLog: []testlog.ExpectedLogEntry{
+				{
+					"level": gomega.Equal(logrus.DebugLevel),
+					"msg":   gomega.Equal("allowing reconciliation of EtcHostsMachineConfig because reconciliation forced"),
+				},
+				{
+					"level": gomega.Equal(logrus.DebugLevel),
+					"msg":   gomega.Equal("running"),
+				},
 			},
-			expectedLog: &logrus.Entry{Level: logrus.DebugLevel, Message: "running"},
-			wantRequeue: false,
 		},
 		{
 			name: "etchosts controller enabled, managed true, only master mc exist",
 			objects: []client.Object{
 				clusterEtcHostsControllerEnabled, machinePoolMaster, machinePoolWorker, etchostsMasterMCMetadata,
 			},
-			mocks: func(mdh *mock_dynamichelper.MockInterface) {
-				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			createdObjects: map[string]int{
+				"MachineConfig//99-worker-aro-etc-hosts-gateway-domains": 1,
 			},
-			expectedLog: &logrus.Entry{Level: logrus.DebugLevel, Message: "99-worker-aro-etc-hosts-gateway-domains not found, creating it"},
-			wantRequeue: true,
+			expectedLog: []testlog.ExpectedLogEntry{
+				{
+					"level": gomega.Equal(logrus.DebugLevel),
+					"msg":   gomega.Equal("allowing reconciliation of EtcHostsMachineConfig because reconciliation forced"),
+				},
+				{
+					"level": gomega.Equal(logrus.DebugLevel),
+					"msg":   gomega.Equal("running"),
+				},
+				{
+					"level": gomega.Equal(logrus.InfoLevel),
+					"msg":   gomega.Equal("Create MachineConfig.machineconfiguration.openshift.io/99-worker-aro-etc-hosts-gateway-domains"),
+				},
+			},
 		},
 		{
 			name: "etchosts controller enabled, managed true, only worker mc exist",
 			objects: []client.Object{
 				clusterEtcHostsControllerEnabled, machinePoolMaster, machinePoolWorker, etchostsWorkerMCMetadata,
 			},
-			mocks: func(mdh *mock_dynamichelper.MockInterface) {
-				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			createdObjects: map[string]int{
+				"MachineConfig//99-master-aro-etc-hosts-gateway-domains": 1,
 			},
-			expectedLog: &logrus.Entry{Level: logrus.DebugLevel, Message: "99-master-aro-etc-hosts-gateway-domains not found, creating it"},
-			wantRequeue: true,
+			expectedLog: []testlog.ExpectedLogEntry{
+				{
+					"level": gomega.Equal(logrus.DebugLevel),
+					"msg":   gomega.Equal("allowing reconciliation of EtcHostsMachineConfig because reconciliation forced"),
+				},
+				{
+					"level": gomega.Equal(logrus.DebugLevel),
+					"msg":   gomega.Equal("running"),
+				},
+				{
+					"level": gomega.Equal(logrus.InfoLevel),
+					"msg":   gomega.Equal("Create MachineConfig.machineconfiguration.openshift.io/99-master-aro-etc-hosts-gateway-domains"),
+				},
+			},
 		},
 		{
 			name: "etchosts controller enabled, managed true, no mc exist",
 			objects: []client.Object{
 				clusterEtcHostsControllerEnabled, machinePoolMaster, machinePoolWorker,
 			},
-			mocks: func(mdh *mock_dynamichelper.MockInterface) {
-				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			createdObjects: map[string]int{
+				"MachineConfig//99-master-aro-etc-hosts-gateway-domains": 1,
+				"MachineConfig//99-worker-aro-etc-hosts-gateway-domains": 1,
 			},
-			expectedLog: &logrus.Entry{Level: logrus.DebugLevel, Message: "99-master-aro-etc-hosts-gateway-domains not found, creating it"},
-			wantRequeue: true,
+			expectedLog: []testlog.ExpectedLogEntry{
+				{
+					"level": gomega.Equal(logrus.DebugLevel),
+					"msg":   gomega.Equal("allowing reconciliation of EtcHostsMachineConfig because reconciliation forced"),
+				},
+				{
+					"level": gomega.Equal(logrus.DebugLevel),
+					"msg":   gomega.Equal("running"),
+				},
+				{
+					"level": gomega.Equal(logrus.InfoLevel),
+					"msg":   gomega.Equal("Create MachineConfig.machineconfiguration.openshift.io/99-master-aro-etc-hosts-gateway-domains"),
+				},
+				{
+					"level": gomega.Equal(logrus.InfoLevel),
+					"msg":   gomega.Equal("Create MachineConfig.machineconfiguration.openshift.io/99-worker-aro-etc-hosts-gateway-domains"),
+				},
+			},
 		},
 		{
-			name: "etchosts controller enabled, managed false, reconcile false, cluster not updating, no action",
+			name: "etchosts controller enabled, managed false, force reconcile false, cluster not updating, no action",
 			objects: []client.Object{
-				clusterEtcHostsControllerEnabledManagedFalseReconcileFalse, clusterVersionNotUpdating, machinePoolMaster, machinePoolWorker, etchostsMasterMCMetadata, etchostsWorkerMCMetadata,
+				clusterEtcHostsControllerEnabledManagedFalseForceReconcileFalse, clusterVersionNotUpdating, machinePoolMaster, machinePoolWorker, etchostsMasterMCMetadata, etchostsWorkerMCMetadata,
 			},
-			mocks: func(mdh *mock_dynamichelper.MockInterface) {
-				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil).Times(0)
+			expectedLog: []testlog.ExpectedLogEntry{
+				{
+					"level": gomega.Equal(logrus.DebugLevel),
+					"msg":   gomega.Equal("reboot-causing reconciliation not allowed right now"),
+				},
 			},
-			expectedLog: &logrus.Entry{Level: logrus.DebugLevel, Message: "running"},
-			wantRequeue: false,
 		},
 		{
-			name: "etchosts controller enabled, managed false, reconcile false, cluster updating, mc removed",
+			name: "etchosts controller enabled, managed false, force reconcile false, cluster updating, mc removed",
 			objects: []client.Object{
-				clusterEtcHostsControllerEnabledManagedFalseReconcileFalse, clusterVersionUpdating, machinePoolMaster, machinePoolWorker, etchostsMasterMCMetadata, etchostsWorkerMCMetadata,
+				clusterEtcHostsControllerEnabledManagedFalseForceReconcileFalse, clusterVersionUpdating, machinePoolMaster, machinePoolWorker, etchostsMasterMCMetadata, etchostsWorkerMCMetadata,
 			},
-			mocks: func(mdh *mock_dynamichelper.MockInterface) {
-				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil).Times(0)
+			deletedObjects: map[string]int{
+				"MachineConfig//99-master-aro-etc-hosts-gateway-domains": 1,
+				"MachineConfig//99-worker-aro-etc-hosts-gateway-domains": 1,
 			},
-			expectedLog: &logrus.Entry{Level: logrus.DebugLevel, Message: "etchosts managed is false, machine configs removed"},
-			wantRequeue: false,
+			expectedLog: []testlog.ExpectedLogEntry{
+				{
+					"level": gomega.Equal(logrus.DebugLevel),
+					"msg":   gomega.Equal("etchosts managed is false, removing machine configs"),
+				},
+				{
+					"level": gomega.Equal(logrus.DebugLevel),
+					"msg":   gomega.Equal("removing machine config 99-master-aro-etc-hosts-gateway-domains"),
+				},
+				{
+					"level": gomega.Equal(logrus.DebugLevel),
+					"msg":   gomega.Equal("removing machine config 99-worker-aro-etc-hosts-gateway-domains"),
+				},
+				{
+					"level": gomega.Equal(logrus.DebugLevel),
+					"msg":   gomega.Equal("etchosts managed is false, machine configs removed"),
+				},
+			},
 		},
 		{
-			name: "etchosts controller enabled, managed true, reconcile false, cluster not updating, mc exist, no action",
+			name: "etchosts controller enabled, managed true, force reconcile false, cluster not updating, mc exist, no action",
 			objects: []client.Object{
-				clusterEtcHostsControllerEnabledReconcileFalse, clusterVersionNotUpdating, machinePoolMaster, machinePoolWorker, etchostsMasterMCMetadata, etchostsWorkerMCMetadata,
+				clusterEtcHostsControllerEnabledForceReconcileFalse, clusterVersionNotUpdating, machinePoolMaster, machinePoolWorker, etchostsMasterMCMetadata, etchostsWorkerMCMetadata,
 			},
-			mocks: func(mdh *mock_dynamichelper.MockInterface) {
-				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil).Times(0)
+			expectedLog: []testlog.ExpectedLogEntry{
+				{
+					"level": gomega.Equal(logrus.DebugLevel),
+					"msg":   gomega.Equal("reboot-causing reconciliation not allowed right now"),
+				},
 			},
-			expectedLog: &logrus.Entry{Level: logrus.DebugLevel, Message: "running"},
-			wantRequeue: false,
 		},
 		{
-			name: "etchosts controller enabled, managed true, reconcile false, cluster updating, mc exist, no action",
+			name: "etchosts controller enabled, managed true, force reconcile false, cluster updating, mc exist, no action",
 			objects: []client.Object{
-				clusterEtcHostsControllerEnabledReconcileFalse, clusterVersionUpdating, machinePoolMaster, machinePoolWorker, etchostsMasterMCMetadata, etchostsWorkerMCMetadata,
+				clusterEtcHostsControllerEnabledForceReconcileFalse, clusterVersionUpdating, machinePoolMaster, machinePoolWorker, etchostsMasterMCMetadata, etchostsWorkerMCMetadata,
 			},
-			mocks: func(mdh *mock_dynamichelper.MockInterface) {
-				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil).Times(0)
+			expectedLog: []testlog.ExpectedLogEntry{
+				{
+					"level": gomega.Equal(logrus.DebugLevel),
+					"msg":   gomega.Equal("running"),
+				},
 			},
-			expectedLog: &logrus.Entry{Level: logrus.DebugLevel, Message: "running"},
-			wantRequeue: false,
 		},
 		{
-			name: "etchosts controller enabled, managed true, reconcile false, cluster not updating, only master mc exist, no action",
+			name: "etchosts controller enabled, managed true, force reconcile false, cluster not updating, only master mc exist, no action",
 			objects: []client.Object{
-				clusterEtcHostsControllerEnabledReconcileFalse, clusterVersionNotUpdating, machinePoolMaster, machinePoolWorker, etchostsMasterMCMetadata,
+				clusterEtcHostsControllerEnabledForceReconcileFalse, clusterVersionNotUpdating, machinePoolMaster, machinePoolWorker, etchostsMasterMCMetadata,
 			},
-			mocks: func(mdh *mock_dynamichelper.MockInterface) {
-				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil).Times(0)
+			expectedLog: []testlog.ExpectedLogEntry{
+				{
+					"level": gomega.Equal(logrus.DebugLevel),
+					"msg":   gomega.Equal("reboot-causing reconciliation not allowed right now"),
+				},
 			},
-			expectedLog: &logrus.Entry{Level: logrus.DebugLevel, Message: "99-worker-aro-etc-hosts-gateway-domains not found, creating it"},
-			wantRequeue: true,
 		},
 		{
-			name: "etchosts controller enabled, managed true, reconcile false, cluster updating, only master mc exist, ensure worker mc",
+			name: "etchosts controller enabled, managed true, force reconcile false, cluster updating, only master mc exist, ensure worker mc",
 			objects: []client.Object{
-				clusterEtcHostsControllerEnabledReconcileFalse, clusterVersionUpdating, machinePoolMaster, machinePoolWorker, etchostsMasterMCMetadata,
+				clusterEtcHostsControllerEnabledForceReconcileFalse, clusterVersionUpdating, machinePoolMaster, machinePoolWorker, etchostsMasterMCMetadata,
 			},
-			mocks: func(mdh *mock_dynamichelper.MockInterface) {
-				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			createdObjects: map[string]int{
+				"MachineConfig//99-worker-aro-etc-hosts-gateway-domains": 1,
 			},
-			expectedLog: &logrus.Entry{Level: logrus.DebugLevel, Message: "99-worker-aro-etc-hosts-gateway-domains not found, creating it"},
-			wantRequeue: true,
+			expectedLog: []testlog.ExpectedLogEntry{
+				{
+					"level": gomega.Equal(logrus.DebugLevel),
+					"msg":   gomega.Equal("running"),
+				},
+				{
+					"level": gomega.Equal(logrus.InfoLevel),
+					"msg":   gomega.Equal("Create MachineConfig.machineconfiguration.openshift.io/99-worker-aro-etc-hosts-gateway-domains"),
+				},
+			},
 		},
 		{
-			name: "etchosts controller enabled, managed true, reconcile false, cluster not updating, only worker mc exist, no action",
+			name: "etchosts controller enabled, managed true, force reconcile false, cluster not updating, only worker mc exist, no action",
 			objects: []client.Object{
-				clusterEtcHostsControllerEnabledReconcileFalse, clusterVersionNotUpdating, machinePoolMaster, machinePoolWorker, etchostsWorkerMCMetadata,
+				clusterEtcHostsControllerEnabledForceReconcileFalse, clusterVersionNotUpdating, machinePoolMaster, machinePoolWorker, etchostsWorkerMCMetadata,
 			},
-			mocks: func(mdh *mock_dynamichelper.MockInterface) {
-				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil).Times(0)
+			expectedLog: []testlog.ExpectedLogEntry{
+				{
+					"level": gomega.Equal(logrus.DebugLevel),
+					"msg":   gomega.Equal("reboot-causing reconciliation not allowed right now"),
+				},
 			},
-			expectedLog: &logrus.Entry{Level: logrus.DebugLevel, Message: "99-master-aro-etc-hosts-gateway-domains not found, creating it"},
-			wantRequeue: true,
 		},
 		{
-			name: "etchosts controller enabled, managed true, reconcile false, cluster updating, only worker mc exist, ensure master mc",
+			name: "etchosts controller enabled, managed true, force reconcile false, cluster updating, only worker mc exist, ensure master mc",
 			objects: []client.Object{
-				clusterEtcHostsControllerEnabledReconcileFalse, clusterVersionUpdating, machinePoolMaster, machinePoolWorker, etchostsWorkerMCMetadata,
+				clusterEtcHostsControllerEnabledForceReconcileFalse, clusterVersionUpdating, machinePoolMaster, machinePoolWorker, etchostsWorkerMCMetadata,
 			},
-			mocks: func(mdh *mock_dynamichelper.MockInterface) {
-				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			createdObjects: map[string]int{
+				"MachineConfig//99-master-aro-etc-hosts-gateway-domains": 1,
 			},
-			expectedLog: &logrus.Entry{Level: logrus.DebugLevel, Message: "99-master-aro-etc-hosts-gateway-domains not found, creating it"},
-			wantRequeue: true,
+			expectedLog: []testlog.ExpectedLogEntry{
+				{
+					"level": gomega.Equal(logrus.DebugLevel),
+					"msg":   gomega.Equal("running"),
+				},
+				{
+					"level": gomega.Equal(logrus.InfoLevel),
+					"msg":   gomega.Equal("Create MachineConfig.machineconfiguration.openshift.io/99-master-aro-etc-hosts-gateway-domains"),
+				},
+			},
 		},
 		{
-			name: "etchosts controller enabled, managed true, reconcile false, cluster not updating, no mc exist, no action",
+			name: "etchosts controller enabled, managed true, force reconcile false, cluster not updating, no mc exist, no action",
 			objects: []client.Object{
-				clusterEtcHostsControllerEnabledReconcileFalse, clusterVersionNotUpdating, machinePoolMaster, machinePoolWorker,
+				clusterEtcHostsControllerEnabledForceReconcileFalse, clusterVersionNotUpdating, machinePoolMaster, machinePoolWorker,
 			},
-			mocks: func(mdh *mock_dynamichelper.MockInterface) {
-				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil).Times(0)
+			expectedLog: []testlog.ExpectedLogEntry{
+				{
+					"level": gomega.Equal(logrus.DebugLevel),
+					"msg":   gomega.Equal("reboot-causing reconciliation not allowed right now"),
+				},
 			},
-			expectedLog: &logrus.Entry{Level: logrus.DebugLevel, Message: "99-master-aro-etc-hosts-gateway-domains not found, creating it"},
-			wantRequeue: true,
 		},
 		{
-			name: "etchosts controller enabled, managed true, reconcile false, cluster updating, no mc exist, ensure master mc",
+			name: "etchosts controller enabled, managed true, force reconcile false, cluster updating, no mc exist, ensure master and worker mc",
 			objects: []client.Object{
-				clusterEtcHostsControllerEnabledReconcileFalse, clusterVersionUpdating, machinePoolMaster, machinePoolWorker,
+				clusterEtcHostsControllerEnabledForceReconcileFalse, clusterVersionUpdating, machinePoolMaster, machinePoolWorker,
 			},
-			mocks: func(mdh *mock_dynamichelper.MockInterface) {
-				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			createdObjects: map[string]int{
+				"MachineConfig//99-master-aro-etc-hosts-gateway-domains": 1,
+				"MachineConfig//99-worker-aro-etc-hosts-gateway-domains": 1,
 			},
-			expectedLog: &logrus.Entry{Level: logrus.DebugLevel, Message: "99-master-aro-etc-hosts-gateway-domains not found, creating it"},
-			wantRequeue: true,
+			expectedLog: []testlog.ExpectedLogEntry{
+				{
+					"level": gomega.Equal(logrus.DebugLevel),
+					"msg":   gomega.Equal("running"),
+				},
+				{
+					"level": gomega.Equal(logrus.InfoLevel),
+					"msg":   gomega.Equal("Create MachineConfig.machineconfiguration.openshift.io/99-master-aro-etc-hosts-gateway-domains"),
+				},
+				{
+					"level": gomega.Equal(logrus.InfoLevel),
+					"msg":   gomega.Equal("Create MachineConfig.machineconfiguration.openshift.io/99-worker-aro-etc-hosts-gateway-domains"),
+				},
+			},
 		},
 	} {
-		controller := gomock.NewController(t)
-		defer controller.Finish()
+		t.Run(tt.name, func(t *testing.T) {
+			hook, logger := testlog.LogForTesting(t)
+			logger.Logger.SetLevel(logrus.TraceLevel)
 
-		mdh := mock_dynamichelper.NewMockInterface(controller)
+			createdObjects := map[string]int{}
+			updatedObjects := map[string]int{}
+			deletedObjects := map[string]int{}
 
-		tt.mocks(mdh)
+			clientBuilder := testclienthelper.NewAROFakeClientBuilder(tt.objects...)
+			ch := testclienthelper.NewHookingClient(clientBuilder.Build())
+			ch.WithPostCreateHook(testclienthelper.TallyCountsAndKey(createdObjects))
+			ch.WithPostDeleteHook(testclienthelper.TallyCountsAndKey(deletedObjects))
+			ch.WithPostUpdateHook(testclienthelper.TallyCountsAndKey(updatedObjects))
 
-		ctx := context.Background()
+			r := &EtcHostsClusterReconciler{
+				AROController: base.AROController{
+					Log:    logger,
+					Client: ch,
+					Name:   ControllerName,
+				},
+				ch: clienthelper.NewWithClient(logger, ch),
+			}
 
-		logger := &logrus.Logger{
-			Out:       io.Discard,
-			Formatter: new(logrus.TextFormatter),
-			Hooks:     make(logrus.LevelHooks),
-			Level:     logrus.TraceLevel,
-		}
-		hook := logtest.NewLocal(logger)
+			request := ctrl.Request{}
+			request.Name = "cluster"
 
-		clientBuilder := testclienthelper.NewAROFakeClientBuilder(tt.objects...)
+			_, err := r.Reconcile(t.Context(), request)
+			if err != nil {
+				logger.Log(logrus.ErrorLevel, err)
+			}
 
-		r := &EtcHostsClusterReconciler{
-			AROController: base.AROController{
-				Log:    logrus.NewEntry(logger),
-				Client: clientBuilder.Build(),
-				Name:   ControllerName,
-			},
-			dh: mdh,
-		}
+			logs := []testlog.ExpectedLogEntry{
+				{
+					"level": gomega.Equal(logrus.DebugLevel),
+					"msg":   gomega.Equal("reconcile MachineConfig openshift-machine-api/cluster"),
+				},
+			}
+			logs = append(logs, tt.expectedLog...)
 
-		request := ctrl.Request{}
-		request.Name = "cluster"
+			err = testlog.AssertLoggingOutput(hook, logs)
+			if err != nil {
+				t.Error(err)
+			}
 
-		result, err := r.Reconcile(ctx, request)
-		if err != nil {
-			logger.Log(logrus.ErrorLevel, err)
-		}
+			errs, err := testclienthelper.CompareTally(tt.createdObjects, createdObjects)
+			if err != nil {
+				t.Error(err, "on created objects")
+				for _, l := range errs {
+					t.Error(l)
+				}
+			}
 
-		if tt.wantRequeue != result.Requeue {
-			t.Errorf("Test %v | wanted to requeue %v but was set to %v", tt.name, tt.wantRequeue, result.Requeue)
-		}
+			errs, err = testclienthelper.CompareTally(tt.deletedObjects, deletedObjects)
+			if err != nil {
+				t.Error(err, "on deleted objects")
+				for _, l := range errs {
+					t.Error(l)
+				}
+			}
 
-		actualLog := hook.LastEntry()
-		logger.Log(logrus.InfoLevel, actualLog)
-		if actualLog == nil {
-			assert.Equal(t, tt.expectedLog, actualLog)
-		} else {
-			assert.Equal(t, tt.expectedLog.Level.String(), actualLog.Level.String())
-			assert.Equal(t, tt.expectedLog.Message, actualLog.Message)
-		}
+			if len(updatedObjects) != 0 {
+				t.Error("no objects should be updated", updatedObjects)
+			}
+		})
 	}
 }

--- a/pkg/operator/controllers/etchosts/cluster_controller_test.go
+++ b/pkg/operator/controllers/etchosts/cluster_controller_test.go
@@ -27,6 +27,22 @@ import (
 )
 
 var (
+	etchostsMasterMCMetadata = &mcv1.MachineConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "99-master-aro-etc-hosts-gateway-domains",
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind: "MachineConfig",
+		},
+	}
+	etchostsWorkerMCMetadata = &mcv1.MachineConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "99-worker-aro-etc-hosts-gateway-domains",
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind: "MachineConfig",
+		},
+	}
 	clusterEtcHostsControllerDisabled = &arov1alpha1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: arov1alpha1.SingletonClusterName,

--- a/pkg/operator/controllers/etchosts/machineconfig_controller.go
+++ b/pkg/operator/controllers/etchosts/machineconfig_controller.go
@@ -14,10 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	mcv1 "github.com/openshift/api/machineconfiguration/v1"
@@ -25,7 +22,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/operator"
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/base"
-	"github.com/Azure/ARO-RP/pkg/operator/predicates"
+	"github.com/Azure/ARO-RP/pkg/util/clienthelper"
 	"github.com/Azure/ARO-RP/pkg/util/dynamichelper"
 )
 
@@ -36,19 +33,19 @@ const (
 type EtcHostsMachineConfigReconciler struct {
 	base.AROController
 
-	dh dynamichelper.Interface
+	ch clienthelper.Interface
 }
 
 var etcHostsRegex = regexp.MustCompile("^99-(.*)-aro-etc-hosts-gateway-domains$")
 
-func NewReconciler(log *logrus.Entry, client client.Client, dh dynamichelper.Interface) *EtcHostsMachineConfigReconciler {
+func NewReconciler(log *logrus.Entry, client client.Client, ch clienthelper.Interface) *EtcHostsMachineConfigReconciler {
 	return &EtcHostsMachineConfigReconciler{
 		AROController: base.AROController{
 			Log:    log,
 			Client: client,
 			Name:   ControllerName,
 		},
-		dh: dh,
+		ch: ch,
 	}
 }
 
@@ -63,6 +60,11 @@ func (r *EtcHostsMachineConfigReconciler) Reconcile(ctx context.Context, request
 
 	if !instance.Spec.OperatorFlags.GetSimpleBoolean(operator.EtcHostsEnabled) {
 		r.Log.Debug("controller is disabled")
+		return reconcile.Result{}, nil
+	}
+
+	if !instance.Spec.OperatorFlags.GetSimpleBoolean(operator.EtcHostsManaged) {
+		r.Log.Debug("etchosts are not managed by this controller")
 		return reconcile.Result{}, nil
 	}
 
@@ -103,7 +105,7 @@ func (r *EtcHostsMachineConfigReconciler) Reconcile(ctx context.Context, request
 		return reconcile.Result{}, nil
 	}
 
-	err = reconcileMachineConfigs(ctx, instance, role, r.dh, allowReconcile, *mcp)
+	err = reconcileMachineConfigs(ctx, instance, role, r.ch, allowReconcile, *mcp)
 	if err != nil {
 		r.Log.Error(err)
 		r.SetDegraded(ctx, err)
@@ -124,7 +126,7 @@ func (r *EtcHostsMachineConfigReconciler) SetupWithManager(mgr ctrl.Manager) err
 		Complete(r)
 }
 
-func reconcileMachineConfigs(ctx context.Context, instance *arov1alpha1.Cluster, role string, dh dynamichelper.Interface, allowReconcile bool, mcps ...mcv1.MachineConfigPool) error {
+func reconcileMachineConfigs(ctx context.Context, instance *arov1alpha1.Cluster, role string, ch clienthelper.Interface, allowReconcile bool, mcps ...mcv1.MachineConfigPool) error {
 	var resources []kruntime.Object
 	for _, mcp := range mcps {
 		resource, err := EtcHostsMachineConfig(instance.Spec.Domain, instance.Spec.APIIntIP, instance.Spec.GatewayDomains, instance.Spec.GatewayPrivateEndpointIP, role)
@@ -149,14 +151,8 @@ func reconcileMachineConfigs(ctx context.Context, instance *arov1alpha1.Cluster,
 	// create or update. If we are not allowed to reconcile, we do not want to
 	// perform any updates.
 	if allowReconcile {
-		return dh.Ensure(ctx, resources...)
+		return ch.Ensure(ctx, resources...)
 	}
 
 	return nil
-}
-
-func (r *EtcHostsMachineConfigReconciler) removeMachineConfig(ctx context.Context, mc *mcv1.MachineConfig) error {
-	r.Log.Debugf("removing machine config %s", mc.Name)
-	err := r.Client.Delete(ctx, mc)
-	return err
 }

--- a/pkg/operator/controllers/etchosts/machineconfig_controller.go
+++ b/pkg/operator/controllers/etchosts/machineconfig_controller.go
@@ -116,7 +116,7 @@ func (r *EtcHostsMachineConfigReconciler) Reconcile(ctx context.Context, request
 	return reconcile.Result{}, nil
 }
 
-// SetupWithManager setup our mananger to watch for changes to MCP and ARO Cluster obj
+// SetupWithManager setup our manager to watch for changes to MachineConfig objects
 func (r *EtcHostsMachineConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.Log.Info("starting etchosts-machine-config controller")
 

--- a/pkg/operator/controllers/etchosts/machineconfig_controller.go
+++ b/pkg/operator/controllers/etchosts/machineconfig_controller.go
@@ -105,7 +105,7 @@ func (r *EtcHostsMachineConfigReconciler) Reconcile(ctx context.Context, request
 		return reconcile.Result{}, nil
 	}
 
-	err = reconcileMachineConfigs(ctx, instance, role, r.ch, allowReconcile, *mcp)
+	err = reconcileMachineConfigs(ctx, instance, r.ch, allowReconcile, *mcp)
 	if err != nil {
 		r.Log.Error(err)
 		r.SetDegraded(ctx, err)
@@ -126,10 +126,10 @@ func (r *EtcHostsMachineConfigReconciler) SetupWithManager(mgr ctrl.Manager) err
 		Complete(r)
 }
 
-func reconcileMachineConfigs(ctx context.Context, instance *arov1alpha1.Cluster, role string, ch clienthelper.Interface, allowReconcile bool, mcps ...mcv1.MachineConfigPool) error {
+func reconcileMachineConfigs(ctx context.Context, instance *arov1alpha1.Cluster, ch clienthelper.Interface, allowReconcile bool, mcps ...mcv1.MachineConfigPool) error {
 	var resources []kruntime.Object
 	for _, mcp := range mcps {
-		resource, err := EtcHostsMachineConfig(instance.Spec.Domain, instance.Spec.APIIntIP, instance.Spec.GatewayDomains, instance.Spec.GatewayPrivateEndpointIP, role)
+		resource, err := EtcHostsMachineConfig(instance.Spec.Domain, instance.Spec.APIIntIP, instance.Spec.GatewayDomains, instance.Spec.GatewayPrivateEndpointIP, mcp.Name)
 		if err != nil {
 			return err
 		}

--- a/pkg/operator/controllers/etchosts/machineconfig_controller.go
+++ b/pkg/operator/controllers/etchosts/machineconfig_controller.go
@@ -73,33 +73,8 @@ func (r *EtcHostsMachineConfigReconciler) Reconcile(ctx context.Context, request
 		return reconcile.Result{}, err
 	}
 
-	// EtchostsManaged = false, remove machine configs
-	if !instance.Spec.OperatorFlags.GetSimpleBoolean(operator.EtcHostsManaged) && allowReconcile {
-		r.Log.Debug("etchosts managed is false, removing machine configs")
-		err = r.removeMachineConfig(ctx, etchostsMasterMCMetadata)
-		if kerrors.IsNotFound(err) {
-			r.ClearDegraded(ctx)
-			return reconcile.Result{}, nil
-		}
-		if err != nil {
-			r.Log.Error(err)
-			r.SetDegraded(ctx, err)
-			return reconcile.Result{}, err
-		}
-
-		err = r.removeMachineConfig(ctx, etchostsWorkerMCMetadata)
-		if kerrors.IsNotFound(err) {
-			r.ClearDegraded(ctx)
-			return reconcile.Result{}, nil
-		}
-		if err != nil {
-			r.Log.Error(err)
-			r.SetDegraded(ctx, err)
-			return reconcile.Result{}, err
-		}
-
+	if !allowReconcile {
 		r.ClearConditions(ctx)
-		r.Log.Debug("etchosts managed is false, machine configs removed")
 		return reconcile.Result{}, nil
 	}
 
@@ -143,17 +118,8 @@ func (r *EtcHostsMachineConfigReconciler) Reconcile(ctx context.Context, request
 func (r *EtcHostsMachineConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.Log.Info("starting etchosts-machine-config controller")
 
-	etcHostsBuilder := ctrl.NewControllerManagedBy(mgr).
+	return ctrl.NewControllerManagedBy(mgr).
 		For(&mcv1.MachineConfig{}).
-		Watches(&mcv1.MachineConfigPool{},
-			&handler.EnqueueRequestForObject{},
-			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
-		Watches(&arov1alpha1.Cluster{},
-			&handler.EnqueueRequestForObject{},
-			builder.WithPredicates(predicate.And(predicates.AROCluster, predicate.GenerationChangedPredicate{})))
-
-	return etcHostsBuilder.
-		WithEventFilter(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.AnnotationChangedPredicate{}, predicate.LabelChangedPredicate{})).
 		Named(ControllerName).
 		Complete(r)
 }

--- a/pkg/operator/controllers/etchosts/machineconfig_controller_test.go
+++ b/pkg/operator/controllers/etchosts/machineconfig_controller_test.go
@@ -48,7 +48,7 @@ func TestReconcileEtcHostsMachineConfig(t *testing.T) {
 			requestName: "cluster",
 		},
 		{
-			name: "etchosts controller disabled",
+			name: "etchosts controller enabled, managed=false, deletions not handled in this controller",
 			objects: []client.Object{
 				clusterEtcHostsControllerEnabledManagedFalse,
 			},

--- a/pkg/operator/controllers/etchosts/machineconfig_controller_test.go
+++ b/pkg/operator/controllers/etchosts/machineconfig_controller_test.go
@@ -4,32 +4,29 @@ package etchosts
 // Licensed under the Apache License 2.0.
 
 import (
-	"context"
-	"io"
 	"testing"
 
+	"github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
-	logtest "github.com/sirupsen/logrus/hooks/test"
-	"github.com/stretchr/testify/assert"
-	"go.uber.org/mock/gomock"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/Azure/ARO-RP/pkg/operator/controllers/base"
-	mock_dynamichelper "github.com/Azure/ARO-RP/pkg/util/mocks/dynamichelper"
+	"github.com/Azure/ARO-RP/pkg/util/clienthelper"
 	_ "github.com/Azure/ARO-RP/pkg/util/scheme"
 	testclienthelper "github.com/Azure/ARO-RP/test/util/clienthelper"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func TestReconcileEtcHostsMachineConfig(t *testing.T) {
 	type test struct {
-		name        string
-		objects     []client.Object
-		mocks       func(mdh *mock_dynamichelper.MockInterface)
-		expectedLog *logrus.Entry
-		wantRequeue bool
-		requestName string
+		name           string
+		objects        []client.Object
+		createdObjects map[string]int
+		updatedObjects map[string]int
+		expectedLog    []testlog.ExpectedLogEntry
+		requestName    string
 	}
 
 	for _, tt := range []*test{
@@ -38,23 +35,33 @@ func TestReconcileEtcHostsMachineConfig(t *testing.T) {
 			objects: []client.Object{
 				clusterEtcHostsControllerDisabled,
 			},
-			mocks: func(mdh *mock_dynamichelper.MockInterface) {
-				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil).Times(0)
+			expectedLog: []testlog.ExpectedLogEntry{
+				{
+					"level": gomega.Equal(logrus.DebugLevel),
+					"msg":   gomega.Equal("reconcile MachineConfig openshift-machine-api/cluster"),
+				},
+				{
+					"level": gomega.Equal(logrus.DebugLevel),
+					"msg":   gomega.Equal("controller is disabled"),
+				},
 			},
-			expectedLog: &logrus.Entry{Level: logrus.DebugLevel, Message: "controller is disabled"},
-			wantRequeue: false,
 			requestName: "cluster",
 		},
 		{
-			name: "etchosts controller enabled, managed false",
+			name: "etchosts controller disabled",
 			objects: []client.Object{
-				clusterEtcHostsControllerEnabledManagedFalse, etchostsMasterMCMetadata, etchostsWorkerMCMetadata,
+				clusterEtcHostsControllerEnabledManagedFalse,
 			},
-			mocks: func(mdh *mock_dynamichelper.MockInterface) {
-				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil).Times(0)
+			expectedLog: []testlog.ExpectedLogEntry{
+				{
+					"level": gomega.Equal(logrus.DebugLevel),
+					"msg":   gomega.Equal("reconcile MachineConfig openshift-machine-api/cluster"),
+				},
+				{
+					"level": gomega.Equal(logrus.DebugLevel),
+					"msg":   gomega.Equal("etchosts are not managed by this controller"),
+				},
 			},
-			expectedLog: &logrus.Entry{Level: logrus.DebugLevel, Message: "etchosts managed is false, machine configs removed"},
-			wantRequeue: false,
 			requestName: "cluster",
 		},
 		{
@@ -62,11 +69,20 @@ func TestReconcileEtcHostsMachineConfig(t *testing.T) {
 			objects: []client.Object{
 				clusterEtcHostsControllerEnabled, machinePoolMaster, machinePoolWorker, etchostsMasterMCMetadata, etchostsWorkerMCMetadata,
 			},
-			mocks: func(mdh *mock_dynamichelper.MockInterface) {
-				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil).Times(0)
+			expectedLog: []testlog.ExpectedLogEntry{
+				{
+					"level": gomega.Equal(logrus.DebugLevel),
+					"msg":   gomega.Equal("reconcile MachineConfig openshift-machine-api/cluster"),
+				},
+				{
+					"level": gomega.Equal(logrus.DebugLevel),
+					"msg":   gomega.Equal("allowing reconciliation of EtcHostsMachineConfig because reconciliation forced"),
+				},
+				{
+					"level": gomega.Equal(logrus.DebugLevel),
+					"msg":   gomega.Equal("running"),
+				},
 			},
-			expectedLog: &logrus.Entry{Level: logrus.DebugLevel, Message: "running"},
-			wantRequeue: false,
 			requestName: "cluster",
 		},
 		{
@@ -74,133 +90,177 @@ func TestReconcileEtcHostsMachineConfig(t *testing.T) {
 			objects: []client.Object{
 				clusterEtcHostsControllerEnabled, machinePoolMaster, machinePoolWorker, etchostsMasterMCMetadata, etchostsWorkerMCMetadata,
 			},
-			mocks: func(mdh *mock_dynamichelper.MockInterface) {
-				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			updatedObjects: map[string]int{
+				"MachineConfig//99-master-aro-etc-hosts-gateway-domains": 1,
 			},
-			expectedLog: &logrus.Entry{Level: logrus.DebugLevel, Message: "reconcile object openshift-machine-api/99-master-aro-etc-hosts-gateway-domains"},
-			wantRequeue: false,
+			expectedLog: []testlog.ExpectedLogEntry{
+				{
+					"level": gomega.Equal(logrus.DebugLevel),
+					"msg":   gomega.Equal("reconcile MachineConfig openshift-machine-api/99-master-aro-etc-hosts-gateway-domains"),
+				},
+				{
+					"level": gomega.Equal(logrus.DebugLevel),
+					"msg":   gomega.Equal("allowing reconciliation of EtcHostsMachineConfig because reconciliation forced"),
+				},
+				{
+					"level": gomega.Equal(logrus.DebugLevel),
+					"msg":   gomega.Equal("running"),
+				},
+				{
+					"level": gomega.Equal(logrus.DebugLevel),
+					"msg":   gomega.Equal("reconcile object openshift-machine-api/99-master-aro-etc-hosts-gateway-domains"),
+				},
+				{
+					"level": gomega.Equal(logrus.InfoLevel),
+					"msg":   gomega.HavePrefix("Update MachineConfig.machineconfiguration.openshift.io/99-master-aro-etc-hosts-gateway-domains: "),
+				},
+			},
 			requestName: "99-master-aro-etc-hosts-gateway-domains",
 		},
 		{
 			name: "etchosts controller enabled, managed false, cluster not updating, no action",
 			objects: []client.Object{
-				clusterEtcHostsControllerEnabledManagedFalseReconcileFalse, clusterVersionNotUpdating, etchostsMasterMCMetadata, etchostsWorkerMCMetadata,
+				clusterEtcHostsControllerEnabledManagedFalseForceReconcileFalse, clusterVersionNotUpdating, etchostsMasterMCMetadata, etchostsWorkerMCMetadata,
 			},
-			mocks: func(mdh *mock_dynamichelper.MockInterface) {
-				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil).Times(0)
+			expectedLog: []testlog.ExpectedLogEntry{
+				{
+					"level": gomega.Equal(logrus.DebugLevel),
+					"msg":   gomega.Equal("reconcile MachineConfig openshift-machine-api/cluster"),
+				},
+				{
+					"level": gomega.Equal(logrus.DebugLevel),
+					"msg":   gomega.Equal("etchosts are not managed by this controller"),
+				},
 			},
-			expectedLog: &logrus.Entry{Level: logrus.DebugLevel, Message: "running"},
-			wantRequeue: false,
-			requestName: "cluster",
-		},
-		{
-			name: "etchosts controller enabled, managed false, cluster updating, no action",
-			objects: []client.Object{
-				clusterEtcHostsControllerEnabledManagedFalseReconcileFalse, clusterVersionUpdating, etchostsMasterMCMetadata, etchostsWorkerMCMetadata,
-			},
-			mocks: func(mdh *mock_dynamichelper.MockInterface) {
-				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil).Times(0)
-			},
-			expectedLog: &logrus.Entry{Level: logrus.DebugLevel, Message: "etchosts managed is false, machine configs removed"},
-			wantRequeue: false,
 			requestName: "cluster",
 		},
 		{
 			name: "etchosts controller enabled, managed true, cluster not updating, regex not match, no action",
 			objects: []client.Object{
-				clusterEtcHostsControllerEnabledReconcileFalse, clusterVersionNotUpdating, machinePoolMaster, machinePoolWorker, etchostsMasterMCMetadata, etchostsWorkerMCMetadata,
+				clusterEtcHostsControllerEnabledForceReconcileFalse, clusterVersionNotUpdating, machinePoolMaster, machinePoolWorker, etchostsMasterMCMetadata, etchostsWorkerMCMetadata,
 			},
-			mocks: func(mdh *mock_dynamichelper.MockInterface) {
-				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil).Times(0)
+			expectedLog: []testlog.ExpectedLogEntry{
+				{
+					"level": gomega.Equal(logrus.DebugLevel),
+					"msg":   gomega.Equal("reconcile MachineConfig openshift-machine-api/cluster"),
+				},
 			},
-			expectedLog: &logrus.Entry{Level: logrus.DebugLevel, Message: "running"},
-			wantRequeue: false,
 			requestName: "cluster",
 		},
 		{
 			name: "etchosts controller enabled, managed true, cluster updating, regex not match, no action",
 			objects: []client.Object{
-				clusterEtcHostsControllerEnabledReconcileFalse, clusterVersionUpdating, machinePoolMaster, machinePoolWorker, etchostsMasterMCMetadata, etchostsWorkerMCMetadata,
+				clusterEtcHostsControllerEnabledForceReconcileFalse, clusterVersionUpdating, machinePoolMaster, machinePoolWorker, etchostsMasterMCMetadata, etchostsWorkerMCMetadata,
 			},
-			mocks: func(mdh *mock_dynamichelper.MockInterface) {
-				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil).Times(0)
+			expectedLog: []testlog.ExpectedLogEntry{
+				{
+					"level": gomega.Equal(logrus.DebugLevel),
+					"msg":   gomega.Equal("reconcile MachineConfig openshift-machine-api/cluster"),
+				},
+				{
+					"level": gomega.Equal(logrus.DebugLevel),
+					"msg":   gomega.Equal("running"),
+				},
 			},
-			expectedLog: &logrus.Entry{Level: logrus.DebugLevel, Message: "running"},
-			wantRequeue: false,
 			requestName: "cluster",
 		},
 		{
-			name: "etchosts controller enabled, managed true, cluster not updating, regex match, reconcile - no action",
+			name: "etchosts controller enabled, managed true, cluster not updating, regex match, reconcile not forced - no action",
 			objects: []client.Object{
-				clusterEtcHostsControllerEnabledReconcileFalse, clusterVersionNotUpdating, machinePoolMaster, machinePoolWorker, etchostsMasterMCMetadata, etchostsWorkerMCMetadata,
+				clusterEtcHostsControllerEnabledForceReconcileFalse, clusterVersionNotUpdating, machinePoolMaster, machinePoolWorker, etchostsMasterMCMetadata, etchostsWorkerMCMetadata,
 			},
-			mocks: func(mdh *mock_dynamichelper.MockInterface) {
-				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil).Times(0)
+			expectedLog: []testlog.ExpectedLogEntry{
+				{
+					"level": gomega.Equal(logrus.DebugLevel),
+					"msg":   gomega.Equal("reconcile MachineConfig openshift-machine-api/99-master-aro-etc-hosts-gateway-domains"),
+				},
 			},
-			expectedLog: &logrus.Entry{Level: logrus.DebugLevel, Message: "reconcile object openshift-machine-api/99-master-aro-etc-hosts-gateway-domains"},
-			wantRequeue: false,
 			requestName: "99-master-aro-etc-hosts-gateway-domains",
 		},
 		{
-			name: "etchosts controller enabled, managed true, cluster updating, regex match, reconcile - ensure machine config",
+			name: "etchosts controller enabled, managed true, cluster updating, regex match, reconcile not forced - ensure machine config",
 			objects: []client.Object{
-				clusterEtcHostsControllerEnabledReconcileFalse, clusterVersionUpdating, machinePoolMaster, machinePoolWorker, etchostsMasterMCMetadata, etchostsWorkerMCMetadata,
+				clusterEtcHostsControllerEnabledForceReconcileFalse, clusterVersionUpdating, machinePoolMaster, machinePoolWorker, etchostsMasterMCMetadata, etchostsWorkerMCMetadata,
 			},
-			mocks: func(mdh *mock_dynamichelper.MockInterface) {
-				mdh.EXPECT().Ensure(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			updatedObjects: map[string]int{
+				"MachineConfig//99-master-aro-etc-hosts-gateway-domains": 1,
 			},
-			expectedLog: &logrus.Entry{Level: logrus.DebugLevel, Message: "reconcile object openshift-machine-api/99-master-aro-etc-hosts-gateway-domains"},
-			wantRequeue: false,
+			expectedLog: []testlog.ExpectedLogEntry{
+				{
+					"level": gomega.Equal(logrus.DebugLevel),
+					"msg":   gomega.Equal("reconcile MachineConfig openshift-machine-api/99-master-aro-etc-hosts-gateway-domains"),
+				},
+				{
+					"level": gomega.Equal(logrus.DebugLevel),
+					"msg":   gomega.Equal("running"),
+				},
+				{
+					"level": gomega.Equal(logrus.DebugLevel),
+					"msg":   gomega.Equal("reconcile object openshift-machine-api/99-master-aro-etc-hosts-gateway-domains"),
+				},
+				{
+					"level": gomega.Equal(logrus.InfoLevel),
+					"msg":   gomega.HavePrefix("Update MachineConfig.machineconfiguration.openshift.io/99-master-aro-etc-hosts-gateway-domains: "),
+				},
+			},
 			requestName: "99-master-aro-etc-hosts-gateway-domains",
 		},
 	} {
-		controller := gomock.NewController(t)
-		defer controller.Finish()
+		t.Run(tt.name, func(t *testing.T) {
+			hook, logger := testlog.LogForTesting(t)
+			logger.Logger.SetLevel(logrus.TraceLevel)
 
-		mdh := mock_dynamichelper.NewMockInterface(controller)
+			createdObjects := map[string]int{}
+			updatedObjects := map[string]int{}
+			deletedObjects := map[string]int{}
 
-		tt.mocks(mdh)
+			clientBuilder := testclienthelper.NewAROFakeClientBuilder(tt.objects...)
+			ch := testclienthelper.NewHookingClient(clientBuilder.Build())
+			ch.WithPostCreateHook(testclienthelper.TallyCountsAndKey(createdObjects))
+			ch.WithPostDeleteHook(testclienthelper.TallyCountsAndKey(deletedObjects))
+			ch.WithPostUpdateHook(testclienthelper.TallyCountsAndKey(updatedObjects))
 
-		ctx := context.Background()
+			r := &EtcHostsMachineConfigReconciler{
+				AROController: base.AROController{
+					Log:    logger,
+					Client: ch,
+					Name:   ControllerName,
+				},
+				ch: clienthelper.NewWithClient(logger, ch),
+			}
 
-		logger := &logrus.Logger{
-			Out:       io.Discard,
-			Formatter: new(logrus.TextFormatter),
-			Hooks:     make(logrus.LevelHooks),
-			Level:     logrus.TraceLevel,
-		}
-		hook := logtest.NewLocal(logger)
+			request := ctrl.Request{}
+			request.Name = tt.requestName
 
-		clientBuilder := testclienthelper.NewAROFakeClientBuilder(tt.objects...)
+			_, err := r.Reconcile(t.Context(), request)
+			if err != nil {
+				logger.Log(logrus.ErrorLevel, err)
+			}
 
-		r := &EtcHostsMachineConfigReconciler{
-			AROController: base.AROController{
-				Log:    logrus.NewEntry(logger),
-				Client: clientBuilder.Build(),
-				Name:   ControllerName,
-			},
-			dh: mdh,
-		}
+			err = testlog.AssertLoggingOutput(hook, tt.expectedLog)
+			if err != nil {
+				t.Error(err)
+			}
 
-		request := ctrl.Request{}
-		request.Name = tt.requestName
+			errs, err := testclienthelper.CompareTally(tt.createdObjects, createdObjects)
+			if err != nil {
+				t.Error(err, "on created objects")
+				for _, l := range errs {
+					t.Error(l)
+				}
+			}
 
-		result, err := r.Reconcile(ctx, request)
-		if err != nil {
-			logger.Log(logrus.ErrorLevel, err)
-		}
+			errs, err = testclienthelper.CompareTally(tt.updatedObjects, updatedObjects)
+			if err != nil {
+				t.Error(err, "on updated objects")
+				for _, l := range errs {
+					t.Error(l)
+				}
+			}
 
-		if tt.wantRequeue != result.Requeue {
-			t.Errorf("Test %v | wanted to requeue %v but was set to %v", tt.name, tt.wantRequeue, result.Requeue)
-		}
-
-		actualLog := hook.LastEntry()
-		logger.Log(logrus.InfoLevel, actualLog)
-		if actualLog == nil {
-			assert.Equal(t, tt.expectedLog, actualLog)
-		} else {
-			assert.Equal(t, tt.expectedLog.Level.String(), actualLog.Level.String())
-			assert.Equal(t, tt.expectedLog.Message, actualLog.Message)
-		}
+			if len(deletedObjects) != 0 {
+				t.Error("should not have deleted objects", deletedObjects)
+			}
+		})
 	}
 }


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-28927](https://redhat.atlassian.net/browse/ARO-28927)

### What this PR does / why we need it:
Changes the etchosts controller to work closer to the dnsmasq controller, as the updates in https://github.com/Azure/ARO-RP/pull/4974 run into issues due to the deprecation of Requeue, and trying to fix it I realised a lot of it needed changing anyway (and could be tested better, etc)

### Test plan for issue:

Unit tests, E2E

### Is there any documentation that needs to be updated for this PR?
N/A

### How do you know this will function as expected in production? 

Unit tests and E2E, hopefully :)
