### PR TITLE
ARO-29185 Increase retry window for platform workload identity RBAC propagation

### DIFF
--- a/pkg/cluster/platformworkloadidentities.go
+++ b/pkg/cluster/platformworkloadidentities.go
@@ -50,7 +50,7 @@ func (m *manager) platformWorkloadIdentityIDs(ctx context.Context) error {
 			var getErr error
 			identityDetails, getErr = m.userAssignedIdentities.Get(ctx, resourceId.ResourceGroupName, resourceId.Name, &armmsi.UserAssignedIdentitiesClientGetOptions{})
 			return getErr
-		}, m.log, fmt.Sprintf("fetching platform workload identity '%s'", operatorName))
+		}, m.log, fmt.Sprintf("fetching platform workload identity '%s'", operatorName), &utilarm.RetryOptions{Steps: 12})
 		if err != nil {
 			if azureerrors.IsStatusUnauthorizedError(err) || azureerrors.IsStatusForbiddenError(err) || azureerrors.IsStatusNotFoundError(err) || azureerrors.IsRetryableError(err) {
 				return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidPlatformWorkloadIdentity, fmt.Sprintf(`.properties.platformWorkloadIdentityProfile.platformWorkloadIdentities["%s"]`, operatorName), err.Error())

--- a/pkg/cluster/platformworkloadidentities_test.go
+++ b/pkg/cluster/platformworkloadidentities_test.go
@@ -73,7 +73,7 @@ func TestPlatformWorkloadIdentityIDs(t *testing.T) {
 	// Must not call t.Parallel(); mutates package-level utilarm.TransientBackoff.
 	savedBackoff := utilarm.TransientBackoff
 	utilarm.TransientBackoff = wait.Backoff{
-		Steps:    4,
+		Steps:    12,
 		Duration: 1 * time.Millisecond,
 		Factor:   1.0,
 		Jitter:   0.0,

--- a/pkg/util/arm/retry.go
+++ b/pkg/util/arm/retry.go
@@ -20,6 +20,8 @@ import (
 	utillog "github.com/Azure/ARO-RP/pkg/util/log"
 )
 
+const RBACPropagationRetrySteps = 12
+
 // TransientBackoff is the retry schedule for ARM write operations when no Retry-After
 // header is present. It is a var so tests can override it; tests that mutate it must
 // not call t.Parallel().

--- a/pkg/util/arm/retry.go
+++ b/pkg/util/arm/retry.go
@@ -36,12 +36,20 @@ var TransientBackoff = wait.Backoff{
 // otherwise, TransientBackoff governs the schedule.
 
 func Retryable(ctx context.Context, f func() error, log *logrus.Entry, desc string) error {
-	return RetryableWith(ctx, azureerrors.IsRetryableError, f, log, desc)
+	return RetryableWith(ctx, azureerrors.IsRetryableError, f, log, desc, nil)
+}
+
+// RetryOptions configures optional behavior for RetryableWith.
+type RetryOptions struct {
+	Steps int
 }
 
 // RetryableWith is like Retryable but with a custom error predicate.
-func RetryableWith(ctx context.Context, isRetryable func(error) bool, f func() error, log *logrus.Entry, desc string) error {
+func RetryableWith(ctx context.Context, isRetryable func(error) bool, f func() error, log *logrus.Entry, desc string, opts *RetryOptions) error {
 	b := TransientBackoff
+	if opts != nil && opts.Steps > 0 {
+		b.Steps = opts.Steps
+	}
 	steps := b.Steps
 	var lastErr error
 	for i := 0; i < steps; i++ {


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://redhat.atlassian.net/browse/ARO-29185

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->
The e2e test  should successfully replace platform workload identity  intermittently fails because Azure RBAC propagation for newly assigned Federated Credential roles can take up to 10 minutes ([Microsoft Learn: Troubleshoot Azure RBAC](https://learn.microsoft.com/en-us/azure/role-based-access-control/troubleshooting#symptom---role-assignment-changes-are-not-being-detected)), but  platformWorkloadIdentityIDs  only retried for ~111s (4 steps). This PR adds a  RetryOptions  struct to  RetryableWith  and uses it to increase the retry window to ~585s (12 steps) for platform workload identity lookups, covering the full documented RBAC propagation window.


### Test plan for issue:



- [x] Existing unit tests in  pkg/util/arm/retry_test.go  pass (no signature change for  Retryable  callers — they pass  nil ).
- [x] pkg/cluster/platformworkloadidentities_test.go  updated to match 12-step backoff; retry success/failure/exhaustion cases all pass.
- [ ] Awaiting confirmation via a successful  e2e-stage-e2e-parallel  run
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

No — internal retry behavior change only, no user-facing API or config changes.
<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 

<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
• The retry mechanism logs each attempt with  retry_after  duration, providing visibility into RBAC propagation delays.
• After exhausting all 12 retries (~10 min), the operation still surfaces the original  InvalidPlatformWorkloadIdentity  error to the user — no silent failures.
• Existing callers of  RetryableWith  are unaffected (pass  nil  for options).