### PR TITLE
[ARO-29319] Defer document encryption key rotation until a re-seal path exists

### DIFF
--- a/pkg/deploy/predeploy.go
+++ b/pkg/deploy/predeploy.go
@@ -335,10 +335,9 @@ func (d *deployer) deployPreDeploy(ctx context.Context, resourceGroupName, deplo
 }
 
 func (d *deployer) configureServiceSecrets(ctx context.Context, lbHealthcheckWaitTimeSec int) error {
-	// aro-portal is the only service holding the portal session key, and that key
-	// is the only one here still rotated, so it alone decides whether the restart
-	// below runs.
-	portalKeyRotated, err := d.ensureAndRotateSecret(ctx, d.portalKeyvault, env.PortalServerSessionKeySecretName, 32)
+	// True when a new version was written, whether by rotation or because the
+	// secret was absent. Either way aro-portal must be restarted to see it.
+	portalKeyVersionCreated, err := d.ensureAndRotateSecret(ctx, d.portalKeyvault, env.PortalServerSessionKeySecretName, 32)
 	if err != nil {
 		return err
 	}
@@ -362,16 +361,19 @@ func (d *deployer) configureServiceSecrets(ctx context.Context, lbHealthcheckWai
 		}
 	}
 
+	// The SSH host key is created if absent and then left alone: ensureSecretKey
+	// returns on finding any version, with no age check, so this code never
+	// supersedes a version a running service already holds. Creation therefore
+	// means initial rollout, where there are no old scale sets to sweep. A
+	// manual delete and purge would also reach it, and would need the readers
+	// restarted by hand. The result is deliberately unused.
 	_, err = d.ensureSecretKey(ctx, d.portalKeyvault, env.PortalServerSSHKeySecretName)
 	if err != nil {
 		return err
 	}
 
-	if portalKeyRotated {
-		err = d.restartOldScalesets(ctx, lbHealthcheckWaitTimeSec)
-		if err != nil {
-			return err
-		}
+	if portalKeyVersionCreated {
+		return d.restartOldScalesets(ctx, lbHealthcheckWaitTimeSec)
 	}
 	return nil
 }

--- a/pkg/deploy/predeploy.go
+++ b/pkg/deploy/predeploy.go
@@ -38,7 +38,8 @@ const (
 	rotateSecretAfter = time.Hour * 24 * 7
 	// A service reads its secrets once at start-up, so restarting it is how it
 	// picks up a rotated one. The portal session key is the only secret still
-	// rotated, and aro-portal is the only service that holds it.
+	// rotated via the predeploy process, and aro-portal is the only service
+	// that holds it.
 	portalRestartScript = "systemctl restart aro-portal"
 )
 
@@ -337,7 +338,7 @@ func (d *deployer) deployPreDeploy(ctx context.Context, resourceGroupName, deplo
 func (d *deployer) configureServiceSecrets(ctx context.Context, lbHealthcheckWaitTimeSec int) error {
 	// True when a new version was written, whether by rotation or because the
 	// secret was absent. Either way aro-portal must be restarted to see it.
-	portalKeyVersionCreated, err := d.ensureAndRotateSecret(ctx, d.portalKeyvault, env.PortalServerSessionKeySecretName, 32)
+	portalKeyCreatedOrRotated, err := d.ensureAndRotateSecret(ctx, d.portalKeyvault, env.PortalServerSessionKeySecretName, 32)
 	if err != nil {
 		return err
 	}
@@ -372,7 +373,7 @@ func (d *deployer) configureServiceSecrets(ctx context.Context, lbHealthcheckWai
 		return err
 	}
 
-	if portalKeyVersionCreated {
+	if portalKeyCreatedOrRotated {
 		return d.restartOldScalesets(ctx, lbHealthcheckWaitTimeSec)
 	}
 	return nil

--- a/pkg/deploy/predeploy.go
+++ b/pkg/deploy/predeploy.go
@@ -36,7 +36,10 @@ const (
 	// Rotate the secret on every deploy of the RP if the most recent
 	// secret is greater than 7 days old
 	rotateSecretAfter = time.Hour * 24 * 7
-	rpRestartScript   = "systemctl restart aro-monitor; systemctl restart aro-portal; systemctl restart aro-rp"
+	// A service reads its secrets once at start-up, so restarting it is how it
+	// picks up a rotated one. The portal session key is the only secret still
+	// rotated, and aro-portal is the only service that holds it.
+	portalRestartScript = "systemctl restart aro-portal"
 )
 
 // PreDeploy deploys managed identity, NSGs and keyvaults, needed for main
@@ -332,7 +335,17 @@ func (d *deployer) deployPreDeploy(ctx context.Context, resourceGroupName, deplo
 }
 
 func (d *deployer) configureServiceSecrets(ctx context.Context, lbHealthcheckWaitTimeSec int) error {
-	isRotated := false
+	// aro-portal is the only service holding the portal session key, and that key
+	// is the only one here still rotated, so it alone decides whether the restart
+	// below runs.
+	portalKeyRotated, err := d.ensureAndRotateSecret(ctx, d.portalKeyvault, env.PortalServerSessionKeySecretName, 32)
+	if err != nil {
+		return err
+	}
+
+	// Created if absent and then left alone. Rotating them would require every
+	// service holding a key to be restarted in step, which is not worth doing
+	// until existing documents can be re-sealed and superseded versions retired.
 	for _, s := range []struct {
 		kv         azsecrets.Client
 		secretName string
@@ -340,38 +353,21 @@ func (d *deployer) configureServiceSecrets(ctx context.Context, lbHealthcheckWai
 	}{
 		{d.serviceKeyvault, env.EncryptionSecretV2Name, 64},
 		{d.serviceKeyvault, env.FrontendEncryptionSecretV2Name, 64},
-		{d.portalKeyvault, env.PortalServerSessionKeySecretName, 32},
-	} {
-		isNew, err := d.ensureAndRotateSecret(ctx, s.kv, s.secretName, s.len)
-		isRotated = isNew || isRotated
-		if err != nil {
-			return err
-		}
-	}
-
-	// don't rotate legacy secrets
-	for _, s := range []struct {
-		kv         azsecrets.Client
-		secretName string
-		len        int
-	}{
 		{d.serviceKeyvault, env.EncryptionSecretName, 32},
 		{d.serviceKeyvault, env.FrontendEncryptionSecretName, 32},
 	} {
-		isNew, err := d.ensureSecret(ctx, s.kv, s.secretName, s.len)
-		isRotated = isNew || isRotated
+		_, err := d.ensureSecret(ctx, s.kv, s.secretName, s.len)
 		if err != nil {
 			return err
 		}
 	}
 
-	isNew, err := d.ensureSecretKey(ctx, d.portalKeyvault, env.PortalServerSSHKeySecretName)
-	isRotated = isNew || isRotated
+	_, err = d.ensureSecretKey(ctx, d.portalKeyvault, env.PortalServerSSHKeySecretName)
 	if err != nil {
 		return err
 	}
 
-	if isRotated {
+	if portalKeyRotated {
 		err = d.restartOldScalesets(ctx, lbHealthcheckWaitTimeSec)
 		if err != nil {
 			return err
@@ -512,7 +508,7 @@ func (d *deployer) restartOldScaleset(ctx context.Context, vmssName string, lbHe
 		d.log.Printf("waiting for restart script to complete on older rp vmss %s, instance %s", vmssName, *vm.InstanceID)
 		err = d.vmssvms.RunCommandAndWait(ctx, d.config.RPResourceGroupName, vmssName, *vm.InstanceID, mgmtcompute.RunCommandInput{
 			CommandID: pointerutils.ToPtr("RunShellScript"),
-			Script:    &[]string{rpRestartScript},
+			Script:    &[]string{portalRestartScript},
 		})
 		if err != nil {
 			return err

--- a/pkg/deploy/predeploy_test.go
+++ b/pkg/deploy/predeploy_test.go
@@ -117,6 +117,10 @@ func TestPreDeploy(t *testing.T) {
 	}
 	deployment := mgmtfeatures.DeploymentExtended{}
 	vmsss := []mgmtcompute.VirtualMachineScaleSet{{Name: &vmssName}}
+	// The secrets the vault already holds. The one absent from this list is the
+	// one the run creates, so listing every secret except the portal session key
+	// is what exercises the create-and-restart path: that key is now the only
+	// secret whose creation or rotation restarts anything.
 	oneMissingSecrets := []string{env.EncryptionSecretV2Name, env.FrontendEncryptionSecretV2Name, env.EncryptionSecretName, env.FrontendEncryptionSecretName, env.PortalServerSSHKeySecretName}
 	oneMissingSecretItems := []*azsecretssdk.SecretProperties{}
 	for _, secret := range oneMissingSecrets {
@@ -970,6 +974,10 @@ func TestRestartScriptRestartsOnlyHoldersOfARotatedSecret(t *testing.T) {
 
 func TestConfigureServiceSecrets(t *testing.T) {
 	ctx := context.Background()
+	// The secrets the vault already holds. The one absent from this list is the
+	// one the run creates, so listing every secret except the portal session key
+	// is what exercises the create-and-restart path: that key is now the only
+	// secret whose creation or rotation restarts anything.
 	oneMissingSecrets := []string{env.EncryptionSecretV2Name, env.FrontendEncryptionSecretV2Name, env.EncryptionSecretName, env.FrontendEncryptionSecretName, env.PortalServerSSHKeySecretName}
 	oneMissingSecretItems := []*azsecretssdk.SecretProperties{}
 	for _, secret := range oneMissingSecrets {

--- a/pkg/deploy/predeploy_test.go
+++ b/pkg/deploy/predeploy_test.go
@@ -6,6 +6,7 @@ package deploy
 import (
 	"context"
 	"errors"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -911,27 +912,58 @@ func TestDeployPreDeploy(t *testing.T) {
 	}
 }
 
-// A service belongs in portalRestartScript only if it holds a secret PreDeploy
-// rotates: each builds its key list once at start-up and never refreshes it, so
-// a restart is the only way it sees a new version. The portal session key is the
-// only rotated secret, and aro-portal the only service holding it.
+// A service belongs in the restart script only if it holds the secret that
+// script answers for: each service builds its key list once at start-up and
+// never refreshes it, so a restart is the only way it sees a new version. Every
+// other service must stay out, because each reads from Cosmos at start-up and
+// restarting them serially across a scale set is expensive.
 //
-// The services below must stay out. None holds a rotated secret, and each reads
-// from Cosmos at start-up, so restarting them serially across a scale set costs
-// time for nothing.
+// This pins the script against a hand-maintained list of holders. It fails on an
+// edit to the script, which is the drift that produced this incident, but it
+// cannot detect a new reader of the secret appearing inside another service.
 func TestRestartScriptRestartsOnlyHoldersOfARotatedSecret(t *testing.T) {
-	if !strings.Contains(portalRestartScript, "aro-portal") {
-		t.Errorf("portalRestartScript does not restart aro-portal, which holds the rotated portal session key: %q", portalRestartScript)
-	}
-
-	for _, unit := range []string{
+	// Every service started with a key vault prefix, per
+	// pkg/deploy/generator/scripts/util-services.sh.
+	keyvaultConsumers := []string{
+		"aro-portal",
 		"aro-rp",
 		"aro-monitor",
 		"aro-mimo-actuator",
 		"aro-mimo-scheduler",
-	} {
-		if strings.Contains(portalRestartScript, unit) {
-			t.Errorf("portalRestartScript restarts %s, which holds no rotated secret: %q", unit, portalRestartScript)
+	}
+
+	// aro-portal is the only service that reads the portal session key
+	// (cmd/aro/portal.go), and that key is the only secret whose rotation drives
+	// the restart.
+	holders := []string{"aro-portal"}
+
+	// Compare whole unit names rather than substrings, so that a future unit
+	// called aro-rp-something cannot satisfy a check for aro-rp.
+	const restartPrefix = "systemctl restart "
+	restarted := []string{}
+	for _, command := range strings.Split(portalRestartScript, ";") {
+		command = strings.TrimSpace(command)
+		if !strings.HasPrefix(command, restartPrefix) {
+			t.Fatalf("script contains a command that is not a unit restart: %q", command)
+		}
+		restarted = append(restarted, strings.TrimPrefix(command, restartPrefix))
+	}
+
+	for _, unit := range restarted {
+		if !slices.Contains(keyvaultConsumers, unit) {
+			t.Errorf("script restarts %s, which is not a known key vault consumer: %q", unit, portalRestartScript)
+		}
+	}
+
+	for _, unit := range keyvaultConsumers {
+		restarts := slices.Contains(restarted, unit)
+		holds := slices.Contains(holders, unit)
+
+		if holds && !restarts {
+			t.Errorf("script does not restart %s, which holds the portal session key: %q", unit, portalRestartScript)
+		}
+		if !holds && restarts {
+			t.Errorf("script restarts %s, which does not hold the portal session key: %q", unit, portalRestartScript)
 		}
 	}
 }
@@ -950,10 +982,17 @@ func TestConfigureServiceSecrets(t *testing.T) {
 	}
 	missingDocumentSecretItems := []*azsecretssdk.SecretProperties{}
 	for _, secret := range allSecrets {
-		if secret == env.EncryptionSecretV2Name {
+		if secret == env.EncryptionSecretV2Name || secret == env.FrontendEncryptionSecretV2Name {
 			continue
 		}
 		missingDocumentSecretItems = append(missingDocumentSecretItems, &azsecretssdk.SecretProperties{ID: pointerutils.ToPtr(azsecretssdk.ID("https://myvaultname.vault.azure.net/keys/" + secret + "/whatever"))})
+	}
+	missingSSHKeyItems := []*azsecretssdk.SecretProperties{}
+	for _, secret := range allSecrets {
+		if secret == env.PortalServerSSHKeySecretName {
+			continue
+		}
+		missingSSHKeyItems = append(missingSSHKeyItems, &azsecretssdk.SecretProperties{ID: pointerutils.ToPtr(azsecretssdk.ID("https://myvaultname.vault.azure.net/keys/" + secret + "/whatever"))})
 	}
 
 	type testParams struct {
@@ -982,11 +1021,13 @@ func TestConfigureServiceSecrets(t *testing.T) {
 	vmssVMsListMock := func(k *mock_azsecrets.MockClient, vmss *mock_compute.MockVirtualMachineScaleSetsClient, vmssvms *mock_compute.MockVirtualMachineScaleSetVMsClient, tp testParams) {
 		vmssvms.EXPECT().List(ctx, tp.resourceGroup, tp.vmssName, "", "", "").Return(vms, nil).AnyTimes()
 	}
+	// Times(1) rather than AnyTimes(): these cases exist to prove the restart
+	// happens, with the script that matches the secret which changed.
 	vmRestartMock := func(k *mock_azsecrets.MockClient, vmss *mock_compute.MockVirtualMachineScaleSetsClient, vmssvms *mock_compute.MockVirtualMachineScaleSetVMsClient, tp testParams) {
 		vmssvms.EXPECT().RunCommandAndWait(ctx, tp.resourceGroup, tp.vmssName, tp.instanceID, mgmtcompute.RunCommandInput{
 			CommandID: pointerutils.ToPtr("RunShellScript"),
 			Script:    &[]string{tp.restartScript},
-		}).Return(nil).AnyTimes()
+		}).Return(nil).Times(1)
 	}
 	instanceViewMock := func(k *mock_azsecrets.MockClient, vmss *mock_compute.MockVirtualMachineScaleSetsClient, vmssvms *mock_compute.MockVirtualMachineScaleSetVMsClient, tp testParams) {
 		vmssvms.EXPECT().GetInstanceView(gomock.Any(), tp.resourceGroup, tp.vmssName, tp.instanceID).Return(healthyVMSS, nil).AnyTimes()
@@ -1034,9 +1075,19 @@ func TestConfigureServiceSecrets(t *testing.T) {
 			},
 		},
 		{
-			name: "return nil without restarting if only a document secret is created",
+			name: "return nil without restarting if only the document secrets are created",
 			mocks: []mock{
-				getSecretsMock(allSecretItems, nil), getSecretMock, getSecretsMock(missingDocumentSecretItems, nil), setSecretMock, getSecretsMock(allSecretItems, nil), getSecretsMock(allSecretItems, nil), getSecretsMock(allSecretItems, nil), getSecretsMock(allSecretItems, nil),
+				getSecretsMock(allSecretItems, nil), getSecretMock, getSecretsMock(missingDocumentSecretItems, nil), setSecretMock, getSecretsMock(missingDocumentSecretItems, nil), setSecretMock, getSecretsMock(allSecretItems, nil), getSecretsMock(allSecretItems, nil), getSecretsMock(allSecretItems, nil),
+			},
+		},
+		{
+			// The SSH host key is created only when absent, so no running
+			// service can be holding a superseded version. gomock fails the
+			// test on any unexpected call, so omitting the restart mocks
+			// asserts that no scale set is swept.
+			name: "return nil without restarting if only the portal SSH host key is created",
+			mocks: []mock{
+				getSecretsMock(allSecretItems, nil), getSecretMock, getSecretsMock(allSecretItems, nil), getSecretsMock(allSecretItems, nil), getSecretsMock(allSecretItems, nil), getSecretsMock(allSecretItems, nil), getSecretsMock(missingSSHKeyItems, nil), setSecretMock,
 			},
 		},
 		{
@@ -1540,7 +1591,7 @@ func TestRestartOldScaleset(t *testing.T) {
 			wantErr: "generic error",
 		},
 		{
-			name: "rp restart script failed",
+			name: "restart script failed",
 			testParams: testParams{
 				resourceGroup: rgName,
 				vmssName:      vmssName,

--- a/pkg/deploy/predeploy_test.go
+++ b/pkg/deploy/predeploy_test.go
@@ -116,7 +116,7 @@ func TestPreDeploy(t *testing.T) {
 	}
 	deployment := mgmtfeatures.DeploymentExtended{}
 	vmsss := []mgmtcompute.VirtualMachineScaleSet{{Name: &vmssName}}
-	oneMissingSecrets := []string{env.FrontendEncryptionSecretV2Name, env.PortalServerSessionKeySecretName, env.EncryptionSecretName, env.FrontendEncryptionSecretName, env.PortalServerSSHKeySecretName}
+	oneMissingSecrets := []string{env.EncryptionSecretV2Name, env.FrontendEncryptionSecretV2Name, env.EncryptionSecretName, env.FrontendEncryptionSecretName, env.PortalServerSSHKeySecretName}
 	oneMissingSecretItems := []*azsecretssdk.SecretProperties{}
 	for _, secret := range oneMissingSecrets {
 		oneMissingSecretItems = append(oneMissingSecretItems, &azsecretssdk.SecretProperties{ID: pointerutils.ToPtr(azsecretssdk.ID("https://myvaultname.vault.azure.net/keys/" + secret + "/whatever"))})
@@ -163,9 +163,6 @@ func TestPreDeploy(t *testing.T) {
 		return func(d *mock_features.MockDeploymentsClient, rg *mock_features.MockResourceGroupsClient, m *mock_msi.MockUserAssignedIdentitiesClient, k *mock_azsecrets.MockClient, vmss *mock_compute.MockVirtualMachineScaleSetsClient, vmssvms *mock_compute.MockVirtualMachineScaleSetVMsClient, tp testParams) {
 			k.EXPECT().NewListSecretPropertiesPager(nil).Return(mock_azuresdk.NewPager(listForItems(items), []error{returnError}))
 		}
-	}
-	getSecretMock := func(d *mock_features.MockDeploymentsClient, rg *mock_features.MockResourceGroupsClient, m *mock_msi.MockUserAssignedIdentitiesClient, k *mock_azsecrets.MockClient, vmss *mock_compute.MockVirtualMachineScaleSetsClient, vmssvms *mock_compute.MockVirtualMachineScaleSetVMsClient, tp testParams) {
-		k.EXPECT().GetSecret(ctx, gomock.Any(), "", nil).Return(newSecretBundle, nil)
 	}
 	setSecretMock := func(d *mock_features.MockDeploymentsClient, rg *mock_features.MockResourceGroupsClient, m *mock_msi.MockUserAssignedIdentitiesClient, k *mock_azsecrets.MockClient, vmss *mock_compute.MockVirtualMachineScaleSetsClient, vmssvms *mock_compute.MockVirtualMachineScaleSetVMsClient, tp testParams) {
 		k.EXPECT().SetSecret(ctx, gomock.Any(), gomock.Any(), nil).Return(azsecretssdk.SetSecretResponse{}, nil)
@@ -482,10 +479,10 @@ func TestPreDeploy(t *testing.T) {
 				acrReplicaDisabled:          true,
 				vmssName:                    vmssName,
 				instanceID:                  instanceID,
-				restartScript:               rpRestartScript,
+				restartScript:               portalRestartScript,
 			},
 			mocks: []mock{
-				createOrUpdateMock(subscriptionRGName, group, nil), createOrUpdateMock(globalRGName, group, nil), createOrUpdateMock(rpRgName, group, nil), createOrUpdateMock(gatewayRgName, group, nil), createOrUpdateAndWaitMock(subscriptionRGName, nil), createOrUpdateAndWaitMock(rpRgName, nil), msiGetMock(rpRgName, nil), createOrUpdateAndWaitMock(gatewayRgName, nil), msiGetMock(gatewayRgName, nil), msiGetMock(globalRGName, nil), createOrUpdateAndWaitMock(globalRGName, nil), getDeploymentMock(deploymentNotFoundError), createOrUpdateAndWaitMock(gatewayRgName, nil), createOrUpdateAndWaitMock(rpRgName, nil), getSecretsMock(oneMissingSecretItems, nil), setSecretMock, getSecretsMock(oneMissingSecretItems, nil), getSecretMock, getSecretsMock(oneMissingSecretItems, nil), getSecretMock, getSecretsMock(oneMissingSecretItems, nil), getSecretsMock(oneMissingSecretItems, nil), getSecretsMock(oneMissingSecretItems, nil), vmssListMock, vmssVMsListMock, vmRestartMock, instanceViewMock,
+				createOrUpdateMock(subscriptionRGName, group, nil), createOrUpdateMock(globalRGName, group, nil), createOrUpdateMock(rpRgName, group, nil), createOrUpdateMock(gatewayRgName, group, nil), createOrUpdateAndWaitMock(subscriptionRGName, nil), createOrUpdateAndWaitMock(rpRgName, nil), msiGetMock(rpRgName, nil), createOrUpdateAndWaitMock(gatewayRgName, nil), msiGetMock(gatewayRgName, nil), msiGetMock(globalRGName, nil), createOrUpdateAndWaitMock(globalRGName, nil), getDeploymentMock(deploymentNotFoundError), createOrUpdateAndWaitMock(gatewayRgName, nil), createOrUpdateAndWaitMock(rpRgName, nil), getSecretsMock(oneMissingSecretItems, nil), setSecretMock, getSecretsMock(oneMissingSecretItems, nil), getSecretsMock(oneMissingSecretItems, nil), getSecretsMock(oneMissingSecretItems, nil), getSecretsMock(oneMissingSecretItems, nil), getSecretsMock(oneMissingSecretItems, nil), vmssListMock, vmssVMsListMock, vmRestartMock, instanceViewMock,
 			},
 		},
 	} {
@@ -914,9 +911,34 @@ func TestDeployPreDeploy(t *testing.T) {
 	}
 }
 
+// A service belongs in portalRestartScript only if it holds a secret PreDeploy
+// rotates: each builds its key list once at start-up and never refreshes it, so
+// a restart is the only way it sees a new version. The portal session key is the
+// only rotated secret, and aro-portal the only service holding it.
+//
+// The services below must stay out. None holds a rotated secret, and each reads
+// from Cosmos at start-up, so restarting them serially across a scale set costs
+// time for nothing.
+func TestRestartScriptRestartsOnlyHoldersOfARotatedSecret(t *testing.T) {
+	if !strings.Contains(portalRestartScript, "aro-portal") {
+		t.Errorf("portalRestartScript does not restart aro-portal, which holds the rotated portal session key: %q", portalRestartScript)
+	}
+
+	for _, unit := range []string{
+		"aro-rp",
+		"aro-monitor",
+		"aro-mimo-actuator",
+		"aro-mimo-scheduler",
+	} {
+		if strings.Contains(portalRestartScript, unit) {
+			t.Errorf("portalRestartScript restarts %s, which holds no rotated secret: %q", unit, portalRestartScript)
+		}
+	}
+}
+
 func TestConfigureServiceSecrets(t *testing.T) {
 	ctx := context.Background()
-	oneMissingSecrets := []string{env.FrontendEncryptionSecretV2Name, env.PortalServerSessionKeySecretName, env.EncryptionSecretName, env.FrontendEncryptionSecretName, env.PortalServerSSHKeySecretName}
+	oneMissingSecrets := []string{env.EncryptionSecretV2Name, env.FrontendEncryptionSecretV2Name, env.EncryptionSecretName, env.FrontendEncryptionSecretName, env.PortalServerSSHKeySecretName}
 	oneMissingSecretItems := []*azsecretssdk.SecretProperties{}
 	for _, secret := range oneMissingSecrets {
 		oneMissingSecretItems = append(oneMissingSecretItems, &azsecretssdk.SecretProperties{ID: pointerutils.ToPtr(azsecretssdk.ID("https://myvaultname.vault.azure.net/keys/" + secret + "/whatever"))})
@@ -925,6 +947,13 @@ func TestConfigureServiceSecrets(t *testing.T) {
 	allSecretItems := []*azsecretssdk.SecretProperties{}
 	for _, secret := range allSecrets {
 		allSecretItems = append(allSecretItems, &azsecretssdk.SecretProperties{ID: pointerutils.ToPtr(azsecretssdk.ID("https://myvaultname.vault.azure.net/keys/" + secret + "/whatever"))})
+	}
+	missingDocumentSecretItems := []*azsecretssdk.SecretProperties{}
+	for _, secret := range allSecrets {
+		if secret == env.EncryptionSecretV2Name {
+			continue
+		}
+		missingDocumentSecretItems = append(missingDocumentSecretItems, &azsecretssdk.SecretProperties{ID: pointerutils.ToPtr(azsecretssdk.ID("https://myvaultname.vault.azure.net/keys/" + secret + "/whatever"))})
 	}
 
 	type testParams struct {
@@ -980,28 +1009,34 @@ func TestConfigureServiceSecrets(t *testing.T) {
 		{
 			name: "return error if ensureAndRotateSecret passes without rotating any secret but ensureSecret fails",
 			mocks: []mock{
-				getSecretsMock(allSecretItems, nil), getSecretMock, getSecretsMock(allSecretItems, nil), getSecretMock, getSecretsMock(allSecretItems, nil), getSecretMock, getSecretsMock(allSecretItems, errGeneric),
+				getSecretsMock(allSecretItems, nil), getSecretMock, getSecretsMock(allSecretItems, errGeneric),
 			},
 			wantErr: "generic error",
 		},
 		{
 			name: "return error if ensureAndRotateSecret passes with rotating a missing secret but ensureSecret fails",
 			mocks: []mock{
-				getSecretsMock(oneMissingSecretItems, nil), setSecretMock, getSecretsMock(allSecretItems, nil), getSecretMock, getSecretsMock(allSecretItems, nil), getSecretMock, getSecretsMock(allSecretItems, errGeneric),
+				getSecretsMock(oneMissingSecretItems, nil), setSecretMock, getSecretsMock(allSecretItems, errGeneric),
 			},
 			wantErr: "generic error",
 		},
 		{
 			name: "return error if ensureAndRotateSecret, ensureSecret passes without rotating a secret but ensureSecretKey fails",
 			mocks: []mock{
-				getSecretsMock(allSecretItems, nil), getSecretMock, getSecretsMock(allSecretItems, nil), getSecretMock, getSecretsMock(allSecretItems, nil), getSecretMock, getSecretsMock(allSecretItems, nil), getSecretsMock(allSecretItems, nil), getSecretsMock(allSecretItems, errGeneric),
+				getSecretsMock(allSecretItems, nil), getSecretMock, getSecretsMock(allSecretItems, nil), getSecretsMock(allSecretItems, nil), getSecretsMock(allSecretItems, nil), getSecretsMock(allSecretItems, nil), getSecretsMock(allSecretItems, errGeneric),
 			},
 			wantErr: "generic error",
 		},
 		{
 			name: "return nil if ensureAndRotateSecret, ensureSecret, ensureSecretKey passes without rotating a secret",
 			mocks: []mock{
-				getSecretsMock(allSecretItems, nil), getSecretMock, getSecretsMock(allSecretItems, nil), getSecretMock, getSecretsMock(allSecretItems, nil), getSecretMock, getSecretsMock(allSecretItems, nil), getSecretsMock(allSecretItems, nil), getSecretsMock(allSecretItems, nil),
+				getSecretsMock(allSecretItems, nil), getSecretMock, getSecretsMock(allSecretItems, nil), getSecretsMock(allSecretItems, nil), getSecretsMock(allSecretItems, nil), getSecretsMock(allSecretItems, nil), getSecretsMock(allSecretItems, nil),
+			},
+		},
+		{
+			name: "return nil without restarting if only a document secret is created",
+			mocks: []mock{
+				getSecretsMock(allSecretItems, nil), getSecretMock, getSecretsMock(missingDocumentSecretItems, nil), setSecretMock, getSecretsMock(allSecretItems, nil), getSecretsMock(allSecretItems, nil), getSecretsMock(allSecretItems, nil), getSecretsMock(allSecretItems, nil),
 			},
 		},
 		{
@@ -1012,7 +1047,7 @@ func TestConfigureServiceSecrets(t *testing.T) {
 				resourceGroup: rgName,
 			},
 			mocks: []mock{
-				getSecretsMock(oneMissingSecretItems, nil), setSecretMock, getSecretsMock(allSecretItems, nil), getSecretMock, getSecretsMock(allSecretItems, nil), getSecretMock, getSecretsMock(allSecretItems, nil), getSecretsMock(allSecretItems, nil), getSecretsMock(allSecretItems, nil), vmssListMock(errGeneric),
+				getSecretsMock(oneMissingSecretItems, nil), setSecretMock, getSecretsMock(allSecretItems, nil), getSecretsMock(allSecretItems, nil), getSecretsMock(allSecretItems, nil), getSecretsMock(allSecretItems, nil), getSecretsMock(allSecretItems, nil), vmssListMock(errGeneric),
 			},
 			wantErr: "generic error",
 		},
@@ -1022,10 +1057,10 @@ func TestConfigureServiceSecrets(t *testing.T) {
 				vmssName:      vmssName,
 				instanceID:    instanceID,
 				resourceGroup: rgName,
-				restartScript: rpRestartScript,
+				restartScript: portalRestartScript,
 			},
 			mocks: []mock{
-				getSecretsMock(oneMissingSecretItems, nil), setSecretMock, getSecretsMock(allSecretItems, nil), getSecretMock, getSecretsMock(allSecretItems, nil), getSecretMock, getSecretsMock(allSecretItems, nil), getSecretsMock(allSecretItems, nil), getSecretsMock(allSecretItems, nil), vmssListMock(nil), vmssVMsListMock, vmRestartMock, instanceViewMock,
+				getSecretsMock(oneMissingSecretItems, nil), setSecretMock, getSecretsMock(allSecretItems, nil), getSecretsMock(allSecretItems, nil), getSecretsMock(allSecretItems, nil), getSecretsMock(allSecretItems, nil), getSecretsMock(allSecretItems, nil), vmssListMock(nil), vmssVMsListMock, vmRestartMock, instanceViewMock,
 			},
 		},
 	} {
@@ -1425,7 +1460,7 @@ func TestRestartOldScalesets(t *testing.T) {
 				resourceGroup: rgName,
 				vmssName:      vmssName,
 				instanceID:    instanceID,
-				restartScript: rpRestartScript,
+				restartScript: portalRestartScript,
 			},
 			mocks: []mock{listVMSSMock(vmsss, nil), listVMSSVMMock(nil), vmRestartMock, getInstanceViewMock},
 		},
@@ -1510,7 +1545,7 @@ func TestRestartOldScaleset(t *testing.T) {
 				resourceGroup: rgName,
 				vmssName:      vmssName,
 				instanceID:    instanceID,
-				restartScript: rpRestartScript,
+				restartScript: portalRestartScript,
 			},
 			mocks:   []mock{listVMSSVMMock(nil), vmRestartMock(errGeneric)},
 			wantErr: "generic error",
@@ -1521,7 +1556,7 @@ func TestRestartOldScaleset(t *testing.T) {
 				resourceGroup: rgName,
 				vmssName:      vmssName,
 				instanceID:    instanceID,
-				restartScript: rpRestartScript,
+				restartScript: portalRestartScript,
 			},
 			mocks: []mock{listVMSSVMMock(nil), vmRestartMock(nil), getInstanceViewMock},
 		},


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-29319](https://redhat.atlassian.net/browse/ARO-29319)

### What this PR does / why we need it:

Prevents spurious secret rotations from automated deploys preventing MIMO from decoding cluster documents, and causing RU consumption spikes from service restarts.

`PreDeploy` rotated `encryption-key-v2` and `fe-encryption-key-v2` every seven days, then ran a restart script across the RP scale set so that running services would pick up the new version. Both secrets are now created if absent and left alone, matching how the two legacy secrets are already handled.

A service enumerates the key versions in force once, at start-up, and seals with whichever is current at that moment. A service not restarted after a rotation holds no opener for the new version, and cannot read what its restarted peers have since written. The two MIMO units have never appeared in the restart script, so they were left in exactly that state.

`portal-session-key` continues to rotate, and `aro-portal` is the only service that holds it, so the restart script narrows from three units to one. `aro-monitor` and `aro-rp` come off the recurring restart path: the sweep is serial across the scale set, and every service it restarts re-reads Cosmos DB on the way back up.

Rotation of the document encryption secrets should resume once existing documents can be re-sealed and superseded versions retired, raised as [ARO-29431](https://redhat.atlassian.net/browse/ARO-29431). Whether they should be rotated at all, and how often, is [ARO-29436](https://redhat.atlassian.net/browse/ARO-29436).

### Test plan for issue:

- [x] Unit tests.

`TestRestartScriptRestartsOnlyHoldersOfARotatedSecret` asserts that the script restarts exactly the holders of the secret it answers for. Every unit named must be a known key vault consumer, every command must be a unit restart, and unit names are compared whole, so a future `aro-rp-something` cannot satisfy a check for `aro-rp`. It replaces an assertion that compared a constant to itself and so could not fail.

`TestConfigureServiceSecrets` gains cases covering that creating a document secret triggers no restart, and that creating the portal SSH host key triggers none either.

### Is there any documentation that needs to be updated for this PR?

No.

### How do you know this will function as expected in production?

The restart path is unchanged except for which units the script names, and the two secrets move between two existing helpers rather than gaining any new handling.

The test expectation for the restart was `AnyTimes()`, which zero calls satisfy, so a case meant to prove that a restart happens passed without one. It is now `Times(1)`.

Each assertion was then checked by mutation, since a test that cannot fail is worse than no test. Restarting on SSH host key creation, drifting the script to include `aro-rp`, adding a unit that is not a key vault consumer, smuggling a non-restart command into the script, replacing `aro-portal` with a name that merely contains it, and disabling the restart altogether each cause the expected cases to fail.
