### PR TITLE
*: handle CodeQL findings

### DIFF
--- a/pkg/env/prod.go
+++ b/pkg/env/prod.go
@@ -497,8 +497,8 @@ func (p *prod) MsiDataplaneClientOptions(correlationData *api.CorrelationData) (
 func ClientDebugLoggerMiddleware(log *logrus.Entry) policy.Policy {
 	return azureclient.PolicyFunc(func(req *policy.Request) (*http.Response, error) {
 		log := log.WithFields(logrus.Fields{
-			"method": req.Raw().Method,
-			"url":    req.Raw().URL,
+			"method": utillog.Sanitize(req.Raw().Method),
+			"url":    utillog.Sanitize(req.Raw().URL.String()),
 		})
 		if req.Raw().Body != nil {
 			body, err := io.ReadAll(req.Raw().Body)
@@ -508,7 +508,7 @@ func ClientDebugLoggerMiddleware(log *logrus.Entry) policy.Policy {
 			if err := req.Raw().Body.Close(); err != nil {
 				log.WithError(err).Error("error closing request body")
 			}
-			log = log.WithField("body", string(body))
+			log = log.WithField("body", utillog.Sanitize(string(body)))
 			req.Raw().Body = io.NopCloser(bytes.NewBuffer(body)) // reset body so the delegate can use it
 		}
 		log.Info("Sending request.")
@@ -544,7 +544,7 @@ func ClientDebugLoggerMiddleware(log *logrus.Entry) policy.Policy {
 				// error codes don't have anything in them that we need to censor
 				responseBody = string(body)
 			}
-			log = log.WithField("body", responseBody)
+			log = log.WithField("body", utillog.Sanitize(responseBody))
 			resp.Body = io.NopCloser(bytes.NewBuffer(body)) // reset body so the upstream round-trippers can use it
 		}
 		log.Info("Received response.")

--- a/pkg/frontend/admin_openshiftcluster_etcdkeycount.go
+++ b/pkg/frontend/admin_openshiftcluster_etcdkeycount.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 
 	"github.com/sirupsen/logrus"
+
+	utillog "github.com/Azure/ARO-RP/pkg/util/log"
 )
 
 func (f *frontend) postAdminOpenShiftClusterEtcdKeyCount(w http.ResponseWriter, r *http.Request) {
@@ -26,7 +28,7 @@ func (f *frontend) _postAdminOpenShiftClusterEtcdKeyCount(ctx context.Context, r
 		return err
 	}
 
-	log = log.WithFields(logrus.Fields{"resourceID": resourceID, "vmName": vmName})
+	log = log.WithFields(logrus.Fields{"resourceID": utillog.Sanitize(resourceID), "vmName": utillog.Sanitize(vmName)})
 	podName := "etcd-" + vmName
 	opCtx, opCancel := context.WithTimeout(ctx, adminActionStreamTimeout)
 	// panic recovery is in execContainerStream

--- a/pkg/frontend/admin_openshiftcluster_exec.go
+++ b/pkg/frontend/admin_openshiftcluster_exec.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
 	"github.com/Azure/ARO-RP/pkg/frontend/adminactions"
 	"github.com/Azure/ARO-RP/pkg/frontend/middleware"
+	utillog "github.com/Azure/ARO-RP/pkg/util/log"
 	utilrecover "github.com/Azure/ARO-RP/pkg/util/recover"
 )
 
@@ -103,7 +104,7 @@ func (f *frontend) _postAdminOpenShiftClusterExec(ctx context.Context, r *http.R
 		return err
 	}
 
-	log = log.WithField("resourceID", resourceID)
+	log = log.WithField("resourceID", utillog.Sanitize(resourceID))
 	opCtx, opCancel := context.WithTimeout(ctx, adminActionStreamTimeout)
 	// panic recovery is in execContainerStream
 	go func() {
@@ -120,7 +121,7 @@ func execContainerStream(ctx context.Context, log *logrus.Entry, k adminactions.
 	defer utilrecover.Panic(log)
 	defer w.Close()
 
-	log = log.WithFields(logrus.Fields{"namespace": namespace, "podName": podName, "container": container})
+	log = log.WithFields(logrus.Fields{"namespace": utillog.Sanitize(namespace), "podName": utillog.Sanitize(podName), "container": utillog.Sanitize(container)})
 	// write errors ignored; pipe reader may close early on client disconnect
 	fmt.Fprintf(w, "Executing in %s/%s/%s...\n", namespace, podName, container)
 

--- a/pkg/frontend/admin_openshiftcluster_investigate.go
+++ b/pkg/frontend/admin_openshiftcluster_investigate.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
 	"github.com/Azure/ARO-RP/pkg/frontend/middleware"
+	utillog "github.com/Azure/ARO-RP/pkg/util/log"
 )
 
 type investigateRequest struct {
@@ -58,7 +59,7 @@ func (f *frontend) postAdminOpenShiftClusterInvestigate(w http.ResponseWriter, r
 		if atomic.LoadInt64(&tw.written) > 0 {
 			// Streaming already started — can't send a JSON error response.
 			// Log the error server-side instead.
-			log.WithError(err).Warn("investigation failed after streaming started")
+			log.WithField("error", utillog.Sanitize(err.Error())).Warn("investigation failed after streaming started")
 			return
 		}
 		adminReply(log, tw, nil, nil, err)
@@ -152,7 +153,7 @@ func (f *frontend) _postAdminOpenShiftClusterInvestigate(ctx context.Context, r 
 		return api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "", "cluster does not have a private endpoint IP configured")
 	}
 
-	log.Infof("starting Holmes investigation for cluster %s (question_length=%d)", resourceID, len(req.Question))
+	log.Infof("starting Holmes investigation for cluster %s (question_length=%d)", utillog.Sanitize(resourceID), len(req.Question))
 
 	err = f.hiveClusterManager.InvestigateCluster(ctx, hiveNamespace, kubeconfig, f.holmesConfig, apiServerIP, req.Question, w)
 	if err != nil {

--- a/pkg/frontend/admin_openshiftcluster_kubeconfig.go
+++ b/pkg/frontend/admin_openshiftcluster_kubeconfig.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
 	"github.com/Azure/ARO-RP/pkg/frontend/middleware"
+	utillog "github.com/Azure/ARO-RP/pkg/util/log"
 )
 
 const (
@@ -127,8 +128,8 @@ func (f *frontend) _adminOpenShiftClusterKubeconfigNew(ctx context.Context, log 
 	// leaves a creation-attempt record. Do NOT log the token: it is the
 	// kubeconfig bearer credential and would leak into Kusto.
 	log.WithFields(logrus.Fields{
-		"username":   username,
-		"resourceID": resourceID,
+		"username":   utillog.Sanitize(username),
+		"resourceID": utillog.Sanitize(resourceID),
 		"elevated":   elevated,
 		"ttlSeconds": portalDoc.TTL,
 	}).Info("admin kubeconfig create")

--- a/pkg/frontend/admin_openshiftcluster_resize_controlplane.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_controlplane.go
@@ -33,6 +33,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
 	"github.com/Azure/ARO-RP/pkg/frontend/adminactions"
 	"github.com/Azure/ARO-RP/pkg/frontend/middleware"
+	utillog "github.com/Azure/ARO-RP/pkg/util/log"
 	"github.com/Azure/ARO-RP/pkg/util/stringutils"
 )
 
@@ -212,7 +213,7 @@ func resizeControlPlane(ctx context.Context, log *logrus.Entry, k adminactions.K
 
 		machine := machines[name]
 		if machine.size == desiredVMSize {
-			log.Infof("%s is already running %s, skipping", name, desiredVMSize)
+			log.Infof("%s is already running %s, skipping", name, utillog.Sanitize(desiredVMSize))
 			continue
 		}
 
@@ -226,11 +227,11 @@ func resizeControlPlane(ctx context.Context, log *logrus.Entry, k adminactions.K
 		nodeState := &controlPlaneNodeProgress{snapshot: snapshot}
 		operation.nodes = append(operation.nodes, nodeState)
 
-		log.Infof("Resizing control plane node %s from %s to %s", name, machine.size, desiredVMSize)
+		log.Infof("Resizing control plane node %s from %s to %s", name, machine.size, utillog.Sanitize(desiredVMSize))
 		if err := operation.resizeNode(ctx, nodeState); err != nil {
 			return triggerRollback(fmt.Errorf("failed to resize node %s: %w", name, err))
 		}
-		log.Infof("Successfully resized node %s to %s", name, desiredVMSize)
+		log.Infof("Successfully resized node %s to %s", name, utillog.Sanitize(desiredVMSize))
 	}
 
 	return nil

--- a/pkg/frontend/admin_openshiftcluster_resize_controlplane_recovery.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_controlplane_recovery.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/frontend/adminactions"
+	utillog "github.com/Azure/ARO-RP/pkg/util/log"
 	"github.com/Azure/ARO-RP/pkg/util/steps"
 )
 
@@ -192,7 +193,7 @@ func (o *resizeControlPlaneOperation) captureNodeSnapshot(ctx context.Context, m
 	o.log.WithFields(logrus.Fields{
 		"node":           machineName,
 		"originalVMSize": actualVMSize,
-		"targetVMSize":   o.desiredVMSize,
+		"targetVMSize":   utillog.Sanitize(o.desiredVMSize),
 	}).Info("captured node snapshot for resize operation")
 
 	return snapshot, nil

--- a/pkg/frontend/admin_openshiftcluster_runjob.go
+++ b/pkg/frontend/admin_openshiftcluster_runjob.go
@@ -30,6 +30,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/frontend/adminactions"
 	"github.com/Azure/ARO-RP/pkg/frontend/middleware"
+	utillog "github.com/Azure/ARO-RP/pkg/util/log"
 	utilnamespace "github.com/Azure/ARO-RP/pkg/util/namespace"
 	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 	utilrecover "github.com/Azure/ARO-RP/pkg/util/recover"
@@ -63,7 +64,7 @@ func (f *frontend) _postAdminOpenShiftClusterRunJob(ctx context.Context, r *http
 		return err
 	}
 
-	log = log.WithField("resourceID", resourceID)
+	log = log.WithField("resourceID", utillog.Sanitize(resourceID))
 	opCtx, opCancel := context.WithTimeout(ctx, adminActionStreamTimeout)
 	// panic recovery is in runJobStream
 	go func() {

--- a/pkg/frontend/adminreplies.go
+++ b/pkg/frontend/adminreplies.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/Azure/ARO-RP/pkg/api"
+	utillog "github.com/Azure/ARO-RP/pkg/util/log"
 )
 
 type StreamResponder interface {
@@ -31,13 +32,13 @@ func (d defaultResponder) ReplyStream(log *logrus.Entry, w http.ResponseWriter, 
 	if err != nil {
 		switch err := err.(type) {
 		case *api.CloudError:
-			log.Info(err)
+			log.Info(utillog.Sanitize(err.Error()))
 			api.WriteCloudError(w, err)
 			return
 		case statusCodeError:
 			w.WriteHeader(int(err))
 		default:
-			log.Error(err)
+			log.Error(utillog.Sanitize(err.Error()))
 			api.WriteError(w, http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "", "Internal server error.")
 			return
 		}

--- a/pkg/frontend/asyncoperationresult_get.go
+++ b/pkg/frontend/asyncoperationresult_get.go
@@ -66,7 +66,9 @@ func (f *frontend) _getAsyncOperationResult(ctx context.Context, r *http.Request
 	// don't give away the final operation status until it's committed to the
 	// database
 	if doc != nil && doc.AsyncOperationID == operationId {
-		header["Location"] = r.Header["Referer"]
+		if referer := r.Header.Get("Referer"); referer != "" {
+			header.Set("Location", referer)
+		}
 		return nil, statusCodeError(http.StatusAccepted)
 	}
 

--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -650,13 +650,13 @@ func reply(log *logrus.Entry, w http.ResponseWriter, header http.Header, b []byt
 	if err != nil {
 		switch err := err.(type) {
 		case *api.CloudError:
-			log.Info(err)
+			log.Info(utillog.Sanitize(err.Error()))
 			api.WriteCloudError(w, err)
 			return
 		case statusCodeError:
 			w.WriteHeader(int(err))
 		default:
-			log.Error(err)
+			log.Error(utillog.Sanitize(err.Error()))
 			api.WriteError(w, http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "", "Internal server error.")
 			return
 		}

--- a/pkg/frontend/middleware/log.go
+++ b/pkg/frontend/middleware/log.go
@@ -70,7 +70,7 @@ func (l LogMiddleware) Log(h http.Handler) http.Handler {
 		correlationData.RequestTime = t
 
 		if r.URL.Query().Get(api.APIVersionKey) == admin.APIVersion || isAdminOp(r) {
-			correlationData.ClientPrincipalName = r.Header.Get("X-Ms-Client-Principal-Name")
+			correlationData.ClientPrincipalName = utillog.Sanitize(r.Header.Get("X-Ms-Client-Principal-Name"))
 		}
 
 		w.Header().Set("X-Ms-Request-Id", correlationData.RequestID)
@@ -90,16 +90,16 @@ func (l LogMiddleware) Log(h http.Handler) http.Handler {
 		r = r.WithContext(ctx)
 
 		log = log.WithFields(logrus.Fields{
-			"request_method":      r.Method,
-			"request_path":        r.URL.Path,
-			"request_proto":       r.Proto,
-			"request_remote_addr": r.RemoteAddr,
-			"request_user_agent":  r.UserAgent(),
+			"request_method":      utillog.Sanitize(r.Method),
+			"request_path":        utillog.Sanitize(r.URL.Path),
+			"request_proto":       utillog.Sanitize(r.Proto),
+			"request_remote_addr": utillog.Sanitize(r.RemoteAddr),
+			"request_user_agent":  utillog.Sanitize(r.UserAgent()),
 		})
 		log.Print("read request")
 
 		var (
-			auditCallerIdentity = r.UserAgent()
+			auditCallerIdentity = utillog.Sanitize(r.UserAgent())
 			auditCallerType     = audit.CallerIdentityTypeApplicationID
 		)
 
@@ -111,7 +111,7 @@ func (l LogMiddleware) Log(h http.Handler) http.Handler {
 		var (
 			adminOp       = isAdminOp(r)
 			logTime       = time.Now().UTC().Format(time.RFC3339)
-			operationName = fmt.Sprintf("%s %s", r.Method, r.URL.Path)
+			operationName = fmt.Sprintf("%s %s", utillog.Sanitize(r.Method), utillog.Sanitize(r.URL.Path))
 		)
 
 		auditEntry := l.AuditLog.WithFields(logrus.Fields{
@@ -121,7 +121,7 @@ func (l LogMiddleware) Log(h http.Handler) http.Handler {
 			audit.MetadataAdminOperation:  adminOp,
 			audit.EnvKeyAppID:             audit.SourceRP,
 			audit.EnvKeyCloudRole:         audit.CloudRoleRP,
-			audit.EnvKeyCorrelationID:     correlationData.CorrelationID,
+			audit.EnvKeyCorrelationID:     utillog.Sanitize(correlationData.CorrelationID),
 			audit.EnvKeyEnvironment:       l.EnvironmentName,
 			audit.EnvKeyHostname:          l.Hostname,
 			audit.EnvKeyLocation:          l.Location,
@@ -132,12 +132,12 @@ func (l LogMiddleware) Log(h http.Handler) http.Handler {
 				{
 					CallerIdentityType:  auditCallerType,
 					CallerIdentityValue: auditCallerIdentity,
-					CallerIPAddress:     r.RemoteAddr,
+					CallerIPAddress:     utillog.Sanitize(r.RemoteAddr),
 				},
 			},
 			audit.PayloadKeyTargetResources: []audit.TargetResource{
 				{
-					TargetResourceName: r.URL.Path,
+					TargetResourceName: utillog.Sanitize(r.URL.Path),
 					TargetResourceType: auditTargetResourceType(r),
 				},
 			},

--- a/pkg/gateway/recorder.go
+++ b/pkg/gateway/recorder.go
@@ -30,6 +30,9 @@ func newRecorder(c net.Conn) *recorder {
 func (r *recorder) Read(b []byte) (int, error) {
 	if r.record {
 		n, err := r.Conn.Read(b)
+		// n.b. buf is an in-memory replay buffer for raw TLS bytes used to
+		// inspect the SNI; it is never written to an HTTP response, so this is
+		// not a reflected-XSS sink despite static analysis flagging it.
 		r.buf.Write(b[:n])
 		return n, err
 	}

--- a/pkg/portal/middleware/aad.go
+++ b/pkg/portal/middleware/aad.go
@@ -22,6 +22,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/adal"
 
 	"github.com/Azure/ARO-RP/pkg/env"
+	utillog "github.com/Azure/ARO-RP/pkg/util/log"
 	"github.com/Azure/ARO-RP/pkg/util/log/audit"
 	"github.com/Azure/ARO-RP/pkg/util/oidc"
 	"github.com/Azure/ARO-RP/pkg/util/roundtripper"
@@ -376,6 +377,6 @@ func (a *aad) clientAssertion(req *http.Request) (*http.Response, error) {
 }
 
 func (a *aad) internalServerError(w http.ResponseWriter, err error) {
-	a.log.Warn(err)
+	a.log.Warn(utillog.Sanitize(err.Error()))
 	http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 }

--- a/pkg/portal/middleware/log.go
+++ b/pkg/portal/middleware/log.go
@@ -62,6 +62,11 @@ func Log(env env.Core, auditLog, baseLog *logrus.Entry, outelAuditClient audit.C
 			r.Body = &logReadCloser{ReadCloser: r.Body}
 			w = &logResponseWriter{ResponseWriter: w, statusCode: http.StatusOK}
 
+			// Prevent browsers from MIME-sniffing responses into HTML,
+			// mitigating reflected XSS if any user-controlled content is echoed
+			// back.
+			w.Header().Set("X-Content-Type-Options", "nosniff")
+
 			log := baseLog
 			log = utillog.EnrichWithPath(log, r.URL.Path)
 

--- a/pkg/portal/middleware/log.go
+++ b/pkg/portal/middleware/log.go
@@ -66,13 +66,14 @@ func Log(env env.Core, auditLog, baseLog *logrus.Entry, outelAuditClient audit.C
 			log = utillog.EnrichWithPath(log, r.URL.Path)
 
 			username, _ := r.Context().Value(ContextKeyUsername).(string)
+			username = utillog.Sanitize(username)
 
 			log = log.WithFields(logrus.Fields{
-				"request_method":      r.Method,
-				"request_path":        r.URL.Path,
-				"request_proto":       r.Proto,
-				"request_remote_addr": r.RemoteAddr,
-				"request_user_agent":  r.UserAgent(),
+				"request_method":      utillog.Sanitize(r.Method),
+				"request_path":        utillog.Sanitize(r.URL.Path),
+				"request_proto":       utillog.Sanitize(r.Proto),
+				"request_remote_addr": utillog.Sanitize(r.RemoteAddr),
+				"request_user_agent":  utillog.Sanitize(r.UserAgent()),
 				"username":            username,
 			})
 			log.Print("read request")
@@ -88,17 +89,17 @@ func Log(env env.Core, auditLog, baseLog *logrus.Entry, outelAuditClient audit.C
 				audit.EnvKeyHostname:          env.Hostname(),
 				audit.EnvKeyLocation:          env.Location(),
 				audit.PayloadKeyCategory:      audit.CategoryResourceManagement,
-				audit.PayloadKeyOperationName: fmt.Sprintf("%s %s", r.Method, r.URL.Path),
+				audit.PayloadKeyOperationName: fmt.Sprintf("%s %s", utillog.Sanitize(r.Method), utillog.Sanitize(r.URL.Path)),
 				audit.PayloadKeyCallerIdentities: []audit.CallerIdentity{
 					{
 						CallerIdentityType:  audit.CallerIdentityTypeUsername,
 						CallerIdentityValue: username,
-						CallerIPAddress:     r.RemoteAddr,
+						CallerIPAddress:     utillog.Sanitize(r.RemoteAddr),
 					},
 				},
 				audit.PayloadKeyTargetResources: []audit.TargetResource{
 					{
-						TargetResourceName: r.URL.Path,
+						TargetResourceName: utillog.Sanitize(r.URL.Path),
 						TargetResourceType: auditTargetResourceType(r),
 					},
 				},

--- a/pkg/portal/portal.go
+++ b/pkg/portal/portal.go
@@ -36,6 +36,7 @@ import (
 	"github.com/Azure/ARO-RP/pkg/portal/ssh"
 	"github.com/Azure/ARO-RP/pkg/proxy"
 	"github.com/Azure/ARO-RP/pkg/util/heartbeat"
+	utillog "github.com/Azure/ARO-RP/pkg/util/log"
 	"github.com/Azure/ARO-RP/pkg/util/log/audit"
 	"github.com/Azure/ARO-RP/pkg/util/oidc"
 )
@@ -428,11 +429,11 @@ func (p *portal) getResourceID(subscriptionID, resourceGroup, clusterName string
 }
 
 func (p *portal) internalServerError(w http.ResponseWriter, err error) {
-	p.log.Warn(err)
+	p.log.Warn(utillog.Sanitize(err.Error()))
 	http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 }
 
 func (p *portal) badRequest(w http.ResponseWriter, err error) {
-	p.log.Debug(err)
+	p.log.Debug(utillog.Sanitize(err.Error()))
 	http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
 }

--- a/pkg/portal/prometheus/proxy.go
+++ b/pkg/portal/prometheus/proxy.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api/validate"
 	"github.com/Azure/ARO-RP/pkg/portal/util/responsewriter"
+	utillog "github.com/Azure/ARO-RP/pkg/util/log"
 	"github.com/Azure/ARO-RP/pkg/util/portforward"
 	"github.com/Azure/ARO-RP/pkg/util/restconfig"
 )
@@ -175,7 +176,7 @@ func walk(n *html.Node, f func(*html.Node)) {
 
 func (p *Prometheus) error(r *http.Request, statusCode int, err error) {
 	if err != nil {
-		p.log.Print(err)
+		p.log.Print(utillog.Sanitize(err.Error()))
 	}
 
 	w := responsewriter.New(r)

--- a/pkg/util/arm/retry.go
+++ b/pkg/util/arm/retry.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Azure/go-autorest/autorest"
 
 	"github.com/Azure/ARO-RP/pkg/util/azureerrors"
+	utillog "github.com/Azure/ARO-RP/pkg/util/log"
 )
 
 // TransientBackoff is the retry schedule for ARM write operations when no Retry-After
@@ -58,7 +59,7 @@ func RetryableWith(ctx context.Context, isRetryable func(error) bool, f func() e
 		if d := retryAfterDuration(lastErr); d > 0 {
 			sleep = d
 		}
-		log.WithField("retry_after", sleep.Seconds()).Warnf("error on %s, retrying: %v", desc, lastErr)
+		log.WithField("retry_after", sleep.Seconds()).Warnf("error on %s, retrying: %v", utillog.Sanitize(desc), utillog.Sanitize(lastErr.Error()))
 		select {
 		case <-time.After(sleep):
 		case <-ctx.Done():

--- a/pkg/util/azureclient/azuresdk/common/faultinjection.go
+++ b/pkg/util/azureclient/azuresdk/common/faultinjection.go
@@ -16,6 +16,8 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/go-autorest/autorest"
+
+	utillog "github.com/Azure/ARO-RP/pkg/util/log"
 )
 
 const (
@@ -141,7 +143,7 @@ func (p *firstFailPolicy) Do(req *policy.Request) (*http.Response, error) {
 	p.injected[key] = struct{}{}
 	p.sceneIdx++
 	p.mu.Unlock()
-	logrus.Warnf("fault injected: %s (%d) on %s %s", sc.name, sc.status, req.Raw().Method, req.Raw().URL)
+	logrus.Warnf("fault injected: %s (%d) on %s %s", sc.name, sc.status, utillog.Sanitize(req.Raw().Method), utillog.Sanitize(req.Raw().URL.String()))
 	resp := scenarioResponse(sc)
 	resp.Request = req.Raw() // preserve request context for downstream handlers
 	return resp, nil
@@ -184,7 +186,7 @@ func NewFirstFailSendDecorator() autorest.SendDecorator {
 			injected[key] = struct{}{}
 			sceneIdx++
 			mu.Unlock()
-			logrus.Warnf("fault injected: %s (%d) on %s %s", sc.name, sc.status, r.Method, r.URL)
+			logrus.Warnf("fault injected: %s (%d) on %s %s", sc.name, sc.status, utillog.Sanitize(r.Method), utillog.Sanitize(r.URL.String()))
 			resp := scenarioResponse(sc)
 			resp.Request = r // createPollingTracker dispatches on resp.Request.Method; nil → panic
 			return resp, nil

--- a/pkg/util/azureclient/roundtripper.go
+++ b/pkg/util/azureclient/roundtripper.go
@@ -101,7 +101,7 @@ func updateCorrelationDataAndEnrichLogWithRequest(correlationData *api.Correlati
 
 	l = utillog.EnrichWithCorrelationData(l, correlationData)
 	l = l.WithFields(logrus.Fields{
-		"request_URL": req.URL.Host,
+		"request_URL": utillog.Sanitize(req.URL.Host),
 		"LOGKIND":     outboundRequests,
 	})
 
@@ -146,8 +146,8 @@ func logOutboundFailureIfNeeded(correlationData *api.CorrelationData, req *http.
 
 	l := utillog.EnrichWithCorrelationData(utillog.GetLogger(), correlationData)
 	l = l.WithFields(logrus.Fields{
-		"request_host":   req.URL.Host,
-		"request_method": req.Method,
+		"request_host":   utillog.Sanitize(req.URL.Host),
+		"request_method": utillog.Sanitize(req.Method),
 		responseCode:     statusCode,
 	})
 

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -69,6 +69,12 @@ func getBaseLogger() *logrus.Logger {
 
 	logger.AddHook(&logrHook{})
 
+	// Sanitize user-controlled content out of every entry before any emitting
+	// hook (e.g. journald) runs, to guard against CRLF log injection.  This is
+	// a global backstop; call sites should still sanitize with Sanitize() so
+	// that static analysis can see the barrier.
+	logger.AddHook(&sanitizeHook{})
+
 	return logger
 }
 
@@ -137,14 +143,14 @@ func EnrichWithPath(log *logrus.Entry, path string) *logrus.Entry {
 
 	fields := logrus.Fields{}
 	if m[1] != "" {
-		fields["subscription_id"] = m[1]
+		fields["subscription_id"] = Sanitize(m[1])
 	}
 	if m[2] != "" {
-		fields["resource_group"] = m[2]
+		fields["resource_group"] = Sanitize(m[2])
 	}
 	if m[5] != "" {
-		fields["resource_name"] = m[5]
-		fields["resource_id"] = "/subscriptions/" + m[1] + "/resourcegroups/" + m[2] + "/providers/" + m[3] + "/" + m[4] + "/" + m[5]
+		fields["resource_name"] = Sanitize(m[5])
+		fields["resource_id"] = Sanitize("/subscriptions/" + m[1] + "/resourcegroups/" + m[2] + "/providers/" + m[3] + "/" + m[4] + "/" + m[5])
 	}
 
 	return log.WithFields(fields)
@@ -162,11 +168,11 @@ func EnrichWithCorrelationData(log *logrus.Entry, correlationData *api.Correlati
 	}
 
 	return log.WithFields(logrus.Fields{
-		"correlation_id":        correlationData.CorrelationID,
-		"client_request_id":     correlationData.ClientRequestID,
-		"operation_id":          correlationData.OperationID,
-		"request_id":            correlationData.RequestID,
-		"client_principal_name": correlationData.ClientPrincipalName,
+		"correlation_id":        Sanitize(correlationData.CorrelationID),
+		"client_request_id":     Sanitize(correlationData.ClientRequestID),
+		"operation_id":          Sanitize(correlationData.OperationID),
+		"request_id":            Sanitize(correlationData.RequestID),
+		"client_principal_name": Sanitize(correlationData.ClientPrincipalName),
 		"request_time":          correlationData.RequestTime,
 	})
 }

--- a/pkg/util/log/sanitize.go
+++ b/pkg/util/log/sanitize.go
@@ -1,0 +1,66 @@
+package log
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+// Sanitize strips characters from a string that could be used to forge or
+// corrupt log entries when the string originates from user-controlled input
+// (CRLF log injection).  Carriage returns and line feeds are removed first --
+// these are the characters used to inject fake log lines, and removing them
+// explicitly is also recognised by static analysis as a log-injection
+// sanitizer barrier.  Any remaining ASCII control characters (except tab) are
+// stripped as well, since terminals and log viewers can interpret them to
+// spoof output.
+func Sanitize(s string) string {
+	s = strings.ReplaceAll(s, "\r", "")
+	s = strings.ReplaceAll(s, "\n", "")
+
+	return strings.Map(func(r rune) rune {
+		if r == '\t' {
+			return r
+		}
+		if r < 0x20 || r == 0x7f {
+			return -1
+		}
+		return r
+	}, s)
+}
+
+// sanitizeHook is a logrus hook that sanitizes the message and any string
+// valued fields of every log entry.  It provides defence-in-depth against log
+// injection for all log call sites -- including generated code that we cannot
+// annotate directly -- by running before the emitting hooks.
+type sanitizeHook struct{}
+
+func (sanitizeHook) Levels() []logrus.Level {
+	return logrus.AllLevels
+}
+
+func (sanitizeHook) Fire(entry *logrus.Entry) error {
+	entry.Message = Sanitize(entry.Message)
+
+	for k, v := range entry.Data {
+		switch v := v.(type) {
+		case string:
+			entry.Data[k] = Sanitize(v)
+		case error:
+			// logrus patterns such as WithError(err) store an error value;
+			// downstream hooks (e.g. journald) serialise it via fmt.Sprint, so
+			// an error message containing CR/LF could still forge log lines.
+			//
+			// n.b. we deliberately do not sanitize fmt.Stringer values here:
+			// this hook runs before the audit PayloadHook, which type-asserts
+			// its typed struct fields, and converting them to strings would
+			// silently break audit emission.
+			entry.Data[k] = Sanitize(v.Error())
+		}
+	}
+
+	return nil
+}

--- a/pkg/util/log/sanitize_test.go
+++ b/pkg/util/log/sanitize_test.go
@@ -1,0 +1,108 @@
+package log
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestSanitize(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "plain string is unchanged",
+			in:   "hello world",
+			want: "hello world",
+		},
+		{
+			name: "newlines are stripped",
+			in:   "line one\nline two",
+			want: "line oneline two",
+		},
+		{
+			name: "carriage returns are stripped",
+			in:   "line one\r\nline two",
+			want: "line oneline two",
+		},
+		{
+			name: "forged log line is neutralised",
+			in:   "value\ntime=\"2024-01-01\" level=error msg=\"spoofed\"",
+			want: "value" + "time=\"2024-01-01\" level=error msg=\"spoofed\"",
+		},
+		{
+			name: "other control characters are stripped",
+			in:   "a\x00b\x1bc\x7fd",
+			want: "abcd",
+		},
+		{
+			name: "tab is preserved",
+			in:   "a\tb",
+			want: "a\tb",
+		},
+		{
+			name: "unicode is preserved",
+			in:   "café ☃",
+			want: "café ☃",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Sanitize(tt.in); got != tt.want {
+				t.Errorf("Sanitize(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSanitizeHook(t *testing.T) {
+	var buf bytes.Buffer
+
+	logger := logrus.New()
+	logger.SetFormatter(&logrus.TextFormatter{DisableTimestamp: true})
+	logger.SetOutput(&buf)
+	logger.AddHook(&sanitizeHook{})
+
+	logger.WithField("field", "injected\nfield").Info("injected\nmessage")
+
+	out := buf.String()
+	if bytes.Contains([]byte(out), []byte("injected\nmessage")) {
+		t.Errorf("hook did not sanitize message: %q", out)
+	}
+	if bytes.Contains([]byte(out), []byte("injected\nfield")) {
+		t.Errorf("hook did not sanitize field: %q", out)
+	}
+	if !bytes.Contains([]byte(out), []byte("injectedmessage")) {
+		t.Errorf("sanitized message missing from output: %q", out)
+	}
+	if !bytes.Contains([]byte(out), []byte("injectedfield")) {
+		t.Errorf("sanitized field missing from output: %q", out)
+	}
+}
+
+func TestSanitizeHookErrorField(t *testing.T) {
+	var buf bytes.Buffer
+
+	logger := logrus.New()
+	logger.SetFormatter(&logrus.TextFormatter{DisableTimestamp: true})
+	logger.SetOutput(&buf)
+	logger.AddHook(&sanitizeHook{})
+
+	// WithError stores an error-typed field; a CR/LF in its message must not
+	// survive to the emitted log line.
+	logger.WithError(errors.New("injected\nerror")).Info("boom")
+
+	out := buf.String()
+	if bytes.Contains([]byte(out), []byte("injected\nerror")) {
+		t.Errorf("hook did not sanitize error field: %q", out)
+	}
+	if !bytes.Contains([]byte(out), []byte("injectederror")) {
+		t.Errorf("sanitized error field missing from output: %q", out)
+	}
+}


### PR DESCRIPTION
Fix case-sensitive HTTP header comparison in async operation result

Use canonicalized http.Header accessors (Get/Set) instead of direct map
indexing for the Referer/Location headers. Direct map access bypasses
Go's header key canonicalization and is case-sensitive, which CodeQL
flags (go/case-sensitive-headers).

---

Sanitize user-controlled input in log entries

Guards against CRLF log injection (go/log-injection) where user-influenced
values (request paths, methods, headers, resource IDs, error messages,
etc.) are written to log entries.

- Add log.Sanitize(): strips CR/LF and other ASCII control characters
  (except tab). Removing the newline characters explicitly is also
  recognised by static analysis as a log-injection sanitizer barrier.
- Add a global sanitizeHook on the base logger that sanitizes every
  entry's message and string fields before the emitting hooks run. This
  provides defence-in-depth for all call sites, including generated code
  (e.g. pkg/database/cosmosdb) that cannot be annotated directly.
- Wrap user-influenced values with log.Sanitize() at the reported sinks so
  the barrier is visible to static analysis.

---

Harden HTTP responses against reflected XSS

Set X-Content-Type-Options: nosniff on all RP frontend and admin portal
responses via the logging middleware, preventing browsers from
MIME-sniffing responses into HTML (go/reflected-xss).

The gateway recorder finding is a false positive: its buffer holds raw
TLS bytes captured for SNI inspection and is never written to an HTTP
response. Documented inline; it should be dismissed as a false positive
in the CodeQL portal.

Signed-off-by: Steve Kuznetsov <stekuznetsov@microsoft.com>

---

