### PR TITLE
[ARO-29320] Refresh encryption keys when a document cannot be opened

### DIFF
--- a/cmd/aro/mimoactuator.go
+++ b/cmd/aro/mimoactuator.go
@@ -64,7 +64,7 @@ func mimoActuator(ctx context.Context, _log *logrus.Entry) error {
 		RequestLatency: k8s.NewLatency(m),
 	})
 
-	aead, err := encryption.NewAEADWithCore(ctx, _env, env.EncryptionSecretV2Name, env.EncryptionSecretName)
+	aead, err := encryption.NewAEADWithCore(ctx, _env, env.EncryptionSecretV2Name, env.EncryptionSecretName, encryption.WithLogger(log))
 	if err != nil {
 		return err
 	}

--- a/cmd/aro/mimoscheduler.go
+++ b/cmd/aro/mimoscheduler.go
@@ -56,7 +56,7 @@ func mimoScheduler(ctx context.Context, _log *logrus.Entry) error {
 
 	tracing.Register(azure.New(m))
 
-	aead, err := encryption.NewAEADWithCore(ctx, _env, env.EncryptionSecretV2Name, env.EncryptionSecretName)
+	aead, err := encryption.NewAEADWithCore(ctx, _env, env.EncryptionSecretV2Name, env.EncryptionSecretName, encryption.WithLogger(log))
 	if err != nil {
 		return err
 	}

--- a/cmd/aro/monitor.go
+++ b/cmd/aro/monitor.go
@@ -66,7 +66,7 @@ func monitor(ctx context.Context, _log *logrus.Entry) error {
 	clusterm := statsd.NewMetricsForCluster(ctx, _env, os.Getenv("CLUSTER_MDM_ACCOUNT"), os.Getenv("CLUSTER_MDM_NAMESPACE"), os.Getenv("MDM_STATSD_SOCKET"))
 	go clusterm.Run(monitorWorkersDone)
 
-	aead, err := encryption.NewAEADWithCore(ctx, _env, env.EncryptionSecretV2Name, env.EncryptionSecretName)
+	aead, err := encryption.NewAEADWithCore(ctx, _env, env.EncryptionSecretV2Name, env.EncryptionSecretName, encryption.WithLogger(_log))
 	if err != nil {
 		return err
 	}

--- a/cmd/aro/portal.go
+++ b/cmd/aro/portal.go
@@ -72,7 +72,7 @@ func portal(ctx context.Context, _log *logrus.Entry, auditLog *logrus.Entry) err
 
 	go g.Run()
 
-	aead, err := encryption.NewAEADWithCore(ctx, _env, env.EncryptionSecretV2Name, env.EncryptionSecretName)
+	aead, err := encryption.NewAEADWithCore(ctx, _env, env.EncryptionSecretV2Name, env.EncryptionSecretName, encryption.WithLogger(_log))
 	if err != nil {
 		return err
 	}

--- a/cmd/aro/rp.go
+++ b/cmd/aro/rp.go
@@ -110,7 +110,7 @@ func rp(ctx context.Context, _log, auditLog *logrus.Entry) error {
 	clusterm := statsd.NewMetricsForCluster(ctx, _env, os.Getenv("CLUSTER_MDM_ACCOUNT"), os.Getenv("CLUSTER_MDM_NAMESPACE"), os.Getenv("MDM_STATSD_SOCKET"))
 	go clusterm.Run(stop)
 
-	aead, err := encryption.NewAEADWithCore(ctx, _env, env.EncryptionSecretV2Name, env.EncryptionSecretName)
+	aead, err := encryption.NewAEADWithCore(ctx, _env, env.EncryptionSecretV2Name, env.EncryptionSecretName, encryption.WithLogger(_log))
 	if err != nil {
 		return err
 	}
@@ -180,7 +180,7 @@ func rp(ctx context.Context, _log, auditLog *logrus.Entry) error {
 
 	go database.EmitOpenShiftClustersMetrics(ctx, _env.LoggerForComponent("metrics"), dbOpenShiftClusters, metrics)
 
-	feAead, err := encryption.NewMulti(ctx, _env.ServiceKeyvault(), env.FrontendEncryptionSecretV2Name, env.FrontendEncryptionSecretName)
+	feAead, err := encryption.NewMulti(ctx, _env.ServiceKeyvault(), env.FrontendEncryptionSecretV2Name, env.FrontendEncryptionSecretName, encryption.WithLogger(_log))
 	if err != nil {
 		return err
 	}

--- a/pkg/util/encryption/azure.go
+++ b/pkg/util/encryption/azure.go
@@ -18,7 +18,7 @@ const (
 
 // NewAEADWithCore creates an AEAD encryption manager with resources available
 // from the Core env object.
-func NewAEADWithCore(ctx context.Context, _env env.Core, encryptionSecretV2Name string, encryptionSecretName string) (AEAD, error) {
+func NewAEADWithCore(ctx context.Context, _env env.Core, encryptionSecretV2Name string, encryptionSecretName string, opts ...Option) (AEAD, error) {
 	msiCredential, err := _env.NewMSITokenCredential()
 	if err != nil {
 		return nil, err
@@ -32,6 +32,6 @@ func NewAEADWithCore(ctx context.Context, _env env.Core, encryptionSecretV2Name 
 	}
 
 	return NewMulti(
-		ctx, serviceKeyvault, encryptionSecretV2Name, encryptionSecretName,
+		ctx, serviceKeyvault, encryptionSecretV2Name, encryptionSecretName, opts...,
 	)
 }

--- a/pkg/util/encryption/multi.go
+++ b/pkg/util/encryption/multi.go
@@ -5,19 +5,202 @@ package encryption
 
 import (
 	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/sirupsen/logrus"
 
 	"github.com/Azure/ARO-RP/pkg/util/azureclient/azuresdk/azsecrets"
 )
 
-type multi struct {
+const (
+	// defaultMinRefreshInterval bounds how often a failure to open can cause
+	// the keys to be re-enumerated. A document that no key can open is not
+	// necessarily rare, so this must be long enough that a stream of them
+	// cannot become a stream of Key Vault requests.
+	defaultMinRefreshInterval = 5 * time.Minute
+
+	// refreshTimeout bounds a single re-enumeration. Open has no context of its
+	// own, and its callers should not be made to wait indefinitely on Key
+	// Vault.
+	refreshTimeout = 30 * time.Second
+)
+
+var errNoOpeners = errors.New("no decryption keys are available")
+
+// A keySet is the keys a multi holds at a point in time. It is replaced
+// wholesale rather than mutated, so that Open needs no lock.
+type keySet struct {
 	sealer  AEAD
 	openers []AEAD
 }
 
+// A keyLoader enumerates the encryption keys currently in force.
+type keyLoader interface {
+	load(ctx context.Context) (*keySet, error)
+}
+
+type multi struct {
+	loader keyLoader
+
+	log                *logrus.Entry
+	minRefreshInterval time.Duration
+	now                func() time.Time
+
+	keys atomic.Pointer[keySet]
+
+	refreshMu     sync.Mutex
+	lastRefreshed time.Time // guarded by refreshMu
+}
+
 var _ AEAD = (*multi)(nil)
 
-func NewMulti(ctx context.Context, serviceKeyvault azsecrets.Client, secretName, legacySecretName string) (AEAD, error) {
-	rawKey, err := serviceKeyvault.GetSecret(ctx, secretName, "", nil)
+// An Option configures optional behaviour of an AEAD returned by NewMulti.
+type Option func(*multi)
+
+// WithLogger sets the logger on which key refreshes are reported. Refreshes are
+// silent by default.
+func WithLogger(log *logrus.Entry) Option {
+	return func(m *multi) { m.log = log }
+}
+
+// WithMinRefreshInterval overrides how often a failure to open may cause the
+// keys to be re-enumerated.
+func WithMinRefreshInterval(d time.Duration) Option {
+	return func(m *multi) { m.minRefreshInterval = d }
+}
+
+func NewMulti(ctx context.Context, serviceKeyvault azsecrets.Client, secretName, legacySecretName string, opts ...Option) (AEAD, error) {
+	return newMulti(ctx, &keyVaultLoader{
+		keyvault:         serviceKeyvault,
+		secretName:       secretName,
+		legacySecretName: legacySecretName,
+	}, opts...)
+}
+
+func newMulti(ctx context.Context, loader keyLoader, opts ...Option) (*multi, error) {
+	m := &multi{
+		loader:             loader,
+		minRefreshInterval: defaultMinRefreshInterval,
+		now:                time.Now,
+	}
+
+	for _, opt := range opts {
+		opt(m)
+	}
+
+	keys, err := m.loader.load(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	m.keys.Store(keys)
+	m.lastRefreshed = m.now()
+
+	return m, nil
+}
+
+func (c *multi) Open(input []byte) ([]byte, error) {
+	b, err := open(c.keys.Load(), input)
+	if err == nil {
+		return b, nil
+	}
+
+	// A failure to open may mean nothing worse than that this process's keys
+	// are stale. The services which hold a multi are long-lived and enumerate
+	// the secret versions once, at start-up, so a version created since then is
+	// absent until the process is restarted. Re-enumerate and try once more.
+	if !c.refresh() {
+		return nil, err
+	}
+
+	b, refreshedErr := open(c.keys.Load(), input)
+	if refreshedErr != nil {
+		// Report the original error. The input cannot be opened by any key this
+		// process holds, and describing that in terms of the first attempt is
+		// the more faithful account.
+		return nil, err
+	}
+
+	return b, nil
+}
+
+func open(keys *keySet, input []byte) ([]byte, error) {
+	if len(keys.openers) == 0 {
+		return nil, errNoOpeners
+	}
+
+	var err error
+	for _, opener := range keys.openers {
+		var b []byte
+		if b, err = opener.Open(input); err == nil {
+			return b, nil
+		}
+	}
+
+	return nil, err
+}
+
+// refresh re-enumerates the keys and reports whether it replaced them. It does
+// nothing, and reports false, if it has already run within the last
+// minRefreshInterval.
+func (c *multi) refresh() bool {
+	c.refreshMu.Lock()
+	defer c.refreshMu.Unlock()
+
+	// Another caller may have refreshed while this one waited for the lock.
+	if c.now().Sub(c.lastRefreshed) < c.minRefreshInterval {
+		return false
+	}
+
+	// Recorded before the attempt rather than after it, so that a Key Vault
+	// which is slow or failing is not asked again any sooner than one which
+	// answered.
+	c.lastRefreshed = c.now()
+
+	ctx, cancel := context.WithTimeout(context.Background(), refreshTimeout)
+	defer cancel()
+
+	keys, err := c.loader.load(ctx)
+	if err != nil {
+		if c.log != nil {
+			c.log.Warnf("failed refreshing encryption keys: %s", err)
+		}
+		return false
+	}
+
+	was := len(c.keys.Load().openers)
+	c.keys.Store(keys)
+
+	if c.log != nil && len(keys.openers) != was {
+		c.log.Infof("refreshed encryption keys: %d openers, was %d", len(keys.openers), was)
+	}
+
+	return true
+}
+
+func (c *multi) Seal(input []byte) ([]byte, error) {
+	return c.keys.Load().sealer.Seal(input)
+}
+
+// A keyVaultLoader enumerates the encryption keys from Key Vault.
+type keyVaultLoader struct {
+	keyvault         azsecrets.Client
+	secretName       string
+	legacySecretName string
+}
+
+var _ keyLoader = (*keyVaultLoader)(nil)
+
+// load reads the encryption secrets from Key Vault.
+//
+// The sealer is the current version of secretName. The openers are every
+// version of both secretName and legacySecretName, so that data written by a
+// process holding a different version can still be read.
+func (l *keyVaultLoader) load(ctx context.Context) (*keySet, error) {
+	rawKey, err := l.keyvault.GetSecret(ctx, l.secretName, "", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -27,68 +210,68 @@ func NewMulti(ctx context.Context, serviceKeyvault azsecrets.Client, secretName,
 		return nil, err
 	}
 
-	aead, err := NewAES256SHA512(ctx, key)
+	sealer, err := NewAES256SHA512(ctx, key)
 	if err != nil {
 		return nil, err
 	}
 
-	m := &multi{
-		sealer: aead,
-	}
+	keys := &keySet{sealer: sealer}
 
 	for _, x := range []struct {
 		secretName  string
 		aeadFactory func(context.Context, []byte) (AEAD, error)
 	}{
-		{secretName, NewAES256SHA512},
-		{legacySecretName, NewXChaCha20Poly1305},
+		{l.secretName, NewAES256SHA512},
+		{l.legacySecretName, NewXChaCha20Poly1305},
 	} {
-		var keys [][]byte
-		pager := serviceKeyvault.NewListSecretPropertiesVersionsPager(x.secretName, nil)
-		for pager.More() {
-			page, err := pager.NextPage(ctx)
-			if err != nil {
-				return nil, err
-			}
-			for _, properties := range page.Value {
-				if properties != nil && properties.ID != nil && properties.Attributes != nil {
-					raw, err := serviceKeyvault.GetSecret(ctx, (*properties.ID).Name(), (*properties.ID).Version(), nil)
-					if err != nil {
-						return nil, err
-					}
-					version, err := azsecrets.ExtractBase64Value(raw)
-					if err != nil {
-						return nil, err
-					}
-					keys = append(keys, version)
+		openers, err := l.openersFor(ctx, x.secretName, x.aeadFactory)
+		if err != nil {
+			return nil, err
+		}
+
+		keys.openers = append(keys.openers, openers...)
+	}
+
+	return keys, nil
+}
+
+// openersFor builds one AEAD per version of the named secret.
+func (l *keyVaultLoader) openersFor(ctx context.Context, secretName string, aeadFactory func(context.Context, []byte) (AEAD, error)) ([]AEAD, error) {
+	var keys [][]byte
+
+	pager := l.keyvault.NewListSecretPropertiesVersionsPager(secretName, nil)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, properties := range page.Value {
+			if properties != nil && properties.ID != nil && properties.Attributes != nil {
+				raw, err := l.keyvault.GetSecret(ctx, (*properties.ID).Name(), (*properties.ID).Version(), nil)
+				if err != nil {
+					return nil, err
 				}
-			}
-		}
 
-		for _, key := range keys {
-			aead, err = x.aeadFactory(ctx, key)
-			if err != nil {
-				return nil, err
-			}
+				version, err := azsecrets.ExtractBase64Value(raw)
+				if err != nil {
+					return nil, err
+				}
 
-			m.openers = append(m.openers, aead)
+				keys = append(keys, version)
+			}
 		}
 	}
 
-	return m, nil
-}
-
-func (c *multi) Open(input []byte) (b []byte, err error) {
-	for _, opener := range c.openers {
-		b, err = opener.Open(input)
-		if err == nil {
-			return
+	openers := make([]AEAD, 0, len(keys))
+	for _, key := range keys {
+		aead, err := aeadFactory(ctx, key)
+		if err != nil {
+			return nil, err
 		}
+
+		openers = append(openers, aead)
 	}
 
-	return nil, err
-}
-
-func (c *multi) Seal(input []byte) ([]byte, error) {
-	return c.sealer.Seal(input)
+	return openers, nil
 }

--- a/pkg/util/encryption/multi.go
+++ b/pkg/util/encryption/multi.go
@@ -103,7 +103,9 @@ func newMulti(ctx context.Context, loader keyLoader, opts ...Option) (*multi, er
 }
 
 func (c *multi) Open(input []byte) ([]byte, error) {
-	b, err := open(c.keys.Load(), input)
+	keys := c.keys.Load()
+
+	b, err := open(keys, input)
 	if err == nil {
 		return b, nil
 	}
@@ -112,11 +114,21 @@ func (c *multi) Open(input []byte) ([]byte, error) {
 	// are stale. The services which hold a multi are long-lived and enumerate
 	// the secret versions once, at start-up, so a version created since then is
 	// absent until the process is restarted. Re-enumerate and try once more.
-	if !c.refresh() {
+	c.refresh()
+
+	// Re-read the keys rather than asking whether this call was the one that
+	// replaced them. A refresh performed by a concurrent caller is just as
+	// useful as one performed here, and under the burst of failures that a
+	// rotation produces most callers will find the keys already replaced by the
+	// time they reach this point. Comparing the pointer, rather than trusting
+	// that a refresh happened, also avoids a pointless second attempt when the
+	// rate limit meant no re-enumeration took place at all.
+	refreshed := c.keys.Load()
+	if refreshed == keys {
 		return nil, err
 	}
 
-	b, refreshedErr := open(c.keys.Load(), input)
+	b, refreshedErr := open(refreshed, input)
 	if refreshedErr != nil {
 		// Report the original error. The input cannot be opened by any key this
 		// process holds, and describing that in terms of the first attempt is
@@ -143,16 +155,25 @@ func open(keys *keySet, input []byte) ([]byte, error) {
 	return nil, err
 }
 
-// refresh re-enumerates the keys and reports whether it replaced them. It does
-// nothing, and reports false, if it has already run within the last
-// minRefreshInterval.
-func (c *multi) refresh() bool {
+// refresh re-enumerates the keys and replaces them. It does nothing if it has
+// already run within the last minRefreshInterval.
+//
+// It reports nothing. Callers observe the outcome by re-reading c.keys, so that
+// a caller which arrives while another is already refreshing benefits from that
+// refresh rather than being told its own attempt did nothing.
+//
+// The lock is held across the load, so a caller arriving mid-refresh waits for
+// it. That wait is bounded by refreshTimeout and is the point of the exercise:
+// the keys it is waiting for are the ones that will let it succeed. Returning
+// early instead would hand it a stale key set and a failure it need not have
+// had.
+func (c *multi) refresh() {
 	c.refreshMu.Lock()
 	defer c.refreshMu.Unlock()
 
 	// Another caller may have refreshed while this one waited for the lock.
 	if c.now().Sub(c.lastRefreshed) < c.minRefreshInterval {
-		return false
+		return
 	}
 
 	// Recorded before the attempt rather than after it, so that a Key Vault
@@ -168,7 +189,7 @@ func (c *multi) refresh() bool {
 		if c.log != nil {
 			c.log.Warnf("failed refreshing encryption keys: %s", err)
 		}
-		return false
+		return
 	}
 
 	was := len(c.keys.Load().openers)
@@ -177,8 +198,6 @@ func (c *multi) refresh() bool {
 	if c.log != nil && len(keys.openers) != was {
 		c.log.Infof("refreshed encryption keys: %d openers, was %d", len(keys.openers), was)
 	}
-
-	return true
 }
 
 func (c *multi) Seal(input []byte) ([]byte, error) {

--- a/pkg/util/encryption/multi.go
+++ b/pkg/util/encryption/multi.go
@@ -67,9 +67,15 @@ func WithLogger(log *logrus.Entry) Option {
 }
 
 // WithMinRefreshInterval overrides how often a failure to open may cause the
-// keys to be re-enumerated.
+// keys to be re-enumerated. Non-positive durations are ignored, since they
+// would let every failed open reach Key Vault, and the failures this exists to
+// answer arrive in bursts.
 func WithMinRefreshInterval(d time.Duration) Option {
-	return func(m *multi) { m.minRefreshInterval = d }
+	return func(m *multi) {
+		if d > 0 {
+			m.minRefreshInterval = d
+		}
+	}
 }
 
 func NewMulti(ctx context.Context, serviceKeyvault azsecrets.Client, secretName, legacySecretName string, opts ...Option) (AEAD, error) {
@@ -95,9 +101,19 @@ func newMulti(ctx context.Context, loader keyLoader, opts ...Option) (*multi, er
 	if err != nil {
 		return nil, err
 	}
+	if keys == nil {
+		return nil, errNoOpeners
+	}
 
 	m.keys.Store(keys)
-	m.lastRefreshed = m.now()
+
+	// lastRefreshed is deliberately left at its zero value rather than set to
+	// now. Recording the construction load here would rate-limit the first
+	// failure-triggered refresh for minRefreshInterval, and a process which
+	// starts just before a new key version is written would then be unable to
+	// recover for that whole window — which is the case this type exists for.
+	// The cost of leaving it zero is one extra enumeration if the first
+	// document opened is genuinely undecryptable.
 
 	return m, nil
 }
@@ -140,7 +156,7 @@ func (c *multi) Open(input []byte) ([]byte, error) {
 }
 
 func open(keys *keySet, input []byte) ([]byte, error) {
-	if len(keys.openers) == 0 {
+	if keys == nil || len(keys.openers) == 0 {
 		return nil, errNoOpeners
 	}
 
@@ -185,6 +201,9 @@ func (c *multi) refresh() {
 	defer cancel()
 
 	keys, err := c.loader.load(ctx)
+	if err == nil && keys == nil {
+		err = errNoOpeners
+	}
 	if err != nil {
 		if c.log != nil {
 			c.log.Warnf("failed refreshing encryption keys: %v", err)

--- a/pkg/util/encryption/multi.go
+++ b/pkg/util/encryption/multi.go
@@ -187,7 +187,7 @@ func (c *multi) refresh() {
 	keys, err := c.loader.load(ctx)
 	if err != nil {
 		if c.log != nil {
-			c.log.Warnf("failed refreshing encryption keys: %s", err)
+			c.log.Warnf("failed refreshing encryption keys: %v", err)
 		}
 		return
 	}

--- a/pkg/util/encryption/multi_test.go
+++ b/pkg/util/encryption/multi_test.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"errors"
 	"reflect"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -215,21 +217,86 @@ func TestRefreshIsRateLimited(t *testing.T) {
 	m.keys.Store(&keySet{})
 	m.lastRefreshed = now.Add(-time.Hour)
 
-	if got := m.refresh(); !got {
-		t.Errorf("multi.refresh() = %v, want true", got)
+	m.refresh()
+	if loads != 1 {
+		t.Errorf("keyLoader.load() called %d times after one refresh, want 1", loads)
 	}
-	if got := m.refresh(); got {
-		t.Errorf("multi.refresh() = %v after an immediate second call, want false", got)
+
+	m.refresh()
+	if loads != 1 {
+		t.Errorf("keyLoader.load() called %d times after an immediate second refresh, want 1", loads)
 	}
 
 	now = now.Add(time.Hour)
 
-	if got := m.refresh(); !got {
-		t.Errorf("multi.refresh() = %v after minRefreshInterval elapsed, want true", got)
+	m.refresh()
+	if loads != 2 {
+		t.Errorf("keyLoader.load() called %d times after minRefreshInterval elapsed, want 2", loads)
+	}
+}
+
+// TestOpenRetriesAfterAConcurrentRefresh covers the caller which finds the keys
+// already being refreshed by another goroutine. It must still retry against the
+// refreshed keys: the rotation this fix exists for produces a burst of
+// simultaneous failures, and only one of them performs the re-enumeration.
+func TestOpenRetriesAfterAConcurrentRefresh(t *testing.T) {
+	const callers = 8
+
+	controller := gomock.NewController(t)
+
+	stale := mock_encryption.NewMockAEAD(controller)
+	stale.EXPECT().Open(gomock.Any()).Return(nil, errors.New("chacha20poly1305: message authentication failed")).AnyTimes()
+
+	fresh := mock_encryption.NewMockAEAD(controller)
+	fresh.EXPECT().Open([]byte("sealed")).Return([]byte("opened"), nil).AnyTimes()
+
+	now := time.Unix(0, 0)
+
+	// Released once every caller is under way, so that they all reach refresh
+	// together and contend for it.
+	release := make(chan struct{})
+	var loads int64
+
+	m := &multi{
+		loader: loaderFunc(func(context.Context) (*keySet, error) {
+			atomic.AddInt64(&loads, 1)
+			<-release
+			return &keySet{openers: []AEAD{fresh}}, nil
+		}),
+		minRefreshInterval: time.Hour,
+		now:                func() time.Time { return now },
+	}
+	m.keys.Store(&keySet{openers: []AEAD{stale}})
+	m.lastRefreshed = now.Add(-time.Hour)
+
+	var wg sync.WaitGroup
+	results := make([][]byte, callers)
+	errs := make([]error, callers)
+
+	for i := range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			results[i], errs[i] = m.Open([]byte("sealed"))
+		}()
 	}
 
-	if loads != 2 {
-		t.Errorf("keyLoader.load() called %d times, want 2", loads)
+	// Let the single in-flight load complete once all callers are under way.
+	time.Sleep(50 * time.Millisecond)
+	close(release)
+	wg.Wait()
+
+	for i := range callers {
+		if errs[i] != nil {
+			t.Errorf("caller %d: multi.Open() returned unexpected error: %v", i, errs[i])
+		}
+		if !reflect.DeepEqual(results[i], []byte("opened")) {
+			t.Errorf("caller %d: multi.Open() = %q, want %q", i, results[i], []byte("opened"))
+		}
+	}
+
+	if got := atomic.LoadInt64(&loads); got != 1 {
+		t.Errorf("keyLoader.load() called %d times, want 1", got)
 	}
 }
 

--- a/pkg/util/encryption/multi_test.go
+++ b/pkg/util/encryption/multi_test.go
@@ -256,11 +256,14 @@ func TestOpenRetriesAfterAConcurrentRefresh(t *testing.T) {
 	// Released once every caller is under way, so that they all reach refresh
 	// together and contend for it.
 	release := make(chan struct{})
+	entered := make(chan struct{})
 	var loads int64
 
 	m := &multi{
 		loader: loaderFunc(func(context.Context) (*keySet, error) {
-			atomic.AddInt64(&loads, 1)
+			if atomic.AddInt64(&loads, 1) == 1 {
+				close(entered)
+			}
 			<-release
 			return &keySet{openers: []AEAD{fresh}}, nil
 		}),
@@ -282,8 +285,11 @@ func TestOpenRetriesAfterAConcurrentRefresh(t *testing.T) {
 		}()
 	}
 
-	// Let the single in-flight load complete once all callers are under way.
-	time.Sleep(50 * time.Millisecond)
+	// Wait for the loader to be entered rather than sleeping. A fixed sleep
+	// either wastes time or, on a slow host, releases before any caller has
+	// reached refresh, which would leave the contention this test exists for
+	// unexercised.
+	<-entered
 	close(release)
 	wg.Wait()
 
@@ -309,5 +315,79 @@ func TestNewMultiReportsLoadFailure(t *testing.T) {
 	}))
 	if !errors.Is(err, wantErr) {
 		t.Errorf("newMulti() error = %v, want %v", err, wantErr)
+	}
+}
+
+// A process which starts shortly before a new key version is written must be
+// able to recover on its first failure. Recording the construction load as a
+// refresh would rate-limit that first attempt for minRefreshInterval, leaving
+// the process unable to open anything sealed with the new version for the whole
+// window — the case this type exists to answer.
+func TestOpenRefreshesOnTheFirstFailureAfterConstruction(t *testing.T) {
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	stale := mock_encryption.NewMockAEAD(controller)
+	stale.EXPECT().Open(gomock.Any()).Return(nil, errors.New("chacha20poly1305: message authentication failed")).AnyTimes()
+
+	fresh := mock_encryption.NewMockAEAD(controller)
+	fresh.EXPECT().Open([]byte("sealed")).Return([]byte("opened"), nil).AnyTimes()
+
+	now := time.Unix(0, 0)
+	loads := 0
+
+	m, err := newMulti(t.Context(), loaderFunc(func(context.Context) (*keySet, error) {
+		loads++
+		if loads == 1 {
+			return &keySet{openers: []AEAD{stale}}, nil
+		}
+		return &keySet{openers: []AEAD{fresh}}, nil
+	}), func(m *multi) { m.now = func() time.Time { return now } })
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// No time has passed since construction, so a refresh recorded there would
+	// suppress this one.
+	got, err := m.Open([]byte("sealed"))
+	if err != nil {
+		t.Errorf("multi.Open() returned unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(got, []byte("opened")) {
+		t.Errorf("multi.Open() = %q, want %q", got, []byte("opened"))
+	}
+	if loads != 2 {
+		t.Errorf("keyLoader.load() called %d times, want 2: construction, then the first failure", loads)
+	}
+}
+
+func TestWithMinRefreshIntervalIgnoresNonPositiveDurations(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		give time.Duration
+		want time.Duration
+	}{
+		{name: "zero is ignored", give: 0, want: defaultMinRefreshInterval},
+		{name: "negative is ignored", give: -time.Minute, want: defaultMinRefreshInterval},
+		{name: "positive is applied", give: time.Minute, want: time.Minute},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &multi{minRefreshInterval: defaultMinRefreshInterval}
+			WithMinRefreshInterval(tt.give)(m)
+
+			if m.minRefreshInterval != tt.want {
+				t.Errorf("minRefreshInterval = %s, want %s", m.minRefreshInterval, tt.want)
+			}
+		})
+	}
+}
+
+// The loader is an interface seam. One which returned no keys and no error
+// would otherwise leave Open dereferencing a nil keySet.
+func TestOpenWithoutAKeySetReportsNoOpeners(t *testing.T) {
+	_, err := open(nil, []byte("sealed"))
+
+	if !errors.Is(err, errNoOpeners) {
+		t.Errorf("open() error = %v, want %v", err, errNoOpeners)
 	}
 }

--- a/pkg/util/encryption/multi_test.go
+++ b/pkg/util/encryption/multi_test.go
@@ -4,15 +4,45 @@ package encryption
 // Licensed under the Apache License 2.0.
 
 import (
+	"context"
 	"errors"
 	"reflect"
 	"testing"
+	"time"
 
 	"go.uber.org/mock/gomock"
 
 	mock_encryption "github.com/Azure/ARO-RP/pkg/util/mocks/encryption"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
 )
+
+// loaderFunc adapts a function to the keyLoader interface.
+type loaderFunc func(ctx context.Context) (*keySet, error)
+
+func (f loaderFunc) load(ctx context.Context) (*keySet, error) {
+	return f(ctx)
+}
+
+// newTestMulti returns a multi holding the given openers, with refreshes rate
+// limited out, so that a failure to open does not reach the loader.
+func newTestMulti(t *testing.T, openers ...AEAD) *multi {
+	t.Helper()
+
+	now := time.Unix(0, 0)
+
+	m := &multi{
+		loader: loaderFunc(func(context.Context) (*keySet, error) {
+			t.Error("keyLoader.load() called, want no call")
+			return nil, errors.New("unexpected refresh")
+		}),
+		minRefreshInterval: time.Hour,
+		now:                func() time.Time { return now },
+	}
+	m.keys.Store(&keySet{openers: openers})
+	m.lastRefreshed = now
+
+	return m
+}
 
 func TestOpen(t *testing.T) {
 	mockInput := []byte("fakeInput")
@@ -56,12 +86,7 @@ func TestOpen(t *testing.T) {
 			firstOpener := mock_encryption.NewMockAEAD(controller)
 			secondOpener := mock_encryption.NewMockAEAD(controller)
 
-			multi := multi{
-				openers: []AEAD{
-					firstOpener,
-					secondOpener,
-				},
-			}
+			multi := newTestMulti(t, firstOpener, secondOpener)
 
 			tt.mocks(firstOpener, secondOpener)
 
@@ -72,5 +97,149 @@ func TestOpen(t *testing.T) {
 				t.Error(b)
 			}
 		})
+	}
+}
+
+func TestOpenWithNoOpeners(t *testing.T) {
+	multi := newTestMulti(t)
+
+	b, err := multi.Open([]byte("fakeInput"))
+	if !errors.Is(err, errNoOpeners) {
+		t.Errorf("multi.Open() error = %v, want %v", err, errNoOpeners)
+	}
+	if b != nil {
+		t.Errorf("multi.Open() = %v, want nil", b)
+	}
+}
+
+// TestOpenRefreshesStaleKeys covers the case this refresh exists for: the
+// process was started before a key was rotated, so the key which sealed the
+// input is not among the ones it enumerated at start-up.
+func TestOpenRefreshesStaleKeys(t *testing.T) {
+	mockInput := []byte("fakeInput")
+	staleErr := errors.New("fake error from the stale opener")
+
+	for _, tt := range []struct {
+		name       string
+		load       func(fresh AEAD) (*keySet, error)
+		mocks      func(stale *mock_encryption.MockAEAD, fresh *mock_encryption.MockAEAD)
+		wantResult []byte
+		wantErr    string
+		wantLoads  int
+	}{
+		{
+			name: "refreshed key opens the input",
+			load: func(fresh AEAD) (*keySet, error) {
+				return &keySet{openers: []AEAD{fresh}}, nil
+			},
+			mocks: func(stale *mock_encryption.MockAEAD, fresh *mock_encryption.MockAEAD) {
+				stale.EXPECT().Open(mockInput).Return(nil, staleErr)
+				fresh.EXPECT().Open(mockInput).Return([]byte("result from the fresh opener"), nil)
+			},
+			wantResult: []byte("result from the fresh opener"),
+			wantLoads:  1,
+		},
+		{
+			name: "refreshed key does not open the input either",
+			load: func(fresh AEAD) (*keySet, error) {
+				return &keySet{openers: []AEAD{fresh}}, nil
+			},
+			mocks: func(stale *mock_encryption.MockAEAD, fresh *mock_encryption.MockAEAD) {
+				stale.EXPECT().Open(mockInput).Return(nil, staleErr)
+				fresh.EXPECT().Open(mockInput).Return(nil, errors.New("fake error from the fresh opener"))
+			},
+			// The original error is reported, not the one from the retry.
+			wantErr:   "fake error from the stale opener",
+			wantLoads: 1,
+		},
+		{
+			name: "refresh fails",
+			load: func(fresh AEAD) (*keySet, error) {
+				return nil, errors.New("fake error from key vault")
+			},
+			mocks: func(stale *mock_encryption.MockAEAD, fresh *mock_encryption.MockAEAD) {
+				stale.EXPECT().Open(mockInput).Return(nil, staleErr)
+			},
+			wantErr:   "fake error from the stale opener",
+			wantLoads: 1,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			controller := gomock.NewController(t)
+			defer controller.Finish()
+
+			stale := mock_encryption.NewMockAEAD(controller)
+			fresh := mock_encryption.NewMockAEAD(controller)
+			tt.mocks(stale, fresh)
+
+			loads := 0
+			now := time.Unix(0, 0)
+
+			m := &multi{
+				loader: loaderFunc(func(context.Context) (*keySet, error) {
+					loads++
+					return tt.load(fresh)
+				}),
+				minRefreshInterval: time.Hour,
+				now:                func() time.Time { return now },
+			}
+			m.keys.Store(&keySet{openers: []AEAD{stale}})
+			m.lastRefreshed = now.Add(-time.Hour)
+
+			b, err := m.Open(mockInput)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
+			if !reflect.DeepEqual(b, tt.wantResult) {
+				t.Errorf("multi.Open(%q) = %q, want %q", mockInput, b, tt.wantResult)
+			}
+			if loads != tt.wantLoads {
+				t.Errorf("keyLoader.load() called %d times, want %d", loads, tt.wantLoads)
+			}
+		})
+	}
+}
+
+// TestRefreshIsRateLimited checks that a run of inputs which no key can open
+// cannot become a run of Key Vault requests.
+func TestRefreshIsRateLimited(t *testing.T) {
+	loads := 0
+	now := time.Unix(0, 0)
+
+	m := &multi{
+		loader: loaderFunc(func(context.Context) (*keySet, error) {
+			loads++
+			return &keySet{}, nil
+		}),
+		minRefreshInterval: time.Hour,
+		now:                func() time.Time { return now },
+	}
+	m.keys.Store(&keySet{})
+	m.lastRefreshed = now.Add(-time.Hour)
+
+	if got := m.refresh(); !got {
+		t.Errorf("multi.refresh() = %v, want true", got)
+	}
+	if got := m.refresh(); got {
+		t.Errorf("multi.refresh() = %v after an immediate second call, want false", got)
+	}
+
+	now = now.Add(time.Hour)
+
+	if got := m.refresh(); !got {
+		t.Errorf("multi.refresh() = %v after minRefreshInterval elapsed, want true", got)
+	}
+
+	if loads != 2 {
+		t.Errorf("keyLoader.load() called %d times, want 2", loads)
+	}
+}
+
+func TestNewMultiReportsLoadFailure(t *testing.T) {
+	wantErr := errors.New("fake error from key vault")
+
+	_, err := newMulti(context.Background(), loaderFunc(func(context.Context) (*keySet, error) {
+		return nil, wantErr
+	}))
+	if !errors.Is(err, wantErr) {
+		t.Errorf("newMulti() error = %v, want %v", err, wantErr)
 	}
 }

--- a/pkg/util/encryption/multi_test.go
+++ b/pkg/util/encryption/multi_test.go
@@ -243,6 +243,7 @@ func TestOpenRetriesAfterAConcurrentRefresh(t *testing.T) {
 	const callers = 8
 
 	controller := gomock.NewController(t)
+	defer controller.Finish()
 
 	stale := mock_encryption.NewMockAEAD(controller)
 	stale.EXPECT().Open(gomock.Any()).Return(nil, errors.New("chacha20poly1305: message authentication failed")).AnyTimes()


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://redhat.atlassian.net/browse/ARO-29320

### What this PR does / why we need it:

The services which hold an `encryption.AEAD` are long lived. Each enumerates the versions of
the encryption secret once, at start-up, and holds the resulting openers for the lifetime of
the process. A version created after that point is absent until the process is restarted,
and every document sealed with it fails to open, with an error which describes the cipher
rather than the cause.

This PR re-enumerates the versions when an input cannot be opened by any key held, and
retries once.

- Refreshes are serialised and rate limited to one every five minutes, so a run of inputs
  which no key can open cannot become a run of Key Vault requests.
- The interval is recorded **before** the attempt, so a Key Vault which is slow or failing
  is not asked again any sooner than one which answered.
- The keys are held in an `atomic.Pointer` and replaced wholesale, so `Open` takes no lock
  in the common case.

This is a defence-in-depth measure. It does not remove the need to restart a service after
its secrets are rotated (see [ARO-29319](https://redhat.atlassian.net/browse/ARO-29319)), but it bounds the consequences of not doing so.

It also fixes a latent defect in `Open`: it used a named return, so an empty opener set
yielded `(nil, nil)` — silently returning nil plaintext with no error. It now returns
`errNoOpeners`.

The refresh is driven through a `keyLoader` interface rather than the `azsecrets` client
directly. That is a testability seam: `NewListSecretPropertiesVersionsPager` returns a
`*runtime.Pager[...]`, which is impractical to fake.

Configuration is by variadic `Option` (`WithLogger`, `WithMinRefreshInterval`) so that the
nine existing `NewMulti`/`NewAEADWithCore` call sites are unaffected. `WithLogger` is wired
into the five long-lived services only.

### Test plan for issue:

Unit tests in `pkg/util/encryption/multi_test.go`, using a `loaderFunc` seam:

- the original `TestOpen` is preserved unchanged;
- `TestOpenRefreshesStaleKeys` — an input sealed under a key added after construction opens
  after the refresh;
- `TestRefreshIsRateLimited` — repeated failures produce one load, not many;
- `TestOpenWithNoOpeners` — covers the `(nil, nil)` defect;
- `TestNewMultiReportsLoadFailure`.

### Is there any documentation that needs to be updated for this PR?

No. `AEAD` is unchanged from a caller's point of view; the new options are additive and
default to the previous behaviour minus the refresh.

### How do you know this will function as expected in production?

The change is inert on the success path: `Open` is untouched when a held key works, and
takes no lock. It only does anything on an input no key can open, which today is an
unrecoverable error.

The cost of the new path is bounded by construction — at most one Key Vault enumeration per
process per five minutes, regardless of how many documents fail — and a failed or slow
enumeration does not shorten that interval. A refresh which fails leaves the previous key
set in place and returns the original open error, so the worst case is the behaviour before
this change.

Refreshes are logged, so a service which is repeatedly refreshing is visible as a service
which is missing key versions.
