### PR TITLE
[ARO-29276] Add the zones param to the admin API and fix podman pulling

### DIFF
--- a/pkg/api/admin/openshiftcluster.go
+++ b/pkg/api/admin/openshiftcluster.go
@@ -38,6 +38,7 @@ type OpenShiftClusterProperties struct {
 	MaintenanceTask                 MaintenanceTask                  `json:"maintenanceTask,omitempty" mutable:"true"`
 	OperatorFlags                   OperatorFlags                    `json:"operatorFlags,omitempty" mutable:"true"`
 	OperatorVersion                 string                           `json:"operatorVersion,omitempty" mutable:"true"`
+	Zones                           []string                         `json:"zones,omitempty"`
 	CreatedAt                       time.Time                        `json:"createdAt,omitempty"`
 	CreatedBy                       string                           `json:"createdBy,omitempty"`
 	ProvisionedBy                   string                           `json:"provisionedBy,omitempty"`

--- a/pkg/api/admin/openshiftcluster_convert.go
+++ b/pkg/api/admin/openshiftcluster_convert.go
@@ -29,6 +29,7 @@ func (c openShiftClusterConverter) ToExternal(oc *api.OpenShiftCluster) interfac
 			MaintenanceTask:         MaintenanceTask(oc.Properties.MaintenanceTask),
 			OperatorFlags:           OperatorFlags(oc.Properties.OperatorFlags),
 			OperatorVersion:         oc.Properties.OperatorVersion,
+			Zones:                   oc.Properties.Zones,
 			CreatedAt:               oc.Properties.CreatedAt,
 			CreatedBy:               oc.Properties.CreatedBy,
 			ProvisionedBy:           oc.Properties.ProvisionedBy,
@@ -287,6 +288,7 @@ func (c openShiftClusterConverter) ToInternal(_oc interface{}, out *api.OpenShif
 	out.Properties.MaintenanceTask = api.MaintenanceTask(oc.Properties.MaintenanceTask)
 	out.Properties.OperatorFlags = api.OperatorFlags(oc.Properties.OperatorFlags)
 	out.Properties.OperatorVersion = oc.Properties.OperatorVersion
+	out.Properties.Zones = oc.Properties.Zones
 	out.Properties.CreatedBy = oc.Properties.CreatedBy
 	out.Properties.ProvisionedBy = oc.Properties.ProvisionedBy
 	out.Properties.MaintenanceState = api.MaintenanceState(oc.Properties.MaintenanceState)

--- a/pkg/containerinstall/install.go
+++ b/pkg/containerinstall/install.go
@@ -53,25 +53,26 @@ func (m *manager) Install(ctx context.Context, sub *api.SubscriptionDocument, do
 		pullPolicy = "always"
 	}
 
-	domain, _, ok := strings.Cut(version.Properties.InstallerPullspec, "/")
-	if !ok {
-		return fmt.Errorf("failed to get domain from %s", version.Properties.InstallerPullspec)
-	}
-	pullSecret, ok := m.pullSecrets[domain]
-	if !ok {
-		return fmt.Errorf("failed to get pullSecret for domain %s", domain)
+	options := (&images.PullOptions{}).
+		WithQuiet(true).
+		WithPolicy(pullPolicy).
+		WithArch("amd64").
+		WithOS("linux")
+
+	if pullPolicy != "never" {
+		domain, _, ok := strings.Cut(version.Properties.InstallerPullspec, "/")
+		if !ok {
+			return fmt.Errorf("failed to get domain from %s", version.Properties.InstallerPullspec)
+		}
+		pullSecret, ok := m.pullSecrets[domain]
+		if !ok {
+			return fmt.Errorf("failed to get pullSecret for domain %s", domain)
+		}
+		options = options.WithUsername(pullSecret.Username).WithPassword(pullSecret.Password)
 	}
 
 	s := []steps.Step{
 		steps.Action(func(context.Context) error {
-			options := (&images.PullOptions{}).
-				WithQuiet(true).
-				WithPolicy(pullPolicy).
-				WithUsername(pullSecret.Username).
-				WithPassword(pullSecret.Password).
-				WithArch("amd64").
-				WithOS("linux")
-
 			_, err := images.Pull(m.conn, version.Properties.InstallerPullspec, options)
 			return err
 		}),


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes part of [ARO-29276](https://redhat.atlassian.net/browse/ARO-29276)

### What this PR does / why we need it:

Exposes the Zones param in the admin API so it can be seen. This gets populated on cluster installs and when the LBs are migrated.

Also fixes podman pulls for locally built images.

### Test plan for issue:

Tested in local dev

### Is there any documentation that needs to be updated for this PR?

N/A

### How do you know this will function as expected in production? 
N/A
