### PR TITLE
Retry auth failures for federated identity credential write operations that leverage the cluster MSI

### DIFF
--- a/pkg/cluster/install.go
+++ b/pkg/cluster/install.go
@@ -255,7 +255,7 @@ func (m *manager) Update(ctx context.Context) error {
 			steps.AuthorizationRetryingAction(m.fpAuthorizer, m.clusterIdentityIDs, m.managedResourceGroupName()),
 			steps.AuthorizationRetryingAction(m.fpAuthorizer, m.persistPlatformWorkloadIdentityIDs, m.managedResourceGroupName()),
 			steps.Action(m.ensurePlatformWorkloadIdentityRBAC),
-			steps.Action(m.federateIdentityCredentials),
+			steps.AuthorizationRetryingAction(nil, m.federateIdentityCredentials, m.managedResourceGroupName()),
 		)
 	} else {
 		s = append(s,
@@ -425,7 +425,7 @@ func (m *manager) bootstrap() []steps.Step {
 
 	if m.doc.OpenShiftCluster.UsesWorkloadIdentity() {
 		s = append(s,
-			steps.Action(m.federateIdentityCredentials),
+			steps.AuthorizationRetryingAction(nil, m.federateIdentityCredentials, m.managedResourceGroupName()),
 		)
 	}
 

--- a/pkg/util/azureerrors/error.go
+++ b/pkg/util/azureerrors/error.go
@@ -20,6 +20,9 @@ import (
 // transientConflictBody is the ARM body text for transient 409s; undocumented, observed in production.
 const transientConflictBody = "Please retry later"
 
+// federatedIdentityCredentialWrite is the ARM action for writing federated identity credentials.
+const federatedIdentityCredentialWrite = "Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials/write"
+
 const (
 	CODE_AUTHFAILED       = "AuthorizationFailed"
 	CODE_DEPLOYACTIVE     = "DeploymentActive"
@@ -205,6 +208,12 @@ func IsUnauthorizedClientError(err error) bool {
 // See https://learn.microsoft.com/en-us/entra/identity-platform/reference-error-codes#aadsts-error-codes
 func IsClientSecretKeysExpired(err error) bool {
 	return strings.Contains(err.Error(), "AADSTS7000222")
+}
+
+// IsFederatedIdentityCredentialWriteForbiddenError returns true if the error is a 403 Forbidden error
+// that occurred during an attempt to write a federated identity credential.
+func IsFederatedIdentityCredentialWriteForbiddenError(err error) bool {
+	return strings.Contains(err.Error(), "does not have authorization to perform action '"+federatedIdentityCredentialWrite+"'")
 }
 
 // ResourceGroupNotFound returns true if the error is an ResourceGroupNotFound error

--- a/pkg/util/azureerrors/error_test.go
+++ b/pkg/util/azureerrors/error_test.go
@@ -524,6 +524,35 @@ func TestIsStatusForbiddenError(t *testing.T) {
 	}
 }
 
+func TestIsFederatedIdentityCredentialWriteForbiddenError(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "federated identity credential write is forbidden",
+			err:  errors.New("the client does not have authorization to perform action 'Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials/write' over the requested scope"),
+			want: true,
+		},
+		{
+			name: "different action is forbidden",
+			err:  errors.New("the client does not have authorization to perform action 'Microsoft.ManagedIdentity/userAssignedIdentities/read' over the requested scope"),
+		},
+		{
+			name: "unrelated error",
+			err:  errors.New("something happened"),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsFederatedIdentityCredentialWriteForbiddenError(tt.err)
+			if got != tt.want {
+				t.Errorf("IsFederatedIdentityCredentialWriteForbiddenError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestIsRetryableError(t *testing.T) {
 	for _, tt := range []struct {
 		name string

--- a/pkg/util/steps/refreshing.go
+++ b/pkg/util/steps/refreshing.go
@@ -88,7 +88,8 @@ func (s *authorizationRefreshingActionStep) run(ctx context.Context, log *logrus
 				err == ErrWantRefresh) {
 			log.Printf("auth error, retrying: %v", err)
 			if s.auth != nil {
-				return false, s.auth.Rebuild()
+				err = s.auth.Rebuild()
+				return false, err
 			}
 			return false, nil
 		}

--- a/pkg/util/steps/refreshing.go
+++ b/pkg/util/steps/refreshing.go
@@ -23,10 +23,10 @@ import (
 
 var ErrWantRefresh = errors.New("want refresh")
 
-// AuthorizationRefreshingAction returns a wrapper Step which will refresh
-// `authorizer` if the step returns an Azure AuthenticationError and rerun it.
-// The step will be retried until `retryTimeout` is hit. Any other error will be
-// returned directly.
+// AuthorizationRetryingAction returns a wrapper Step which retries Azure
+// authorization errors until retryTimeout is hit. If authorizer is non-nil, it
+// is rebuilt before each retry; a nil authorizer enables retry-only behavior.
+// Any other error is returned directly.
 func AuthorizationRetryingAction(r refreshable.Authorizer, action actionFunction, managedRGName string) Step {
 	return &authorizationRefreshingActionStep{
 		auth:          r,
@@ -76,19 +76,21 @@ func (s *authorizationRefreshingActionStep) run(ctx context.Context, log *logrus
 		err = s.f(ctx)
 
 		// If we haven't timed out and there is an error that is either an
-		// unauthorized client (AADSTS700016) or "AuthorizationFailed" (likely
-		// role propagation delay) then refresh and retry.
+		// unauthorized client (AADSTS700016), HTTP 403, or
+		// "AuthorizationFailed" (likely role propagation delay) then retry.
 		if timeoutCtx.Err() == nil && err != nil &&
 			(azureerrors.IsUnauthorizedClientError(err) ||
+				azureerrors.IsStatusForbiddenError(err) ||
 				azureerrors.HasAuthorizationFailedError(err) ||
 				azureerrors.HasLinkedAuthorizationFailedError(err) ||
 				azureerrors.IsInvalidSecretError(err) ||
 				azureerrors.IsDeploymentMissingPermissionsError(err) ||
 				err == ErrWantRefresh) {
-			log.Printf("auth error, refreshing and retrying: %v", err)
-			// Try refreshing auth.
-			err = s.auth.Rebuild()
-			return false, err // retry step
+			log.Printf("auth error, retrying: %v", err)
+			if s.auth != nil {
+				return false, s.auth.Rebuild()
+			}
+			return false, nil
 		}
 		if err != nil {
 			log.Printf("non-auth error, giving up: %v", err)
@@ -96,6 +98,9 @@ func (s *authorizationRefreshingActionStep) run(ctx context.Context, log *logrus
 		return true, err
 	}, timeoutCtx.Done())
 
+	if s.auth == nil {
+		return err
+	}
 	return CreateActionableError(err, s.managedRGName)
 }
 

--- a/pkg/util/steps/refreshing_test.go
+++ b/pkg/util/steps/refreshing_test.go
@@ -14,7 +14,9 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
 
@@ -294,4 +296,41 @@ func TestAuthorizationRefreshingActionRetries(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAuthorizationRetryingActionWithoutAuthorizerRetriesForbidden(t *testing.T) {
+	callCount := 0
+	action := func(ctx context.Context) error {
+		callCount++
+		if callCount == 1 {
+			return &azcore.ResponseError{StatusCode: http.StatusForbidden}
+		}
+		return nil
+	}
+
+	s := &authorizationRefreshingActionStep{
+		f:            action,
+		retryTimeout: 30 * time.Second,
+		pollInterval: time.Millisecond,
+	}
+
+	err := s.run(context.Background(), logrus.NewEntry(logrus.StandardLogger()))
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, callCount)
+}
+
+func TestAuthorizationRetryingActionWithoutAuthorizerReturnsLastError(t *testing.T) {
+	wantErr := &azcore.ResponseError{StatusCode: http.StatusForbidden}
+	s := &authorizationRefreshingActionStep{
+		f: func(ctx context.Context) error {
+			return wantErr
+		},
+		retryTimeout: time.Millisecond,
+		pollInterval: 30 * time.Second,
+	}
+
+	err := s.run(context.Background(), logrus.NewEntry(logrus.StandardLogger()))
+
+	assert.Same(t, wantErr, err)
 }

--- a/pkg/util/steps/runner.go
+++ b/pkg/util/steps/runner.go
@@ -73,6 +73,17 @@ func Run(ctx context.Context, log *logrus.Entry, pollInterval time.Duration, ste
 					api.CloudErrorCodeInternalServerError,
 					"encountered error",
 					err.Error())
+			} else if azureerrors.IsFederatedIdentityCredentialWriteForbiddenError(err) {
+				// Dynamic validation should theoretically catch this before we get here. In practice we found
+				// it didn't. Federated identity credential write calls are currently the only post-validation
+				// API calls that use the cluster MSI - if there are ever more, this branch needs to be extended
+				// to handle them. If we were to fail to extend this check, the customer would end up seeing an
+				// "InvalidServicePrincipalCredentials" error instead (see next branch below), which would be incorrect.
+				err = api.NewCloudError(
+					http.StatusBadRequest,
+					api.CloudErrorCodeInvalidClusterMSIPermissions,
+					"encountered error",
+					err.Error())
 			} else if azureerrors.IsUnauthorizedClientError(err) ||
 				azureerrors.IsInvalidSecretError(err) ||
 				azureerrors.HasAuthorizationFailedError(err) {

--- a/pkg/util/steps/runner_test.go
+++ b/pkg/util/steps/runner_test.go
@@ -28,6 +28,10 @@ func failingAzureError(context.Context) error {
 	return errors.New("Status=403 Code=\"AuthorizationFailed\"")
 }
 
+func failingFederatedIdentityCredentialWrite(context.Context) error {
+	return errors.New("the client does not have authorization to perform action 'Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials/write' over the requested scope")
+}
+
 func failingODataError(context.Context) error {
 	mainError := odataerrors.NewMainError()
 	mainError.SetCode(pointerutils.ToPtr("Authorization_IdentityNotFound"))
@@ -106,6 +110,25 @@ func TestStepRunner(t *testing.T) {
 				},
 			},
 			wantErr: "Status=403 Code=\"AuthorizationFailed\"",
+		},
+		{
+			name: "A forbidden federated identity credential write returns a cluster MSI permissions error",
+			steps: func(controller *gomock.Controller) []Step {
+				return []Step{
+					Action(failingFederatedIdentityCredentialWrite),
+				}
+			},
+			wantEntries: []testlog.ExpectedLogEntry{
+				{
+					"msg":   gomega.Equal("running step [Action pkg/util/steps.failingFederatedIdentityCredentialWrite]"),
+					"level": gomega.Equal(logrus.InfoLevel),
+				},
+				{
+					"msg":   gomega.Equal("step [Action pkg/util/steps.failingFederatedIdentityCredentialWrite] encountered error: 400: InvalidClusterMSIPermissions: encountered error: the client does not have authorization to perform action 'Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials/write' over the requested scope"),
+					"level": gomega.Equal(logrus.ErrorLevel),
+				},
+			},
+			wantErr: "400: InvalidClusterMSIPermissions: encountered error: the client does not have authorization to perform action 'Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials/write' over the requested scope",
 		},
 		{
 			name: "An odata error will fail the run",


### PR DESCRIPTION
### Which issue this PR addresses:

https://redhat.atlassian.net/browse/ARO-29265

### What this PR does / why we need it:

- Ensure we retry federated identity credential write operations to account for role assignment propagation delays (dynamic validation/CheckAccess don't seem to always save us from them)
- If the error persists after retries, ensure it is correctly categorized as a cluster MSI permission error rather than an SP permission error

### Test plan for issue:

Unit tests and E2E

### Is there any documentation that needs to be updated for this PR?

N/A

### How do you know this will function as expected in production? 

Prod E2E will stop being such a pain 😄 🥲 