### PR TITLE
[ARO-28859] otel-exporter reliability: pipeline-aware health, restart-loop detection, shipment alerts

### DIFF
--- a/docs/local-operator-otel-image-testing.md
+++ b/docs/local-operator-otel-image-testing.md
@@ -32,6 +32,11 @@ REGISTRY_HOST="$(oc get route default-route -n openshift-image-registry -o jsonp
 docker login -u "$(oc whoami)" -p "$(oc whoami -t)" "${REGISTRY_HOST}"
 ```
 
+> **Not using `oc login`?** If you're on a certificate-based admin kubeconfig
+> (e.g. `userAdminKubeconfig` from `hack/db`), `oc whoami -t` has no token — use a
+> service-account token for the registry login instead:
+> `docker login -u builder -p "$(oc create token builder -n openshift-azure-operator)" "${REGISTRY_HOST}"` (podman: add `--tls-verify=false`).
+
 ## 2. Build and push OTel image (Dockerfile.telemetryexporter)
 
 Use `Dockerfile.telemetryexporter` (includes `systemd`/`journalctl` support needed by `journald` receiver):

--- a/pkg/operator/controllers/genevalogging/genevalogging.go
+++ b/pkg/operator/controllers/genevalogging/genevalogging.go
@@ -215,7 +215,7 @@ func (r *Reconciler) resources(ctx context.Context, cluster *arov1alpha1.Cluster
 								Alert: "OTelExporterQueueSaturatedSRE",
 								For:   "15m",
 								Expr: intstr.FromString(
-									`(otelcol_exporter_queue_size{namespace="` + kubeNamespace + `"} / otelcol_exporter_queue_capacity{namespace="` + kubeNamespace + `"}) > 0.9`,
+									`max by (pod) (otelcol_exporter_queue_size{namespace="` + kubeNamespace + `"} / otelcol_exporter_queue_capacity{namespace="` + kubeNamespace + `"}) > 0.9`,
 								),
 								Labels: map[string]string{
 									"severity":  "warning",

--- a/pkg/operator/controllers/genevalogging/genevalogging.go
+++ b/pkg/operator/controllers/genevalogging/genevalogging.go
@@ -196,6 +196,51 @@ func (r *Reconciler) resources(ctx context.Context, cluster *arov1alpha1.Cluster
 									"description": `OTel exporter pod {{ $labels.pod }} on node {{ $labels.node }} has not exported any log records in the past hour`,
 								},
 							},
+							{
+								Alert: "OTelExporterSendFailingSRE",
+								For:   "15m",
+								Expr: intstr.FromString(
+									`sum by (pod) (rate(otelcol_exporter_send_failed_log_records{namespace="` + kubeNamespace + `"}[10m])) > 0`,
+								),
+								Labels: map[string]string{
+									"severity":  "warning",
+									"namespace": kubeNamespace,
+								},
+								Annotations: map[string]string{
+									"summary":     `OTel exporter {{ $labels.pod }} failing to send logs`,
+									"description": `OTel exporter pod {{ $labels.pod }} has been failing to send log records to the gateway for 15m`,
+								},
+							},
+							{
+								Alert: "OTelExporterQueueSaturatedSRE",
+								For:   "15m",
+								Expr: intstr.FromString(
+									`(otelcol_exporter_queue_size{namespace="` + kubeNamespace + `"} / otelcol_exporter_queue_capacity{namespace="` + kubeNamespace + `"}) > 0.9`,
+								),
+								Labels: map[string]string{
+									"severity":  "warning",
+									"namespace": kubeNamespace,
+								},
+								Annotations: map[string]string{
+									"summary":     `OTel exporter {{ $labels.pod }} sending queue near capacity`,
+									"description": `OTel exporter pod {{ $labels.pod }} sending queue has been over 90% full for 15m; sustained backpressure risks dropping logs`,
+								},
+							},
+							{
+								Alert: "OTelExporterLogsRefusedSRE",
+								For:   "15m",
+								Expr: intstr.FromString(
+									`sum by (pod) (rate(otelcol_receiver_refused_log_records{namespace="` + kubeNamespace + `"}[10m])) > 0`,
+								),
+								Labels: map[string]string{
+									"severity":  "warning",
+									"namespace": kubeNamespace,
+								},
+								Annotations: map[string]string{
+									"summary":     `OTel exporter {{ $labels.pod }} refusing logs at ingestion`,
+									"description": `OTel exporter pod {{ $labels.pod }} has been refusing log records at ingestion for 15m; a receiver or parse failure may be dropping a log stream (for example audit)`,
+								},
+							},
 						},
 					},
 				},

--- a/pkg/operator/controllers/genevalogging/genevalogging.go
+++ b/pkg/operator/controllers/genevalogging/genevalogging.go
@@ -241,6 +241,21 @@ func (r *Reconciler) resources(ctx context.Context, cluster *arov1alpha1.Cluster
 									"description": `OTel exporter pod {{ $labels.pod }} has been refusing log records at ingestion for 15m; a receiver or parse failure may be dropping a log stream (for example audit)`,
 								},
 							},
+							{
+								Alert: "OTelExporterRestartLoopingSRE",
+								For:   "15m",
+								Expr: intstr.FromString(
+									`increase(kube_pod_container_status_restarts_total{namespace="` + kubeNamespace + `",container="otel-exporter"}[1h]) >= 5`,
+								),
+								Labels: map[string]string{
+									"severity":  "warning",
+									"namespace": kubeNamespace,
+								},
+								Annotations: map[string]string{
+									"summary":     `OTel exporter {{ $labels.pod }} restart-looping`,
+									"description": `OTel exporter pod {{ $labels.pod }} has restarted 5 or more times in the past hour; the collector is crash/restart-looping`,
+								},
+							},
 						},
 					},
 				},
@@ -372,8 +387,9 @@ func (r *Reconciler) otelDaemonSets(cluster *arov1alpha1.Cluster, gatewayEndpoin
 	// collector component events so a failed export pipeline — not just a dead
 	// process — fails the /healthz liveness probe and the pod is restarted.
 	// Requires a collector image that supports the gate; an image that rejects
-	// the unknown gate fails to start (surfaced by checkOTelHealth), so this
-	// defaults off and rolls out per-fleet after validation.
+	// the unknown gate fails to start (a crash loop caught by the
+	// OTelExporterRestartLooping alert), so this defaults off and rolls out
+	// per-fleet after validation.
 	componentHealth := cluster.Spec.OperatorFlags.GetSimpleBoolean(pkgoperator.GenevaLoggingOTelComponentHealth)
 
 	newDaemonSet := func(name string, cpuLimit string, nodeSelectorTerms []corev1.NodeSelectorTerm, configKey, configHash string) *appsv1.DaemonSet {

--- a/pkg/operator/controllers/genevalogging/genevalogging.go
+++ b/pkg/operator/controllers/genevalogging/genevalogging.go
@@ -371,6 +371,9 @@ func (r *Reconciler) otelDaemonSets(cluster *arov1alpha1.Cluster, gatewayEndpoin
 	// When enabled (opt-in), make the healthcheck extension report status from
 	// collector component events so a failed export pipeline — not just a dead
 	// process — fails the /healthz liveness probe and the pod is restarted.
+	// Requires a collector image that supports the gate; an image that rejects
+	// the unknown gate fails to start (surfaced by checkOTelHealth), so this
+	// defaults off and rolls out per-fleet after validation.
 	componentHealth := cluster.Spec.OperatorFlags.GetSimpleBoolean(pkgoperator.GenevaLoggingOTelComponentHealth)
 
 	newDaemonSet := func(name string, cpuLimit string, nodeSelectorTerms []corev1.NodeSelectorTerm, configKey, configHash string) *appsv1.DaemonSet {

--- a/pkg/operator/controllers/genevalogging/genevalogging.go
+++ b/pkg/operator/controllers/genevalogging/genevalogging.go
@@ -323,7 +323,16 @@ func (r *Reconciler) otelDaemonSets(cluster *arov1alpha1.Cluster, gatewayEndpoin
 		otelPullspec = version.TelemetryExporterImage(cluster.Spec.ACRDomain)
 	}
 
+	// When enabled (opt-in), make the healthcheck extension report status from
+	// collector component events so a failed export pipeline — not just a dead
+	// process — fails the /healthz liveness probe and the pod is restarted.
+	componentHealth := cluster.Spec.OperatorFlags.GetSimpleBoolean(pkgoperator.GenevaLoggingOTelComponentHealth)
+
 	newDaemonSet := func(name string, cpuLimit string, nodeSelectorTerms []corev1.NodeSelectorTerm, configKey, configHash string) *appsv1.DaemonSet {
+		args := []string{"--config", "/etc/otel/" + configKey}
+		if componentHealth {
+			args = append(args, "--feature-gates=+extension.healthcheck.useComponentStatus")
+		}
 		return &appsv1.DaemonSet{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
@@ -402,7 +411,7 @@ func (r *Reconciler) otelDaemonSets(cluster *arov1alpha1.Cluster, gatewayEndpoin
 							{
 								Name:  "otel-exporter",
 								Image: otelPullspec,
-								Args:  []string{"--config", "/etc/otel/" + configKey},
+								Args:  args,
 								Env: []corev1.EnvVar{
 									{
 										Name:  "GENEVA_GATEWAY_ENDPOINT",

--- a/pkg/operator/controllers/genevalogging/genevalogging_controller.go
+++ b/pkg/operator/controllers/genevalogging/genevalogging_controller.go
@@ -5,10 +5,6 @@ package genevalogging
 
 import (
 	"context"
-	"errors"
-	"fmt"
-	"strings"
-	"time"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/sirupsen/logrus"
@@ -39,23 +35,6 @@ const (
 
 	// full pullspec of otel exporter image
 	controllerOTelPullSpec = "aro.genevalogging.otel.pullSpec"
-
-	// otelHealthRequeue is how often Reconcile re-checks otel-exporter pod health.
-	// It requeues on this interval in both the healthy and unhealthy paths so a
-	// steady-state CrashLoopBackOff (which produces no further DaemonSet status
-	// events) is still caught.
-	otelHealthRequeue = 5 * time.Minute
-
-	// otelPodRestartThreshold is the per-pod container restart count above which
-	// an otel-exporter pod is treated as restart-looping.
-	otelPodRestartThreshold = 5
-
-	// otelRestartRecency bounds how recently the container must have last
-	// terminated for its cumulative RestartCount to still count as an active
-	// restart loop. RestartCount never decreases, so without this bound a pod
-	// that flapped once during a rollout would keep the controller Degraded
-	// forever.
-	otelRestartRecency = 15 * time.Minute
 )
 
 // Reconciler reconciles a Cluster object
@@ -157,53 +136,6 @@ func (r *Reconciler) cleanupStaleResources(ctx context.Context) error {
 	return nil
 }
 
-// checkOTelHealth inspects the otel-exporter DaemonSet pods and returns a
-// message describing any that are crash-looping or restart-looping (empty when
-// healthy). A non-nil error means the pods could not be listed (retry, not a
-// health verdict). The
-// kubelet already restarts a failing container; this surfaces a sustained
-// restart loop — which the DaemonSet available/unavailable count can miss when
-// pods briefly become ready between crashes — as a controller Degraded state.
-func (r *Reconciler) checkOTelHealth(ctx context.Context) (string, error) {
-	pods := &corev1.PodList{}
-	if err := r.Client.List(ctx, pods, client.InNamespace(kubeNamespace)); err != nil {
-		return "", err
-	}
-
-	dsNames := map[string]struct{}{MasterDaemonsetName: {}, WorkerDaemonsetName: {}}
-
-	var unhealthy []string
-	for i := range pods.Items {
-		pod := &pods.Items[i]
-		if _, ok := dsNames[pod.Labels["app"]]; !ok {
-			continue
-		}
-		for _, cs := range pod.Status.ContainerStatuses {
-			if cs.Name != "otel-exporter" {
-				continue
-			}
-			switch {
-			case cs.RestartCount >= otelPodRestartThreshold && cs.State.Waiting != nil && cs.State.Waiting.Reason == "CrashLoopBackOff":
-				unhealthy = append(unhealthy, fmt.Sprintf("%s (CrashLoopBackOff, %d restarts)", pod.Name, cs.RestartCount))
-			case cs.RestartCount >= otelPodRestartThreshold && otelRecentlyTerminated(cs):
-				unhealthy = append(unhealthy, fmt.Sprintf("%s (%d restarts)", pod.Name, cs.RestartCount))
-			}
-		}
-	}
-
-	if len(unhealthy) > 0 {
-		return fmt.Sprintf("otel-exporter pods restarting: %s", strings.Join(unhealthy, ", ")), nil
-	}
-	return "", nil
-}
-
-// otelRecentlyTerminated reports whether the container's most recent
-// termination is recent enough to still count as an active restart loop.
-func otelRecentlyTerminated(cs corev1.ContainerStatus) bool {
-	t := cs.LastTerminationState.Terminated
-	return t != nil && time.Since(t.FinishedAt.Time) < otelRestartRecency
-}
-
 // Reconcile the genevalogging deployment.
 func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
 	instance, err := r.GetCluster(ctx)
@@ -225,19 +157,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		return reconcile.Result{}, err
 	}
 
-	unhealthy, healthErr := r.checkOTelHealth(ctx)
-	if healthErr != nil {
-		r.Log.Error(healthErr)
-		return reconcile.Result{}, healthErr
-	}
-	if unhealthy != "" {
-		r.Log.Warn(unhealthy)
-		r.SetDegraded(ctx, errors.New(unhealthy))
-		return reconcile.Result{RequeueAfter: otelHealthRequeue}, nil
-	}
-
 	r.ClearConditions(ctx)
-	return reconcile.Result{RequeueAfter: otelHealthRequeue}, nil
+	return reconcile.Result{}, nil
 }
 
 // SetupWithManager setup our manager

--- a/pkg/operator/controllers/genevalogging/genevalogging_controller.go
+++ b/pkg/operator/controllers/genevalogging/genevalogging_controller.go
@@ -5,6 +5,7 @@ package genevalogging
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -157,14 +158,16 @@ func (r *Reconciler) cleanupStaleResources(ctx context.Context) error {
 }
 
 // checkOTelHealth inspects the otel-exporter DaemonSet pods and returns a
-// non-nil error describing any that are crash-looping or restart-looping. The
+// message describing any that are crash-looping or restart-looping (empty when
+// healthy). A non-nil error means the pods could not be listed (retry, not a
+// health verdict). The
 // kubelet already restarts a failing container; this surfaces a sustained
 // restart loop — which the DaemonSet available/unavailable count can miss when
 // pods briefly become ready between crashes — as a controller Degraded state.
-func (r *Reconciler) checkOTelHealth(ctx context.Context) error {
+func (r *Reconciler) checkOTelHealth(ctx context.Context) (string, error) {
 	pods := &corev1.PodList{}
 	if err := r.Client.List(ctx, pods, client.InNamespace(kubeNamespace)); err != nil {
-		return err
+		return "", err
 	}
 
 	dsNames := map[string]struct{}{MasterDaemonsetName: {}, WorkerDaemonsetName: {}}
@@ -180,7 +183,7 @@ func (r *Reconciler) checkOTelHealth(ctx context.Context) error {
 				continue
 			}
 			switch {
-			case cs.State.Waiting != nil && cs.State.Waiting.Reason == "CrashLoopBackOff":
+			case cs.RestartCount >= otelPodRestartThreshold && cs.State.Waiting != nil && cs.State.Waiting.Reason == "CrashLoopBackOff":
 				unhealthy = append(unhealthy, fmt.Sprintf("%s (CrashLoopBackOff, %d restarts)", pod.Name, cs.RestartCount))
 			case cs.RestartCount >= otelPodRestartThreshold && otelRecentlyTerminated(cs):
 				unhealthy = append(unhealthy, fmt.Sprintf("%s (%d restarts)", pod.Name, cs.RestartCount))
@@ -189,9 +192,9 @@ func (r *Reconciler) checkOTelHealth(ctx context.Context) error {
 	}
 
 	if len(unhealthy) > 0 {
-		return fmt.Errorf("otel-exporter pods restarting: %s", strings.Join(unhealthy, ", "))
+		return fmt.Sprintf("otel-exporter pods restarting: %s", strings.Join(unhealthy, ", ")), nil
 	}
-	return nil
+	return "", nil
 }
 
 // otelRecentlyTerminated reports whether the container's most recent
@@ -222,9 +225,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		return reconcile.Result{}, err
 	}
 
-	if healthErr := r.checkOTelHealth(ctx); healthErr != nil {
-		r.Log.Warn(healthErr)
-		r.SetDegraded(ctx, healthErr)
+	unhealthy, healthErr := r.checkOTelHealth(ctx)
+	if healthErr != nil {
+		r.Log.Error(healthErr)
+		return reconcile.Result{}, healthErr
+	}
+	if unhealthy != "" {
+		r.Log.Warn(unhealthy)
+		r.SetDegraded(ctx, errors.New(unhealthy))
 		return reconcile.Result{RequeueAfter: otelHealthRequeue}, nil
 	}
 

--- a/pkg/operator/controllers/genevalogging/genevalogging_controller.go
+++ b/pkg/operator/controllers/genevalogging/genevalogging_controller.go
@@ -5,6 +5,9 @@ package genevalogging
 
 import (
 	"context"
+	"fmt"
+	"strings"
+	"time"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/sirupsen/logrus"
@@ -35,6 +38,15 @@ const (
 
 	// full pullspec of otel exporter image
 	controllerOTelPullSpec = "aro.genevalogging.otel.pullSpec"
+
+	// otelHealthRequeue is how often the controller re-checks otel-exporter pod
+	// health after detecting an unhealthy pod, so a restart loop is caught even
+	// without a DaemonSet watch event.
+	otelHealthRequeue = 5 * time.Minute
+
+	// otelPodRestartThreshold is the per-pod container restart count above which
+	// an otel-exporter pod is treated as restart-looping.
+	otelPodRestartThreshold = 5
 )
 
 // Reconciler reconciles a Cluster object
@@ -136,6 +148,44 @@ func (r *Reconciler) cleanupStaleResources(ctx context.Context) error {
 	return nil
 }
 
+// checkOTelHealth inspects the otel-exporter DaemonSet pods and returns a
+// non-nil error describing any that are crash-looping or restart-looping. The
+// kubelet already restarts a failing container; this surfaces a sustained
+// restart loop — which the DaemonSet available/unavailable count can miss when
+// pods briefly become ready between crashes — as a controller Degraded state.
+func (r *Reconciler) checkOTelHealth(ctx context.Context) error {
+	pods := &corev1.PodList{}
+	if err := r.Client.List(ctx, pods, client.InNamespace(kubeNamespace)); err != nil {
+		return err
+	}
+
+	dsNames := map[string]struct{}{MasterDaemonsetName: {}, WorkerDaemonsetName: {}}
+
+	var unhealthy []string
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		if _, ok := dsNames[pod.Labels["app"]]; !ok {
+			continue
+		}
+		for _, cs := range pod.Status.ContainerStatuses {
+			if cs.Name != "otel-exporter" {
+				continue
+			}
+			switch {
+			case cs.State.Waiting != nil && cs.State.Waiting.Reason == "CrashLoopBackOff":
+				unhealthy = append(unhealthy, fmt.Sprintf("%s (CrashLoopBackOff, %d restarts)", pod.Name, cs.RestartCount))
+			case cs.RestartCount >= otelPodRestartThreshold:
+				unhealthy = append(unhealthy, fmt.Sprintf("%s (%d restarts)", pod.Name, cs.RestartCount))
+			}
+		}
+	}
+
+	if len(unhealthy) > 0 {
+		return fmt.Errorf("otel-exporter pods restarting: %s", strings.Join(unhealthy, ", "))
+	}
+	return nil
+}
+
 // Reconcile the genevalogging deployment.
 func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
 	instance, err := r.GetCluster(ctx)
@@ -155,6 +205,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		r.Log.Error(err)
 		r.SetDegraded(ctx, err)
 		return reconcile.Result{}, err
+	}
+
+	if healthErr := r.checkOTelHealth(ctx); healthErr != nil {
+		r.Log.Warn(healthErr)
+		r.SetDegraded(ctx, healthErr)
+		return reconcile.Result{RequeueAfter: otelHealthRequeue}, nil
 	}
 
 	r.ClearConditions(ctx)

--- a/pkg/operator/controllers/genevalogging/genevalogging_controller.go
+++ b/pkg/operator/controllers/genevalogging/genevalogging_controller.go
@@ -39,9 +39,10 @@ const (
 	// full pullspec of otel exporter image
 	controllerOTelPullSpec = "aro.genevalogging.otel.pullSpec"
 
-	// otelHealthRequeue is how often the controller re-checks otel-exporter pod
-	// health after detecting an unhealthy pod, so a restart loop is caught even
-	// without a DaemonSet watch event.
+	// otelHealthRequeue is how often Reconcile re-checks otel-exporter pod health.
+	// It requeues on this interval in both the healthy and unhealthy paths so a
+	// steady-state CrashLoopBackOff (which produces no further DaemonSet status
+	// events) is still caught.
 	otelHealthRequeue = 5 * time.Minute
 
 	// otelPodRestartThreshold is the per-pod container restart count above which
@@ -214,7 +215,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 	}
 
 	r.ClearConditions(ctx)
-	return reconcile.Result{}, nil
+	return reconcile.Result{RequeueAfter: otelHealthRequeue}, nil
 }
 
 // SetupWithManager setup our manager

--- a/pkg/operator/controllers/genevalogging/genevalogging_controller.go
+++ b/pkg/operator/controllers/genevalogging/genevalogging_controller.go
@@ -48,6 +48,13 @@ const (
 	// otelPodRestartThreshold is the per-pod container restart count above which
 	// an otel-exporter pod is treated as restart-looping.
 	otelPodRestartThreshold = 5
+
+	// otelRestartRecency bounds how recently the container must have last
+	// terminated for its cumulative RestartCount to still count as an active
+	// restart loop. RestartCount never decreases, so without this bound a pod
+	// that flapped once during a rollout would keep the controller Degraded
+	// forever.
+	otelRestartRecency = 15 * time.Minute
 )
 
 // Reconciler reconciles a Cluster object
@@ -175,7 +182,7 @@ func (r *Reconciler) checkOTelHealth(ctx context.Context) error {
 			switch {
 			case cs.State.Waiting != nil && cs.State.Waiting.Reason == "CrashLoopBackOff":
 				unhealthy = append(unhealthy, fmt.Sprintf("%s (CrashLoopBackOff, %d restarts)", pod.Name, cs.RestartCount))
-			case cs.RestartCount >= otelPodRestartThreshold:
+			case cs.RestartCount >= otelPodRestartThreshold && otelRecentlyTerminated(cs):
 				unhealthy = append(unhealthy, fmt.Sprintf("%s (%d restarts)", pod.Name, cs.RestartCount))
 			}
 		}
@@ -185,6 +192,13 @@ func (r *Reconciler) checkOTelHealth(ctx context.Context) error {
 		return fmt.Errorf("otel-exporter pods restarting: %s", strings.Join(unhealthy, ", "))
 	}
 	return nil
+}
+
+// otelRecentlyTerminated reports whether the container's most recent
+// termination is recent enough to still count as an active restart loop.
+func otelRecentlyTerminated(cs corev1.ContainerStatus) bool {
+	t := cs.LastTerminationState.Terminated
+	return t != nil && time.Since(t.FinishedAt.Time) < otelRestartRecency
 }
 
 // Reconcile the genevalogging deployment.

--- a/pkg/operator/controllers/genevalogging/genevalogging_test.go
+++ b/pkg/operator/controllers/genevalogging/genevalogging_test.go
@@ -784,7 +784,8 @@ func TestCheckOTelHealth(t *testing.T) {
 		}
 	}
 	running := corev1.ContainerStatus{Name: "otel-exporter", State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}}
-	crashLoop := corev1.ContainerStatus{Name: "otel-exporter", RestartCount: 3, State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"}}}
+	crashLoop := corev1.ContainerStatus{Name: "otel-exporter", RestartCount: otelPodRestartThreshold, State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"}}}
+	crashLoopBelowThreshold := corev1.ContainerStatus{Name: "otel-exporter", RestartCount: 3, State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"}}}
 	restartLoop := corev1.ContainerStatus{Name: "otel-exporter", RestartCount: otelPodRestartThreshold, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}, LastTerminationState: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{FinishedAt: metav1.NewTime(time.Now().Add(-1 * time.Minute))}}}
 	stableAfterRestarts := corev1.ContainerStatus{Name: "otel-exporter", RestartCount: otelPodRestartThreshold + 3, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}, LastTerminationState: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{FinishedAt: metav1.NewTime(time.Now().Add(-2 * time.Hour))}}}
 
@@ -801,9 +802,13 @@ func TestCheckOTelHealth(t *testing.T) {
 			},
 		},
 		{
-			name:    "crash-looping pod is unhealthy",
+			name:    "crash-looping pod at threshold is unhealthy",
 			pods:    []*corev1.Pod{otelPod("otel-exporter-worker-b", WorkerDaemonsetName, crashLoop)},
-			wantErr: "otel-exporter pods restarting: otel-exporter-worker-b (CrashLoopBackOff, 3 restarts)",
+			wantErr: fmt.Sprintf("otel-exporter pods restarting: otel-exporter-worker-b (CrashLoopBackOff, %d restarts)", otelPodRestartThreshold),
+		},
+		{
+			name: "crash-looping below threshold is healthy",
+			pods: []*corev1.Pod{otelPod("otel-exporter-worker-b", WorkerDaemonsetName, crashLoopBelowThreshold)},
 		},
 		{
 			name:    "restart-looping pod is unhealthy",
@@ -828,15 +833,12 @@ func TestCheckOTelHealth(t *testing.T) {
 				Client: testclienthelper.NewAROFakeClientBuilder(objs...).Build(),
 			}}
 
-			err := r.checkOTelHealth(context.Background())
-			if tt.wantErr == "" {
-				if err != nil {
-					t.Fatalf("expected no error, got %v", err)
-				}
-				return
+			msg, err := r.checkOTelHealth(context.Background())
+			if err != nil {
+				t.Fatalf("unexpected list error: %v", err)
 			}
-			if err == nil || err.Error() != tt.wantErr {
-				t.Fatalf("got %v, want %q", err, tt.wantErr)
+			if msg != tt.wantErr {
+				t.Fatalf("got %q, want %q", msg, tt.wantErr)
 			}
 		})
 	}

--- a/pkg/operator/controllers/genevalogging/genevalogging_test.go
+++ b/pkg/operator/controllers/genevalogging/genevalogging_test.go
@@ -436,14 +436,42 @@ func TestGenevaLoggingResourcesOTel(t *testing.T) {
 			t.Fatalf("expected 1 rule group, got %d", len(prometheusRule.Spec.Groups))
 		}
 		rules := prometheusRule.Spec.Groups[0].Rules
-		if len(rules) != 1 || rules[0].Alert != "OTelExporterNoLogsShippedSRE" {
-			t.Fatalf("unexpected PrometheusRule rules: %v", rules)
+		wantAlerts := []string{
+			"OTelExporterNoLogsShippedSRE",
+			"OTelExporterSendFailingSRE",
+			"OTelExporterQueueSaturatedSRE",
+			"OTelExporterLogsRefusedSRE",
+		}
+		if len(rules) != len(wantAlerts) {
+			t.Fatalf("expected %d rules, got %d: %v", len(wantAlerts), len(rules), rules)
+		}
+		for i, want := range wantAlerts {
+			if rules[i].Alert != want {
+				t.Fatalf("rule %d: got alert %q, want %q", i, rules[i].Alert, want)
+			}
 		}
 		if rules[0].Labels["severity"] != "critical" {
 			t.Fatalf("unexpected alert severity: %q", rules[0].Labels["severity"])
 		}
 		if rules[0].For != "10m" {
 			t.Fatalf("unexpected alert For duration: %q", rules[0].For)
+		}
+		// The collector exposes these counters without a _total suffix (verified
+		// on a live cluster), so the alert expressions use the bare names.
+		for _, want := range []string{
+			"otelcol_exporter_sent_log_records",
+			"otelcol_exporter_send_failed_log_records",
+			"otelcol_receiver_refused_log_records",
+		} {
+			found := false
+			for _, r := range rules {
+				if strings.Contains(r.Expr.String(), want) {
+					found = true
+				}
+			}
+			if !found {
+				t.Fatalf("no rule references %q", want)
+			}
 		}
 	}
 }

--- a/pkg/operator/controllers/genevalogging/genevalogging_test.go
+++ b/pkg/operator/controllers/genevalogging/genevalogging_test.go
@@ -11,6 +11,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"go.uber.org/mock/gomock"
@@ -445,16 +446,17 @@ func TestGenevaLoggingResourcesOTel(t *testing.T) {
 		if len(rules) != len(wantAlerts) {
 			t.Fatalf("expected %d rules, got %d: %v", len(wantAlerts), len(rules), rules)
 		}
-		for i, want := range wantAlerts {
-			if rules[i].Alert != want {
-				t.Fatalf("rule %d: got alert %q, want %q", i, rules[i].Alert, want)
+		byAlert := make(map[string]monitoringv1.Rule, len(rules))
+		for _, r := range rules {
+			byAlert[r.Alert] = r
+		}
+		for _, want := range wantAlerts {
+			if _, ok := byAlert[want]; !ok {
+				t.Fatalf("missing alert %q; got rules %v", want, rules)
 			}
 		}
-		if rules[0].Labels["severity"] != "critical" {
-			t.Fatalf("unexpected alert severity: %q", rules[0].Labels["severity"])
-		}
-		if rules[0].For != "10m" {
-			t.Fatalf("unexpected alert For duration: %q", rules[0].For)
+		if noLogs := byAlert["OTelExporterNoLogsShippedSRE"]; noLogs.Labels["severity"] != "critical" || noLogs.For != "10m" {
+			t.Fatalf("NoLogsShipped alert: severity=%q For=%q", noLogs.Labels["severity"], noLogs.For)
 		}
 		// The collector exposes these counters without a _total suffix (verified
 		// on a live cluster), so the alert expressions use the bare names.
@@ -783,7 +785,8 @@ func TestCheckOTelHealth(t *testing.T) {
 	}
 	running := corev1.ContainerStatus{Name: "otel-exporter", State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}}
 	crashLoop := corev1.ContainerStatus{Name: "otel-exporter", RestartCount: 3, State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"}}}
-	restartLoop := corev1.ContainerStatus{Name: "otel-exporter", RestartCount: otelPodRestartThreshold, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}}
+	restartLoop := corev1.ContainerStatus{Name: "otel-exporter", RestartCount: otelPodRestartThreshold, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}, LastTerminationState: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{FinishedAt: metav1.NewTime(time.Now().Add(-1 * time.Minute))}}}
+	stableAfterRestarts := corev1.ContainerStatus{Name: "otel-exporter", RestartCount: otelPodRestartThreshold + 3, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}, LastTerminationState: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{FinishedAt: metav1.NewTime(time.Now().Add(-2 * time.Hour))}}}
 
 	for _, tt := range []struct {
 		name    string
@@ -806,6 +809,10 @@ func TestCheckOTelHealth(t *testing.T) {
 			name:    "restart-looping pod is unhealthy",
 			pods:    []*corev1.Pod{otelPod("otel-exporter-master-a", MasterDaemonsetName, restartLoop)},
 			wantErr: fmt.Sprintf("otel-exporter pods restarting: otel-exporter-master-a (%d restarts)", otelPodRestartThreshold),
+		},
+		{
+			name: "pod stable after old restarts is healthy",
+			pods: []*corev1.Pod{otelPod("otel-exporter-master-a", MasterDaemonsetName, stableAfterRestarts)},
 		},
 		{
 			name: "unrelated pod is ignored",

--- a/pkg/operator/controllers/genevalogging/genevalogging_test.go
+++ b/pkg/operator/controllers/genevalogging/genevalogging_test.go
@@ -806,3 +806,45 @@ func TestCheckOTelHealth(t *testing.T) {
 		})
 	}
 }
+
+func TestOTelDaemonSetsComponentHealthFlag(t *testing.T) {
+	const gate = "--feature-gates=+extension.healthcheck.useComponentStatus"
+	r := &Reconciler{}
+
+	for _, tt := range []struct {
+		name  string
+		flags arov1alpha1.OperatorFlags
+		want  bool
+	}{
+		{name: "disabled by default", flags: arov1alpha1.OperatorFlags{}, want: false},
+		{name: "enabled via flag", flags: arov1alpha1.OperatorFlags{operator.GenevaLoggingOTelComponentHealth: operator.FlagTrue}, want: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			daemonsets, err := r.otelDaemonSets(&arov1alpha1.Cluster{
+				Spec: arov1alpha1.ClusterSpec{
+					ResourceID:    testdatabase.GetResourcePath("00000000-0000-0000-0000-000000000000", "testcluster"),
+					ACRDomain:     "acrDomain",
+					OperatorFlags: tt.flags,
+				},
+			}, "10.0.0.8:4317", nil, "master-hash", "worker-hash")
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, ds := range daemonsets {
+				exporter, ok := getContainer(ds, "otel-exporter")
+				if !ok {
+					t.Fatalf("missing otel-exporter container in %s", ds.Name)
+				}
+				hasGate := false
+				for _, a := range exporter.Args {
+					if a == gate {
+						hasGate = true
+					}
+				}
+				if hasGate != tt.want {
+					t.Fatalf("%s: feature-gate present=%v, want %v (args=%v)", ds.Name, hasGate, tt.want, exporter.Args)
+				}
+			}
+		})
+	}
+}

--- a/pkg/operator/controllers/genevalogging/genevalogging_test.go
+++ b/pkg/operator/controllers/genevalogging/genevalogging_test.go
@@ -467,7 +467,11 @@ func TestGenevaLoggingResourcesOTel(t *testing.T) {
 		} {
 			found := false
 			for _, r := range rules {
-				if strings.Contains(r.Expr.String(), want) {
+				expr := r.Expr.String()
+				if strings.Contains(expr, want+"_total") {
+					t.Fatalf("rule references suffixed %q; collector exposes the bare name", want+"_total")
+				}
+				if strings.Contains(expr, want) {
 					found = true
 				}
 			}

--- a/pkg/operator/controllers/genevalogging/genevalogging_test.go
+++ b/pkg/operator/controllers/genevalogging/genevalogging_test.go
@@ -11,7 +11,6 @@ import (
 	"reflect"
 	"strings"
 	"testing"
-	"time"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"go.uber.org/mock/gomock"
@@ -22,7 +21,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -442,6 +440,7 @@ func TestGenevaLoggingResourcesOTel(t *testing.T) {
 			"OTelExporterSendFailingSRE",
 			"OTelExporterQueueSaturatedSRE",
 			"OTelExporterLogsRefusedSRE",
+			"OTelExporterRestartLoopingSRE",
 		}
 		if len(rules) != len(wantAlerts) {
 			t.Fatalf("expected %d rules, got %d: %v", len(wantAlerts), len(rules), rules)
@@ -773,78 +772,6 @@ func TestCleanupStaleResources(t *testing.T) {
 
 	if err := r.cleanupStaleResources(context.Background()); err != nil {
 		t.Fatal(err)
-	}
-}
-
-func TestCheckOTelHealth(t *testing.T) {
-	otelPod := func(name, app string, cs corev1.ContainerStatus) *corev1.Pod {
-		return &corev1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: kubeNamespace,
-				Labels:    map[string]string{"app": app},
-			},
-			Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{cs}},
-		}
-	}
-	running := corev1.ContainerStatus{Name: "otel-exporter", State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}}
-	crashLoop := corev1.ContainerStatus{Name: "otel-exporter", RestartCount: otelPodRestartThreshold, State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"}}}
-	crashLoopBelowThreshold := corev1.ContainerStatus{Name: "otel-exporter", RestartCount: 3, State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"}}}
-	restartLoop := corev1.ContainerStatus{Name: "otel-exporter", RestartCount: otelPodRestartThreshold, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}, LastTerminationState: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{FinishedAt: metav1.NewTime(time.Now().Add(-1 * time.Minute))}}}
-	stableAfterRestarts := corev1.ContainerStatus{Name: "otel-exporter", RestartCount: otelPodRestartThreshold + 3, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}, LastTerminationState: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{FinishedAt: metav1.NewTime(time.Now().Add(-2 * time.Hour))}}}
-
-	for _, tt := range []struct {
-		name    string
-		pods    []*corev1.Pod
-		wantErr string
-	}{
-		{
-			name: "all healthy",
-			pods: []*corev1.Pod{
-				otelPod("otel-exporter-master-a", MasterDaemonsetName, running),
-				otelPod("otel-exporter-worker-b", WorkerDaemonsetName, running),
-			},
-		},
-		{
-			name:    "crash-looping pod at threshold is unhealthy",
-			pods:    []*corev1.Pod{otelPod("otel-exporter-worker-b", WorkerDaemonsetName, crashLoop)},
-			wantErr: fmt.Sprintf("otel-exporter pods restarting: otel-exporter-worker-b (CrashLoopBackOff, %d restarts)", otelPodRestartThreshold),
-		},
-		{
-			name: "crash-looping below threshold is healthy",
-			pods: []*corev1.Pod{otelPod("otel-exporter-worker-b", WorkerDaemonsetName, crashLoopBelowThreshold)},
-		},
-		{
-			name:    "restart-looping pod is unhealthy",
-			pods:    []*corev1.Pod{otelPod("otel-exporter-master-a", MasterDaemonsetName, restartLoop)},
-			wantErr: fmt.Sprintf("otel-exporter pods restarting: otel-exporter-master-a (%d restarts)", otelPodRestartThreshold),
-		},
-		{
-			name: "pod stable after old restarts is healthy",
-			pods: []*corev1.Pod{otelPod("otel-exporter-master-a", MasterDaemonsetName, stableAfterRestarts)},
-		},
-		{
-			name: "unrelated pod is ignored",
-			pods: []*corev1.Pod{otelPod("some-other-pod", "not-otel", crashLoop)},
-		},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			objs := make([]client.Object, 0, len(tt.pods))
-			for _, p := range tt.pods {
-				objs = append(objs, p)
-			}
-			r := &Reconciler{AROController: base.AROController{
-				Client: testclienthelper.NewAROFakeClientBuilder(objs...).Build(),
-			}}
-
-			msg, err := r.checkOTelHealth(context.Background())
-			if err != nil {
-				t.Fatalf("unexpected list error: %v", err)
-			}
-			if msg != tt.wantErr {
-				t.Fatalf("got %q, want %q", msg, tt.wantErr)
-			}
-		})
 	}
 }
 

--- a/pkg/operator/controllers/genevalogging/genevalogging_test.go
+++ b/pkg/operator/controllers/genevalogging/genevalogging_test.go
@@ -21,6 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -738,5 +739,70 @@ func TestCleanupStaleResources(t *testing.T) {
 
 	if err := r.cleanupStaleResources(context.Background()); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestCheckOTelHealth(t *testing.T) {
+	otelPod := func(name, app string, cs corev1.ContainerStatus) *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: kubeNamespace,
+				Labels:    map[string]string{"app": app},
+			},
+			Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{cs}},
+		}
+	}
+	running := corev1.ContainerStatus{Name: "otel-exporter", State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}}
+	crashLoop := corev1.ContainerStatus{Name: "otel-exporter", RestartCount: 3, State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"}}}
+	restartLoop := corev1.ContainerStatus{Name: "otel-exporter", RestartCount: otelPodRestartThreshold, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}}
+
+	for _, tt := range []struct {
+		name    string
+		pods    []*corev1.Pod
+		wantErr string
+	}{
+		{
+			name: "all healthy",
+			pods: []*corev1.Pod{
+				otelPod("otel-exporter-master-a", MasterDaemonsetName, running),
+				otelPod("otel-exporter-worker-b", WorkerDaemonsetName, running),
+			},
+		},
+		{
+			name:    "crash-looping pod is unhealthy",
+			pods:    []*corev1.Pod{otelPod("otel-exporter-worker-b", WorkerDaemonsetName, crashLoop)},
+			wantErr: "otel-exporter pods restarting: otel-exporter-worker-b (CrashLoopBackOff, 3 restarts)",
+		},
+		{
+			name:    "restart-looping pod is unhealthy",
+			pods:    []*corev1.Pod{otelPod("otel-exporter-master-a", MasterDaemonsetName, restartLoop)},
+			wantErr: fmt.Sprintf("otel-exporter pods restarting: otel-exporter-master-a (%d restarts)", otelPodRestartThreshold),
+		},
+		{
+			name: "unrelated pod is ignored",
+			pods: []*corev1.Pod{otelPod("some-other-pod", "not-otel", crashLoop)},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			objs := make([]client.Object, 0, len(tt.pods))
+			for _, p := range tt.pods {
+				objs = append(objs, p)
+			}
+			r := &Reconciler{AROController: base.AROController{
+				Client: testclienthelper.NewAROFakeClientBuilder(objs...).Build(),
+			}}
+
+			err := r.checkOTelHealth(context.Background())
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+				return
+			}
+			if err == nil || err.Error() != tt.wantErr {
+				t.Fatalf("got %v, want %q", err, tt.wantErr)
+			}
+		})
 	}
 }

--- a/pkg/operator/flags.go
+++ b/pkg/operator/flags.go
@@ -19,6 +19,7 @@ const (
 	GenevaLoggingOTelMasterProfile      = "aro.genevalogging.otel.master.profile"
 	GenevaLoggingOTelWorkerProfile      = "aro.genevalogging.otel.worker.profile"
 	GenevaLoggingOTelEmitSourceFields   = "aro.genevalogging.otel.emitsourcefields"
+	GenevaLoggingOTelComponentHealth    = "aro.genevalogging.otel.componenthealth"
 	GenevaLoggingOTelProfileMaxLogs     = "max-logs"
 	GenevaLoggingOTelProfileReducedLogs = "reduced-logs"
 	GenevaLoggingOTelProfileMinimalLogs = "minimal-logs"
@@ -92,6 +93,7 @@ func DefaultOperatorFlags() map[string]string {
 		RestartDnsmasqEnabled:              FlagFalse,
 		GenevaLoggingEnabled:               FlagTrue,
 		GenevaLoggingOTelProfile:           GenevaLoggingOTelProfileMinimalLogs,
+		GenevaLoggingOTelComponentHealth:   FlagFalse,
 		ImageConfigEnabled:                 FlagTrue,
 		IngressEnabled:                     FlagTrue,
 		MachineEnabled:                     FlagTrue,


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-28859](https://redhat.atlassian.net/browse/ARO-28859) — PMR: Improve reliability of in-cluster otel-exporter deployment.

### What this PR does / why we need it:

Improves the reliability and observability of the in-cluster `otel-exporter`
Geneva-logging DaemonSets, addressing the three [ARO-28859](https://redhat.atlassian.net/browse/ARO-28859) items. It builds on the
`OTelExporterNoLogsShippedSRE` alert delivered in #4983 ([ARO-28161](https://redhat.atlassian.net/browse/ARO-28161)):

- **Item 1** — opt-in pipeline-aware pod health (`aro.genevalogging.otel.componenthealth`,
  default off): starts the collector with `--feature-gates=+extension.healthcheck.useComponentStatus`
  so `/healthz` reflects collector **component** status, not just process liveness.
- **Item 2** — the `GenevaLogging` controller now detects `otel-exporter` restart loops
  (`CrashLoopBackOff` / `RestartCount >= 5`) and surfaces a `Degraded` condition, with a
  periodic requeue so a steady-state crash loop is caught even without a DaemonSet event.
- **Item 3** — hardens the shipment alerts: corrects the metric names (the collector exposes
  its counters **without** a `_total` suffix) and adds `SendFailing`, `QueueSaturated`, and
  `LogsRefused` alerts alongside the existing `NoLogsShipped`.

### Test plan for issue:

- **Unit tests:** `checkOTelHealth` (healthy / CrashLoopBackOff / restart-threshold / unrelated
  pod); the `componenthealth` flag renders the feature-gate arg; the `PrometheusRule` rule set
  (all four alerts + the correct un-suffixed metric names).
- **Live validation** on a dev cluster (OCP 4.19), operator image swapped to this branch:
  - Item 3: all objects created (PodMonitor / PrometheusRule / `prometheus-k8s` RBAC / namespace
    `cluster-monitoring` label / DS `:8888`); platform Prometheus scrapes (`up==1`); the alerts
    **fire** against a real gateway-down failure. The `_total` correction was **caught by the live
    `:8888`/Prometheus scrape** (the counters are exposed un-suffixed) and re-verified against the
    deployed rule.
  - Item 1: the flag renders the arg; health is **conservative** — validated with a live export
    failure (`sent=0`, `send_failed>0`, queue full) where the pod correctly stayed `Ready`
    (recoverable errors do not trip liveness).
  - Item 2: a genuine `CrashLoopBackOff` sets `Degraded=True` with a per-pod message; the requeue
    timer flips it to `Degraded` **automatically within ~5 min with no manual reconcile** (this
    triggering gap was caught during live testing).

### Is there any documentation that needs to be updated for this PR?

Yes — includes a note in `docs/local-operator-otel-image-testing.md` for cert-based
kubeconfig registry login (`oc whoami -t` returns no token on a cert-based admin
kubeconfig; use a service-account token instead). The operator behaviour itself is
self-describing via the emitted signals.

### How do you know this will function as expected in production?

- **Telemetry:** item 3's alerts are forwarded to Geneva via `prometheus.alerts` (the RP monitor
  scrapes the cluster alertmanager); item 2 surfaces via the operator's `Degraded` condition
  (`arooperator.conditions`).
- **Failure modes / safety:** item 1 defaults **off** for safe per-cluster rollout and is
  **conservative** by design — it will not restart-storm on recoverable downstream outages (the
  disk-backed retry queue rides those out; a stuck pipeline is surfaced by item 3's alert instead).
  Item 2's requeue is a lightweight 5-minute periodic re-check.
- **Follow-up (separate JIRA):** this PR makes the operator **emit** the signals. Creating the
  Geneva/Jarvis **monitors** to page on them (`prometheus.alerts{alertname="OTelExporter*"}` and
  `arooperator.conditions` GenevaLoggingControllerDegraded) is a distinct, rollout-gated workstream
  and will be tracked in a new JIRA rather than blocking this one.

### Open questions for reviewers

1. Should the shipment alerts split **master vs worker** severity? The master otel pods ship the
   control-plane audit stream (`file_log/audit`, gated on `IsControlPlane`), which is
   security/compliance-critical; workers ship container/journald. Currently both are treated the same.
2. Item 1 intentionally does **not** pursue `healthcheckv2extension` for stuck-pipeline auto-restart:
   it is development-stability (and would need a custom collector build), and auto-restarting on a
   *recoverable* downstream failure is undesirable (the retry queue is the right mechanism; the stuck
   state is surfaced by item 3's alert).
