### PR TITLE
Include LinkedAuthorizationFailed in authorizationRetryingAction

### DIFF
--- a/pkg/util/steps/refreshing.go
+++ b/pkg/util/steps/refreshing.go
@@ -81,6 +81,7 @@ func (s *authorizationRefreshingActionStep) run(ctx context.Context, log *logrus
 		if timeoutCtx.Err() == nil && err != nil &&
 			(azureerrors.IsUnauthorizedClientError(err) ||
 				azureerrors.HasAuthorizationFailedError(err) ||
+				azureerrors.HasLinkedAuthorizationFailedError(err) ||
 				azureerrors.IsInvalidSecretError(err) ||
 				azureerrors.IsDeploymentMissingPermissionsError(err) ||
 				err == ErrWantRefresh) {

--- a/pkg/util/steps/refreshing_test.go
+++ b/pkg/util/steps/refreshing_test.go
@@ -4,11 +4,15 @@ package steps
 // Licensed under the Apache License 2.0.
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 	"testing"
+	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/Azure/go-autorest/autorest"
@@ -175,6 +179,118 @@ func TestCreateActionableError(t *testing.T) {
 				}
 			} else {
 				assert.Equal(t, err, tt.rawErr)
+			}
+		})
+	}
+}
+
+type fakeRefreshableAuthorizer struct {
+	rebuildCalled int
+	rebuildErr    error
+}
+
+func (f *fakeRefreshableAuthorizer) Rebuild() error {
+	f.rebuildCalled++
+	return f.rebuildErr
+}
+
+func (f *fakeRefreshableAuthorizer) WithAuthorization() autorest.PrepareDecorator {
+	return func(p autorest.Preparer) autorest.Preparer { return p }
+}
+
+func TestAuthorizationRefreshingActionRetries(t *testing.T) {
+	for _, tt := range []struct {
+		name           string
+		errors         []error
+		expectRetries  bool
+		expectFinalErr string
+	}{
+		{
+			name:           "AuthorizationFailed is retried then succeeds",
+			errors:         []error{autorest.DetailedError{Original: &azure.ServiceError{Code: "AuthorizationFailed"}}, nil},
+			expectRetries:  true,
+			expectFinalErr: "",
+		},
+		{
+			name:           "LinkedAuthorizationFailed is retried then succeeds",
+			errors:         []error{autorest.DetailedError{Original: &azure.ServiceError{Code: "LinkedAuthorizationFailed"}}, nil},
+			expectRetries:  true,
+			expectFinalErr: "",
+		},
+		{
+			name:           "UnauthorizedClient (AADSTS700016) is retried then succeeds",
+			errors:         []error{fmt.Errorf("AADSTS700016: application not found"), nil},
+			expectRetries:  true,
+			expectFinalErr: "",
+		},
+		{
+			name:           "InvalidSecret (AADSTS7000215) is retried then succeeds",
+			errors:         []error{fmt.Errorf("AADSTS7000215: invalid client secret"), nil},
+			expectRetries:  true,
+			expectFinalErr: "",
+		},
+		{
+			name: "DeploymentMissingPermissions is retried then succeeds",
+			errors: []error{
+				autorest.DetailedError{Original: &azure.ServiceError{Code: "InvalidTemplateDeployment", Message: "Authorization failed for template resource 'foo'"}},
+				nil,
+			},
+			expectRetries:  true,
+			expectFinalErr: "",
+		},
+		{
+			name:           "ErrWantRefresh is retried then succeeds",
+			errors:         []error{ErrWantRefresh, nil},
+			expectRetries:  true,
+			expectFinalErr: "",
+		},
+		{
+			name:           "non-auth error is not retried",
+			errors:         []error{fmt.Errorf("some other error")},
+			expectRetries:  false,
+			expectFinalErr: "some other error",
+		},
+		{
+			name:           "nil error succeeds immediately",
+			errors:         []error{nil},
+			expectRetries:  false,
+			expectFinalErr: "",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			callCount := 0
+			action := func(ctx context.Context) error {
+				idx := callCount
+				callCount++
+				if idx < len(tt.errors) {
+					return tt.errors[idx]
+				}
+				return nil
+			}
+
+			auth := &fakeRefreshableAuthorizer{}
+			s := &authorizationRefreshingActionStep{
+				f:             action,
+				auth:          auth,
+				retryTimeout:  30 * time.Second,
+				pollInterval:  1 * time.Millisecond,
+				managedRGName: "",
+			}
+
+			err := s.run(context.Background(), logrus.NewEntry(logrus.StandardLogger()))
+
+			if tt.expectRetries {
+				assert.Greater(t, callCount, 1, "action should have been called more than once")
+				assert.Positive(t, auth.rebuildCalled, "Rebuild should have been called")
+			} else {
+				assert.Equal(t, 1, callCount, "action should have been called exactly once")
+				assert.Equal(t, 0, auth.rebuildCalled, "Rebuild should not have been called")
+			}
+
+			if tt.expectFinalErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tt.expectFinalErr)
 			}
 		})
 	}


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://redhat.atlassian.net/browse/ARO-28997

### What this PR does / why we need it:

- We've seen an uptick in LinkedAuthorizationFailed errors from the FPSP against the managed NSG in the managed resource group. Since this permission is inherited from the FPSP's ownership of the managed resource group and isn't manually granted by the user, this is a role assignment propagation delay. I've attached evidence and Kusto queries in the JIRA attached:
```
{
  "error": {
    "code": "LinkedAuthorizationFailed",
    "message": "The client '' with object id '' has permission to perform action 'Microsoft.Network/virtualNetworks/subnets/write' on scope '/subscriptions/x/resourceGroups/x/providers/Microsoft.Network/virtualNetworks/x-vnet/subnets/x-master'; however, it does not have permission to perform action(s) 'Microsoft.Network/networkSecurityGroups/join/action' on the linked scope(s) '/subscriptions/x/resourcegroups/managed-rg/providers/Microsoft.Network/networkSecurityGroups/x-managed-nsg' (respectively) or the linked scope(s) are invalid."
  }
}
```
- We have retry logic for this sort of thing, we just need to include LinkedAuthorizationFailed in it so that it rightfully retries these.
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

- Unit and e2e
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
