### PR TITLE
Clean up old CODEOWNERS, add @cloudygreybeard

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @bennerv @hawkowl @rogbas @mrWinston @jharrington22 @cadenmarchese @SudoBrendan @yjst2012 @hlipsig @tiguelu @mociarain @kimorris27 @tsatam @sankur-codes @wanghaoran1988 @pepedocs @alcasim @tuxerrante @ventifus @kevinobriendotca
+* @bennerv @hawkowl @rogbas @mrWinston @cadenmarchese @SudoBrendan @yjst2012 @hlipsig @tiguelu @kimorris27 @tsatam @sankur-codes @wanghaoran1988 @pepedocs @tuxerrante @ventifus @kevinobriendotca @cloudygreybeard


### PR DESCRIPTION
### Which issue this PR addresses:

N/A

### What this PR does / why we need it:

This cleans up our CODEOWNERS (removing people no longer on this team) and adds @cloudygreybeard as a CODEOWNER.

### Test plan for issue:

N/A

### Is there any documentation that needs to be updated for this PR?
N/A

### How do you know this will function as expected in production? 
N/A