### PR TITLE
ARO-28964: retry transient 403 when fetching platform workload identity details

### DIFF
--- a/pkg/cluster/platformworkloadidentities.go
+++ b/pkg/cluster/platformworkloadidentities.go
@@ -8,10 +8,13 @@ import (
 	"fmt"
 	"net/http"
 
+	"k8s.io/apimachinery/pkg/util/wait"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi"
 
 	"github.com/Azure/ARO-RP/pkg/api"
+	utilarm "github.com/Azure/ARO-RP/pkg/util/arm"
 	"github.com/Azure/ARO-RP/pkg/util/azureerrors"
 )
 
@@ -42,13 +45,33 @@ func (m *manager) platformWorkloadIdentityIDs(ctx context.Context) error {
 			return fmt.Errorf("platform workload identity '%s' invalid: %w", operatorName, err)
 		}
 
-		identityDetails, err := m.userAssignedIdentities.Get(ctx, resourceId.ResourceGroupName, resourceId.Name, &armmsi.UserAssignedIdentitiesClientGetOptions{})
-		if err != nil {
+		var identityDetails armmsi.UserAssignedIdentitiesClientGetResponse
+		var lastGetErr error
+		retryErr := wait.ExponentialBackoffWithContext(ctx, utilarm.TransientBackoff, func(ctx context.Context) (bool, error) {
+			var getErr error
+			identityDetails, getErr = m.userAssignedIdentities.Get(ctx, resourceId.ResourceGroupName, resourceId.Name, &armmsi.UserAssignedIdentitiesClientGetOptions{})
+			if getErr == nil {
+				return true, nil
+			}
+
+			lastGetErr = getErr
+
+			if azureerrors.IsStatusForbiddenError(getErr) || azureerrors.IsRetryableError(getErr) {
+				m.log.Warnf("transient error fetching platform workload identity '%s', will retry: %v", operatorName, getErr)
+				return false, nil
+			}
+
+			return false, getErr
+		})
+		if retryErr != nil {
+			err = lastGetErr
+			if err == nil {
+				err = retryErr
+			}
 			if azureerrors.IsStatusUnauthorizedError(err) || azureerrors.IsStatusForbiddenError(err) || azureerrors.IsStatusNotFoundError(err) || azureerrors.IsRetryableError(err) {
 				return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidPlatformWorkloadIdentity, fmt.Sprintf(`.properties.platformWorkloadIdentityProfile.platformWorkloadIdentities["%s"]`, operatorName), err.Error())
-			} else {
-				return fmt.Errorf("error occurred when retrieving platform workload identity '%s' details: %w", operatorName, err)
 			}
+			return fmt.Errorf("error occurred when retrieving platform workload identity '%s' details: %w", operatorName, err)
 		}
 
 		updatedIdentities[operatorName] = api.PlatformWorkloadIdentity{

--- a/pkg/cluster/platformworkloadidentities.go
+++ b/pkg/cluster/platformworkloadidentities.go
@@ -8,8 +8,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"k8s.io/apimachinery/pkg/util/wait"
-
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi"
 
@@ -46,28 +44,14 @@ func (m *manager) platformWorkloadIdentityIDs(ctx context.Context) error {
 		}
 
 		var identityDetails armmsi.UserAssignedIdentitiesClientGetResponse
-		var lastGetErr error
-		retryErr := wait.ExponentialBackoffWithContext(ctx, utilarm.TransientBackoff, func(ctx context.Context) (bool, error) {
+		err = utilarm.RetryableWith(ctx, func(err error) bool {
+			return azureerrors.IsStatusForbiddenError(err) || azureerrors.IsRetryableError(err)
+		}, func() error {
 			var getErr error
 			identityDetails, getErr = m.userAssignedIdentities.Get(ctx, resourceId.ResourceGroupName, resourceId.Name, &armmsi.UserAssignedIdentitiesClientGetOptions{})
-			if getErr == nil {
-				return true, nil
-			}
-
-			lastGetErr = getErr
-
-			if azureerrors.IsStatusForbiddenError(getErr) || azureerrors.IsRetryableError(getErr) {
-				m.log.Warnf("transient error fetching platform workload identity '%s', will retry: %v", operatorName, getErr)
-				return false, nil
-			}
-
-			return false, getErr
-		})
-		if retryErr != nil {
-			err = lastGetErr
-			if err == nil {
-				err = retryErr
-			}
+			return getErr
+		}, m.log, fmt.Sprintf("fetching platform workload identity '%s'", operatorName))
+		if err != nil {
 			if azureerrors.IsStatusUnauthorizedError(err) || azureerrors.IsStatusForbiddenError(err) || azureerrors.IsStatusNotFoundError(err) || azureerrors.IsRetryableError(err) {
 				return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidPlatformWorkloadIdentity, fmt.Sprintf(`.properties.platformWorkloadIdentityProfile.platformWorkloadIdentities["%s"]`, operatorName), err.Error())
 			}

--- a/pkg/cluster/platformworkloadidentities_test.go
+++ b/pkg/cluster/platformworkloadidentities_test.go
@@ -9,15 +9,19 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
+	"k8s.io/apimachinery/pkg/util/wait"
+
 	azruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi"
 
 	"github.com/Azure/ARO-RP/pkg/api"
+	utilarm "github.com/Azure/ARO-RP/pkg/util/arm"
 	mock_armmsi "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/azuresdk/armmsi"
 	testdatabase "github.com/Azure/ARO-RP/test/database"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
@@ -65,6 +69,16 @@ func TestPlatformWorkloadIdentityIDs(t *testing.T) {
 	}
 
 	ctx := context.Background()
+
+	savedBackoff := utilarm.TransientBackoff
+	utilarm.TransientBackoff = wait.Backoff{
+		Steps:    4,
+		Duration: 1 * time.Millisecond,
+		Factor:   1.0,
+		Jitter:   0.0,
+	}
+	defer func() { utilarm.TransientBackoff = savedBackoff }()
+
 	for _, tt := range []struct {
 		name                              string
 		doc                               *api.OpenShiftClusterDocument
@@ -221,6 +235,110 @@ func TestPlatformWorkloadIdentityIDs(t *testing.T) {
 					Return(armmsi.UserAssignedIdentitiesClientGetResponse{}, tooManyRequestsErr)
 			},
 			wantErr: api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidPlatformWorkloadIdentity, fooTarget, tooManyRequestsErr.Error()).Error(),
+		},
+		{
+			name: "success - transient forbidden error retried then succeeds",
+			doc:  validWIClusterDoc,
+			userAssignedIdentitiesClientMocks: func(mock *mock_armmsi.MockUserAssignedIdentitiesClient) {
+				gomock.InOrder(
+					mock.EXPECT().Get(gomock.Any(), gomock.Eq(clusterRG), gomock.Eq(identityFooName), gomock.Any()).
+						Return(armmsi.UserAssignedIdentitiesClientGetResponse{}, forbiddenErr),
+					mock.EXPECT().Get(gomock.Any(), gomock.Eq(clusterRG), gomock.Eq(identityFooName), gomock.Any()).
+						Return(armmsi.UserAssignedIdentitiesClientGetResponse{
+							Identity: armmsi.Identity{
+								Properties: &armmsi.UserAssignedIdentityProperties{
+									ClientID:    &identityFooClientId,
+									PrincipalID: &identityFooObjectId,
+								},
+							},
+						}, nil),
+				)
+
+				mock.EXPECT().Get(gomock.Any(), gomock.Eq(clusterRG), gomock.Eq(identityBarName), gomock.Any()).Times(1).
+					Return(armmsi.UserAssignedIdentitiesClientGetResponse{
+						Identity: armmsi.Identity{
+							Properties: &armmsi.UserAssignedIdentityProperties{
+								ClientID:    &identityBarClientId,
+								PrincipalID: &identityBarObjectId,
+							},
+						},
+					}, nil)
+			},
+			wantIdentities: &map[string]api.PlatformWorkloadIdentity{
+				identityFooName: {
+					ResourceID: identityFooResourceId,
+					ClientID:   identityFooClientId,
+					ObjectID:   identityFooObjectId,
+				},
+				identityBarName: {
+					ResourceID: identityBarResourceId,
+					ClientID:   identityBarClientId,
+					ObjectID:   identityBarObjectId,
+				},
+			},
+		},
+		{
+			name: "success - transient too many requests error retried then succeeds",
+			doc: &api.OpenShiftClusterDocument{
+				ID:  clusterId,
+				Key: clusterId,
+				OpenShiftCluster: &api.OpenShiftCluster{
+					Properties: api.OpenShiftClusterProperties{
+						PlatformWorkloadIdentityProfile: &api.PlatformWorkloadIdentityProfile{
+							PlatformWorkloadIdentities: map[string]api.PlatformWorkloadIdentity{
+								identityFooName: {
+									ResourceID: identityFooResourceId,
+								},
+							},
+						},
+					},
+				},
+			},
+			userAssignedIdentitiesClientMocks: func(mock *mock_armmsi.MockUserAssignedIdentitiesClient) {
+				gomock.InOrder(
+					mock.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(armmsi.UserAssignedIdentitiesClientGetResponse{}, tooManyRequestsErr),
+					mock.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(armmsi.UserAssignedIdentitiesClientGetResponse{
+							Identity: armmsi.Identity{
+								Properties: &armmsi.UserAssignedIdentityProperties{
+									ClientID:    &identityFooClientId,
+									PrincipalID: &identityFooObjectId,
+								},
+							},
+						}, nil),
+				)
+			},
+			wantIdentities: &map[string]api.PlatformWorkloadIdentity{
+				identityFooName: {
+					ResourceID: identityFooResourceId,
+					ClientID:   identityFooClientId,
+					ObjectID:   identityFooObjectId,
+				},
+			},
+		},
+		{
+			name: "error - forbidden exhausts all retries",
+			doc: &api.OpenShiftClusterDocument{
+				ID:  clusterId,
+				Key: clusterId,
+				OpenShiftCluster: &api.OpenShiftCluster{
+					Properties: api.OpenShiftClusterProperties{
+						PlatformWorkloadIdentityProfile: &api.PlatformWorkloadIdentityProfile{
+							PlatformWorkloadIdentities: map[string]api.PlatformWorkloadIdentity{
+								identityFooName: {
+									ResourceID: identityFooResourceId,
+								},
+							},
+						},
+					},
+				},
+			},
+			userAssignedIdentitiesClientMocks: func(mock *mock_armmsi.MockUserAssignedIdentitiesClient) {
+				mock.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().
+					Return(armmsi.UserAssignedIdentitiesClientGetResponse{}, forbiddenErr)
+			},
+			wantErr: api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidPlatformWorkloadIdentity, fooTarget, forbiddenErr.Error()).Error(),
 		},
 		{
 			name: "success - all clientIDs and objectIDs updated in clusterdoc",

--- a/pkg/cluster/platformworkloadidentities_test.go
+++ b/pkg/cluster/platformworkloadidentities_test.go
@@ -70,6 +70,7 @@ func TestPlatformWorkloadIdentityIDs(t *testing.T) {
 
 	ctx := context.Background()
 
+	// Must not call t.Parallel(); mutates package-level utilarm.TransientBackoff.
 	savedBackoff := utilarm.TransientBackoff
 	utilarm.TransientBackoff = wait.Backoff{
 		Steps:    4,

--- a/pkg/util/arm/retry.go
+++ b/pkg/util/arm/retry.go
@@ -62,6 +62,37 @@ func Retryable(ctx context.Context, f func() error, log *logrus.Entry, desc stri
 	return lastErr
 }
 
+// RetryableWith wraps f with transient ARM retry using a caller-supplied predicate
+// to decide which errors are retryable. Otherwise identical to Retryable.
+func RetryableWith(ctx context.Context, isRetryable func(error) bool, f func() error, log *logrus.Entry, desc string) error {
+	b := TransientBackoff
+	steps := b.Steps
+	var lastErr error
+	for i := 0; i < steps; i++ {
+		lastErr = f()
+		if lastErr == nil {
+			return nil
+		}
+		if !isRetryable(lastErr) {
+			return lastErr
+		}
+		if i == steps-1 {
+			break
+		}
+		sleep := b.Step()
+		if d := retryAfterDuration(lastErr); d > 0 {
+			sleep = d
+		}
+		log.WithField("retry_after", sleep.Seconds()).Warnf("error on %s, retrying: %v", desc, lastErr)
+		select {
+		case <-time.After(sleep):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return lastErr
+}
+
 // RetryableDelete wraps f with transient ARM retry and logs each attempt, treating 404 as success.
 func RetryableDelete(ctx context.Context, f func() error, log *logrus.Entry, desc string) error {
 	return Retryable(ctx, func() error {

--- a/pkg/util/arm/retry.go
+++ b/pkg/util/arm/retry.go
@@ -30,40 +30,15 @@ var TransientBackoff = wait.Backoff{
 	Cap:      60 * time.Second,
 }
 
-// Retryable wraps f with transient ARM retry and logs each retry attempt.
+// Retryable wraps f with transient ARM retry and logs each attempt.
 // If the error carries a Retry-After header, that duration is used as the sleep;
-// otherwise TransientBackoff governs the schedule.
+// otherwise, TransientBackoff governs the schedule.
+
 func Retryable(ctx context.Context, f func() error, log *logrus.Entry, desc string) error {
-	b := TransientBackoff
-	steps := b.Steps
-	var lastErr error
-	for i := 0; i < steps; i++ {
-		lastErr = f()
-		if lastErr == nil {
-			return nil
-		}
-		if !azureerrors.IsRetryableError(lastErr) {
-			return lastErr
-		}
-		if i == steps-1 {
-			break
-		}
-		sleep := b.Step()
-		if d := retryAfterDuration(lastErr); d > 0 {
-			sleep = d
-		}
-		log.WithField("retry_after", sleep.Seconds()).Warnf("error on %s, retrying: %v", desc, lastErr)
-		select {
-		case <-time.After(sleep):
-		case <-ctx.Done():
-			return ctx.Err()
-		}
-	}
-	return lastErr
+	return RetryableWith(ctx, azureerrors.IsRetryableError, f, log, desc)
 }
 
-// RetryableWith wraps f with transient ARM retry using a caller-supplied predicate
-// to decide which errors are retryable. Otherwise identical to Retryable.
+// RetryableWith is like Retryable but with a custom error predicate.
 func RetryableWith(ctx context.Context, isRetryable func(error) bool, f func() error, log *logrus.Entry, desc string) error {
 	b := TransientBackoff
 	steps := b.Steps


### PR DESCRIPTION
Which issue this PR addresses:
Issue: https://redhat.atlassian.net/browse/ARO-28964

What this PR does / why we need it:
The e2e test for platform workload identity replacement was flaky in westcentralus and eastus2euap. Root cause: the RP does a GET on a user-assigned identity to fetch its clientID/objectID, and that GET can fail with a 403 because the role assignment granting read access hasn't propagated yet. Confirmed in Kusto that the same GET succeeds if retried ~20 seconds later. PR #5032 fixed this on the test side, but the RP itself still had no retry, so this could still happen in a real rollout.

Fix:
Wrapped the Get call in platformWorkloadIdentityIDs in a retry, reusing the existing arm.TransientBackoff schedule. Only retries on 403 and errors already considered retryable. 401 and 404 still fail immediately, same as before.

Testing:
Added three test cases:

"transient forbidden error retried then succeeds"
"transient too many requests error retried then succeeds"
"forbidden exhausts all retries"
All existing tests still pass.
