### PR TITLE
[ARO-29321] Make the Cosmos DB change feed resilient to a page it cannot read

### DIFF
--- a/pkg/database/cosmosdb/changefeed.go
+++ b/pkg/database/cosmosdb/changefeed.go
@@ -1,0 +1,186 @@
+package cosmosdb
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+
+	pkg "github.com/Azure/ARO-RP/pkg/api"
+)
+
+// defaultChangeFeedMaxFailures is how many consecutive failures at the same
+// position are tolerated before a resilient change feed gives up on the page
+// and moves on.
+//
+// The consumers poll every ten seconds, so thirty failures is five minutes of
+// uninterrupted failure. That is far longer than any throttling or transient
+// service fault, and so short against the time a stalled feed can otherwise go
+// unnoticed that the choice is not delicate.
+const defaultChangeFeedMaxFailures = 30
+
+// A resilientChangeFeedIterator is a change feed iterator which can make
+// progress past a page it cannot read.
+//
+// The generated iterators cannot. Their continuation advances only after a
+// successful read, so a page which fails deterministically — because a document
+// in it cannot be decoded, say, because the key which sealed it is not held —
+// is re-requested from the same position on every poll, for as long as the
+// process runs. Nothing downstream of the feed is then updated again.
+//
+// This type re-implements Next with that error path corrected. It is
+// hand-written because the generated files must not be edited; if the change is
+// taken upstream into the generator, this file can be deleted.
+type resilientChangeFeedIterator[T any] struct {
+	client     *databaseClient
+	path       string
+	options    *Options
+	setOptions func(*Options, http.Header) error
+
+	continuation        string
+	consecutiveFailures int
+	maxFailures         int
+}
+
+func newResilientChangeFeedIterator[T any](client *databaseClient, path string, options *Options, setOptions func(*Options, http.Header) error) *resilientChangeFeedIterator[T] {
+	continuation := ""
+	if options != nil {
+		continuation = options.Continuation
+	}
+
+	return &resilientChangeFeedIterator[T]{
+		client:       client,
+		path:         path,
+		options:      options,
+		setOptions:   setOptions,
+		continuation: continuation,
+		maxFailures:  defaultChangeFeedMaxFailures,
+	}
+}
+
+func (i *resilientChangeFeedIterator[T]) Next(ctx context.Context, maxItemCount int) (*T, error) {
+	headers := http.Header{}
+	headers.Set("A-IM", "Incremental feed")
+	headers.Set("X-Ms-Max-Item-Count", strconv.Itoa(maxItemCount))
+	if i.continuation != "" {
+		headers.Set("If-None-Match", i.continuation)
+	}
+
+	err := i.setOptions(i.options, headers)
+	if err != nil {
+		return nil, err
+	}
+
+	var docs *T
+	err = i.client.do(ctx, http.MethodGet, i.path+"/docs", "docs", i.path, http.StatusOK, nil, &docs, headers)
+	if IsErrorStatusCode(err, http.StatusNotModified) {
+		err = nil
+	}
+	if err != nil {
+		i.onFailure(headers, err)
+		return nil, err
+	}
+
+	i.consecutiveFailures = 0
+	i.continuation = headers.Get("Etag")
+
+	return docs, nil
+}
+
+// onFailure records a failed read and, once the same position has failed
+// maxFailures times in succession, advances past it.
+//
+// The position to advance to is already in hand. do copies the response headers
+// into the caller's map whenever there was a response at all, and _do returns
+// the response alongside a decode error, so the Etag naming the page after this
+// one is present even though the read failed.
+//
+// It is absent when there was no response — a transport error, for instance —
+// which is why the advance is conditional on it. An empty If-None-Match asks
+// Cosmos DB to read the feed from the beginning, so advancing to "" would reset
+// the feed, re-read the whole collection, and arrive back at the same page.
+// The guard is load-bearing rather than defensive.
+//
+// Requiring maxFailures consecutive failures, and resetting the count on any
+// success, means the threshold measures persistence: a page is only ever
+// skipped when it cannot be read at all, never during a passing fault.
+func (i *resilientChangeFeedIterator[T]) onFailure(headers http.Header, err error) {
+	i.consecutiveFailures++
+
+	// Acting on every maxFailures'th failure rather than on every failure past
+	// the first threshold keeps a feed which cannot advance from logging on
+	// every poll, while still having it report itself periodically.
+	if i.consecutiveFailures%i.maxFailures != 0 {
+		return
+	}
+
+	etag := headers.Get("Etag")
+	if etag == "" || etag == i.continuation {
+		i.client.log.Errorf("changefeed %s: %d consecutive failures with no position to advance to; the feed is stalled: %s", i.path, i.consecutiveFailures, err)
+		return
+	}
+
+	i.client.log.Errorf("changefeed %s: advancing past a page which failed %d times in succession; its contents will not be delivered: %s", i.path, i.consecutiveFailures, err)
+
+	i.continuation = etag
+	i.consecutiveFailures = 0
+}
+
+func (i *resilientChangeFeedIterator[T]) Continuation() string {
+	return i.continuation
+}
+
+// NewResilientOpenShiftClusterDocumentChangeFeed returns a change feed iterator
+// which can make progress past a page it cannot read. See
+// resilientChangeFeedIterator.
+func NewResilientOpenShiftClusterDocumentChangeFeed(c OpenShiftClusterDocumentClient, options *Options) OpenShiftClusterDocumentIterator {
+	cc, ok := c.(*openShiftClusterDocumentClient)
+	if !ok {
+		// Not a real Cosmos DB client — the fake, in all current cases. It has
+		// no failing page to get past.
+		return c.ChangeFeed(options)
+	}
+
+	return newResilientChangeFeedIterator[pkg.OpenShiftClusterDocuments](
+		cc.databaseClient, cc.path, options,
+		func(options *Options, headers http.Header) error {
+			return cc.setOptions(options, nil, headers)
+		},
+	)
+}
+
+// NewResilientSubscriptionDocumentChangeFeed returns a change feed iterator
+// which can make progress past a page it cannot read. See
+// resilientChangeFeedIterator.
+func NewResilientSubscriptionDocumentChangeFeed(c SubscriptionDocumentClient, options *Options) SubscriptionDocumentIterator {
+	cc, ok := c.(*subscriptionDocumentClient)
+	if !ok {
+		return c.ChangeFeed(options)
+	}
+
+	return newResilientChangeFeedIterator[pkg.SubscriptionDocuments](
+		cc.databaseClient, cc.path, options,
+		func(options *Options, headers http.Header) error {
+			return cc.setOptions(options, nil, headers)
+		},
+	)
+}
+
+// NewResilientGatewayDocumentChangeFeed returns a change feed iterator which
+// can make progress past a page it cannot read. See
+// resilientChangeFeedIterator.
+func NewResilientGatewayDocumentChangeFeed(c GatewayDocumentClient, options *Options) GatewayDocumentIterator {
+	cc, ok := c.(*gatewayDocumentClient)
+	if !ok {
+		return c.ChangeFeed(options)
+	}
+
+	return newResilientChangeFeedIterator[pkg.GatewayDocuments](
+		cc.databaseClient, cc.path, options,
+		func(options *Options, headers http.Header) error {
+			return cc.setOptions(options, nil, headers)
+		},
+	)
+}

--- a/pkg/database/cosmosdb/changefeed.go
+++ b/pkg/database/cosmosdb/changefeed.go
@@ -42,6 +42,7 @@ type resilientChangeFeedIterator[T any] struct {
 	continuation        string
 	consecutiveFailures int
 	maxFailures         int
+	pagesSkipped        int
 }
 
 func newResilientChangeFeedIterator[T any](client *databaseClient, path string, options *Options, setOptions func(*Options, http.Header) error) *resilientChangeFeedIterator[T] {
@@ -126,6 +127,16 @@ func (i *resilientChangeFeedIterator[T]) onFailure(headers http.Header, err erro
 
 	i.continuation = etag
 	i.consecutiveFailures = 0
+	i.pagesSkipped++
+}
+
+// PagesSkipped is the number of pages this iterator has given up on and
+// advanced past. It only ever rises, so that a skip remains visible after the
+// feed recovers: the consecutive-failure count resets on the next success, and
+// a page whose contents were never delivered would otherwise leave nothing
+// behind but a log line.
+func (i *resilientChangeFeedIterator[T]) PagesSkipped() int {
+	return i.pagesSkipped
 }
 
 func (i *resilientChangeFeedIterator[T]) Continuation() string {

--- a/pkg/database/cosmosdb/changefeed_test.go
+++ b/pkg/database/cosmosdb/changefeed_test.go
@@ -99,6 +99,9 @@ func TestChangeFeedAdvancesPastAnUnreadablePage(t *testing.T) {
 		if got := i.Continuation(); got != startPosition {
 			t.Errorf("iterator.Continuation() = %q after %d of %d tolerated failures, want %q", got, attempt, maxFailures, startPosition)
 		}
+		if got := i.PagesSkipped(); got != 0 {
+			t.Errorf("iterator.PagesSkipped() = %d after %d of %d tolerated failures, want 0", got, attempt, maxFailures)
+		}
 	}
 
 	nextExpectingFailure(t, i, maxFailures)
@@ -108,6 +111,12 @@ func TestChangeFeedAdvancesPastAnUnreadablePage(t *testing.T) {
 	}
 	if len(h.Entries) != 1 {
 		t.Errorf("logged %d entries, want 1 reporting the skipped page", len(h.Entries))
+	}
+	// The skip must remain countable after the fact. consecutiveFailures is
+	// reset by the advance, so without this the only surviving evidence that a
+	// page was never delivered is the log line above.
+	if got := i.PagesSkipped(); got != 1 {
+		t.Errorf("iterator.PagesSkipped() = %d after a page was skipped, want 1", got)
 	}
 }
 

--- a/pkg/database/cosmosdb/changefeed_test.go
+++ b/pkg/database/cosmosdb/changefeed_test.go
@@ -1,0 +1,252 @@
+package cosmosdb
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/ugorji/go/codec"
+
+	pkg "github.com/Azure/ARO-RP/pkg/api"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
+)
+
+const (
+	// startPosition is the continuation the iterators under test begin at. It
+	// is not the empty string, so that "did not advance" and "was reset to the
+	// beginning of the feed" can be told apart.
+	startPosition = "page-1"
+
+	// nextPosition is the Etag a response carries, naming the page after the
+	// one being read.
+	nextPosition = "page-2"
+
+	// undecodableBody is a response body which fails to decode, as a page
+	// containing a document sealed with a key the process does not hold does.
+	undecodableBody = "{"
+)
+
+// newTestChangeFeedIterator returns an iterator reading from hostname, and the
+// hook capturing what it logs.
+func newTestChangeFeedIterator(t *testing.T, maxFailures int, hostname string, hc *http.Client) (*resilientChangeFeedIterator[pkg.OpenShiftClusterDocuments], *test.Hook) {
+	t.Helper()
+
+	h, log := testlog.New()
+
+	i := newResilientChangeFeedIterator[pkg.OpenShiftClusterDocuments](
+		&databaseClient{
+			log:              log,
+			jsonHandle:       &codec.JsonHandle{},
+			databaseHostname: hostname,
+			hc:               hc,
+			maxRetries:       1,
+		},
+		"dbs/testdb/colls/testcoll",
+		&Options{Continuation: startPosition},
+		// The generated setOptions does nothing for a change feed read, which
+		// passes no document and no triggers.
+		func(*Options, http.Header) error { return nil },
+	)
+	i.maxFailures = maxFailures
+
+	return i, h
+}
+
+// newTestServer starts a TLS server and returns its hostname and a client
+// configured to trust it.
+func newTestServer(t *testing.T, handler http.HandlerFunc) (string, *http.Client) {
+	t.Helper()
+
+	server := httptest.NewTLSServer(handler)
+	t.Cleanup(server.Close)
+
+	return strings.TrimPrefix(server.URL, "https://"), server.Client()
+}
+
+// nextExpectingFailure calls Next and fails the test if it succeeds.
+func nextExpectingFailure(t *testing.T, i *resilientChangeFeedIterator[pkg.OpenShiftClusterDocuments], attempt int) {
+	t.Helper()
+
+	if _, err := i.Next(context.Background(), 10); err == nil {
+		t.Fatalf("iterator.Next() error = nil on attempt %d, want an error", attempt)
+	}
+}
+
+// TestChangeFeedAdvancesPastAnUnreadablePage covers the wedge this iterator
+// exists to prevent: a page which fails to decode on every attempt.
+func TestChangeFeedAdvancesPastAnUnreadablePage(t *testing.T) {
+	const maxFailures = 3
+
+	hostname, hc := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Etag", nextPosition)
+		w.WriteHeader(http.StatusOK)
+		io.WriteString(w, undecodableBody)
+	})
+
+	i, h := newTestChangeFeedIterator(t, maxFailures, hostname, hc)
+
+	for attempt := 1; attempt < maxFailures; attempt++ {
+		nextExpectingFailure(t, i, attempt)
+
+		if got := i.Continuation(); got != startPosition {
+			t.Errorf("iterator.Continuation() = %q after %d of %d tolerated failures, want %q", got, attempt, maxFailures, startPosition)
+		}
+	}
+
+	nextExpectingFailure(t, i, maxFailures)
+
+	if got := i.Continuation(); got != nextPosition {
+		t.Errorf("iterator.Continuation() = %q after %d failures, want %q", got, maxFailures, nextPosition)
+	}
+	if len(h.Entries) != 1 {
+		t.Errorf("logged %d entries, want 1 reporting the skipped page", len(h.Entries))
+	}
+}
+
+// TestChangeFeedDoesNotAdvanceWithoutAPosition is the most important test here.
+// An empty If-None-Match asks Cosmos DB to read from the beginning of the feed,
+// so advancing to an absent Etag would re-read the entire collection and arrive
+// back where it started. The iterator must stay put instead.
+func TestChangeFeedDoesNotAdvanceWithoutAPosition(t *testing.T) {
+	const maxFailures = 3
+
+	for _, tt := range []struct {
+		name    string
+		handler http.HandlerFunc
+		// transport reaches a port nothing is listening on, so that hc.Do
+		// fails and no response reaches do at all.
+		transport bool
+	}{
+		{
+			name:      "no response at all",
+			transport: true,
+		},
+		{
+			name: "response carries no Etag",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusInternalServerError)
+				io.WriteString(w, `{"code": "InternalServerError", "message": "fake error"}`)
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var (
+				hostname string
+				hc       *http.Client
+			)
+			if tt.transport {
+				hostname, hc = "127.0.0.1:1", &http.Client{}
+			} else {
+				hostname, hc = newTestServer(t, tt.handler)
+			}
+
+			i, _ := newTestChangeFeedIterator(t, maxFailures, hostname, hc)
+
+			// Well past the threshold, to catch an advance that is merely late.
+			for attempt := 1; attempt <= maxFailures*3; attempt++ {
+				nextExpectingFailure(t, i, attempt)
+
+				if got := i.Continuation(); got != startPosition {
+					t.Fatalf("iterator.Continuation() = %q after %d failures, want %q", got, attempt, startPosition)
+				}
+			}
+		})
+	}
+}
+
+// TestChangeFeedResetsItsFailureCountOnSuccess checks that the threshold
+// measures persistent failure rather than accumulated failure, so that a page
+// is never skipped because of faults spread across an otherwise healthy feed.
+func TestChangeFeedResetsItsFailureCountOnSuccess(t *testing.T) {
+	const (
+		maxFailures     = 3
+		positionAfterOK = "page-a"
+		positionAfterKO = "page-b"
+	)
+
+	attempts := 0
+
+	hostname, hc := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case attempts < maxFailures:
+			// Short of the threshold, then interrupted by a success.
+			w.Header().Set("Etag", nextPosition)
+			w.WriteHeader(http.StatusOK)
+			io.WriteString(w, undecodableBody)
+		case attempts == maxFailures:
+			w.Header().Set("Etag", positionAfterOK)
+			w.WriteHeader(http.StatusOK)
+			io.WriteString(w, `{}`)
+		default:
+			w.Header().Set("Etag", positionAfterKO)
+			w.WriteHeader(http.StatusOK)
+			io.WriteString(w, undecodableBody)
+		}
+	})
+
+	i, _ := newTestChangeFeedIterator(t, maxFailures, hostname, hc)
+
+	for attempt := 1; attempt < maxFailures; attempt++ {
+		nextExpectingFailure(t, i, attempt)
+	}
+
+	if _, err := i.Next(context.Background(), 10); err != nil {
+		t.Fatalf("iterator.Next() error = %v on the successful attempt, want nil", err)
+	}
+	if got := i.Continuation(); got != positionAfterOK {
+		t.Fatalf("iterator.Continuation() = %q after a successful read, want %q", got, positionAfterOK)
+	}
+
+	// Had the count not been reset, the first of these would take the iterator
+	// past the threshold and advance it.
+	for attempt := 1; attempt < maxFailures; attempt++ {
+		nextExpectingFailure(t, i, attempt)
+
+		if got := i.Continuation(); got != positionAfterOK {
+			t.Errorf("iterator.Continuation() = %q after %d failures following a success, want %q", got, attempt, positionAfterOK)
+		}
+	}
+
+	nextExpectingFailure(t, i, maxFailures)
+
+	if got := i.Continuation(); got != positionAfterKO {
+		t.Errorf("iterator.Continuation() = %q after %d consecutive failures, want %q", got, maxFailures, positionAfterKO)
+	}
+}
+
+// TestChangeFeedReportsAStallPeriodically checks that a feed which can neither
+// read nor advance says so more than once, but not on every poll. The incident
+// which prompted this produced 5.49 million identical log lines.
+func TestChangeFeedReportsAStallPeriodically(t *testing.T) {
+	const maxFailures = 3
+
+	hostname, hc := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		io.WriteString(w, `{"code": "InternalServerError", "message": "fake error"}`)
+	})
+
+	i, h := newTestChangeFeedIterator(t, maxFailures, hostname, hc)
+
+	const polls = maxFailures * 4
+	for attempt := 1; attempt <= polls; attempt++ {
+		nextExpectingFailure(t, i, attempt)
+	}
+
+	if want := polls / maxFailures; len(h.Entries) != want {
+		t.Errorf("logged %d entries over %d failed polls, want %d", len(h.Entries), polls, want)
+	}
+}

--- a/pkg/database/gateway.go
+++ b/pkg/database/gateway.go
@@ -46,7 +46,7 @@ func (c *gateway) NewUUID() string {
 }
 
 func (c *gateway) ChangeFeed() cosmosdb.GatewayDocumentIterator {
-	return c.c.ChangeFeed(nil)
+	return cosmosdb.NewResilientGatewayDocumentChangeFeed(c.c, nil)
 }
 
 func (c *gateway) Create(ctx context.Context, doc *api.GatewayDocument) (*api.GatewayDocument, error) {

--- a/pkg/database/openshiftclusters.go
+++ b/pkg/database/openshiftclusters.go
@@ -243,7 +243,7 @@ func (c *openShiftClusters) Delete(ctx context.Context, doc *api.OpenShiftCluste
 }
 
 func (c *openShiftClusters) ChangeFeed() cosmosdb.OpenShiftClusterDocumentIterator {
-	return c.c.ChangeFeed(nil)
+	return cosmosdb.NewResilientOpenShiftClusterDocumentChangeFeed(c.c, nil)
 }
 
 func (c *openShiftClusters) List(continuation string) cosmosdb.OpenShiftClusterDocumentIterator {

--- a/pkg/database/subscriptions.go
+++ b/pkg/database/subscriptions.go
@@ -115,7 +115,7 @@ func (c *subscriptions) update(ctx context.Context, doc *api.SubscriptionDocumen
 }
 
 func (c *subscriptions) ChangeFeed() cosmosdb.SubscriptionDocumentIterator {
-	return c.c.ChangeFeed(nil)
+	return cosmosdb.NewResilientSubscriptionDocumentChangeFeed(c.c, nil)
 }
 
 func (c *subscriptions) Dequeue(ctx context.Context) (*api.SubscriptionDocument, error) {

--- a/pkg/mimo/scheduler/manager_test.go
+++ b/pkg/mimo/scheduler/manager_test.go
@@ -1356,7 +1356,7 @@ func TestProcessLoop(t *testing.T) {
 
 			// check the metrics -- we don't want any floats, but we do have gauges
 			metrics.AssertFloats()
-			metrics.AssertGauges(tt.expectedMetrics...)
+			metrics.AssertGauges(withChangefeedGauges(tt.expectedMetrics)...)
 		})
 	}
 }

--- a/pkg/mimo/scheduler/manager_test.go
+++ b/pkg/mimo/scheduler/manager_test.go
@@ -6,6 +6,7 @@ package scheduler
 import (
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -1272,10 +1273,19 @@ func TestProcessLoop(t *testing.T) {
 				WithSubscriptions(subscriptions)
 
 			stop := make(chan struct{})
-			t.Cleanup(func() { close(stop) })
 
 			serv := NewService(_env, log, dbs, metrics)
 			serv.changefeedInterval = 10 * time.Millisecond
+
+			// The changefeeds emit metrics on every poll, and the fake emitter
+			// requires every emitted metric to be accounted for, so they must
+			// be stopped before the assertions below rather than left running
+			// alongside them.
+			stopChangefeeds := sync.OnceFunc(func() {
+				close(stop)
+				serv.changefeeds.Wait()
+			})
+			t.Cleanup(stopChangefeeds)
 
 			a := &scheduler{
 				log: log,
@@ -1355,6 +1365,7 @@ func TestProcessLoop(t *testing.T) {
 			require.NoError(err)
 
 			// check the metrics -- we don't want any floats, but we do have gauges
+			stopChangefeeds()
 			metrics.AssertFloats()
 			metrics.AssertGauges(withChangefeedGauges(tt.expectedMetrics)...)
 		})

--- a/pkg/mimo/scheduler/service.go
+++ b/pkg/mimo/scheduler/service.go
@@ -66,6 +66,11 @@ type service struct {
 	workerCount  *atomic.Int32
 	newScheduler newSchedulerFunc
 
+	// changefeeds tracks the goroutines started by startChangefeeds, so that a
+	// caller which closes their stop channel can wait for them to exit rather
+	// than leaving them running.
+	changefeeds sync.WaitGroup
+
 	buckets  atomic.Value // []int
 	b        buckets.WorkerPool[*api.MaintenanceScheduleDocument]
 	subs     changefeed.SubscriptionsCache
@@ -292,20 +297,28 @@ func (s *service) startChangefeeds(ctx context.Context, stop <-chan struct{}) er
 	}
 
 	// start subscription changefeed
-	go changefeed.RunChangefeed(
-		ctx, s.baseLog.WithField("component", "changefeed"), s.m, "SubscriptionDocument",
-		dbSubscriptions.ChangeFeed(),
-		s.changefeedInterval,
-		s.changefeedBatchSize, s.subs, stop,
-	)
+	s.changefeeds.Add(1)
+	go func() {
+		defer s.changefeeds.Done()
+		changefeed.RunChangefeed(
+			ctx, s.baseLog.WithField("component", "changefeed"), s.m, "SubscriptionDocument",
+			dbSubscriptions.ChangeFeed(),
+			s.changefeedInterval,
+			s.changefeedBatchSize, s.subs, stop,
+		)
+	}()
 
 	// start cluster changefeed
-	go changefeed.RunChangefeed(
-		ctx, s.baseLog.WithField("component", "changefeed"), s.m, "OpenShiftClusterDocument",
-		dbOpenShiftClusters.ChangeFeed(),
-		s.changefeedInterval,
-		s.changefeedBatchSize, s.clusters, stop,
-	)
+	s.changefeeds.Add(1)
+	go func() {
+		defer s.changefeeds.Done()
+		changefeed.RunChangefeed(
+			ctx, s.baseLog.WithField("component", "changefeed"), s.m, "OpenShiftClusterDocument",
+			dbOpenShiftClusters.ChangeFeed(),
+			s.changefeedInterval,
+			s.changefeedBatchSize, s.clusters, stop,
+		)
+	}()
 
 	return nil
 }

--- a/pkg/mimo/scheduler/service.go
+++ b/pkg/mimo/scheduler/service.go
@@ -293,14 +293,16 @@ func (s *service) startChangefeeds(ctx context.Context, stop <-chan struct{}) er
 
 	// start subscription changefeed
 	go changefeed.RunChangefeed(
-		ctx, s.baseLog.WithField("component", "changefeed"), dbSubscriptions.ChangeFeed(),
+		ctx, s.baseLog.WithField("component", "changefeed"), s.m, "SubscriptionDocument",
+		dbSubscriptions.ChangeFeed(),
 		s.changefeedInterval,
 		s.changefeedBatchSize, s.subs, stop,
 	)
 
 	// start cluster changefeed
 	go changefeed.RunChangefeed(
-		ctx, s.baseLog.WithField("component", "changefeed"), dbOpenShiftClusters.ChangeFeed(),
+		ctx, s.baseLog.WithField("component", "changefeed"), s.m, "OpenShiftClusterDocument",
+		dbOpenShiftClusters.ChangeFeed(),
 		s.changefeedInterval,
 		s.changefeedBatchSize, s.clusters, stop,
 	)

--- a/pkg/mimo/scheduler/service_test.go
+++ b/pkg/mimo/scheduler/service_test.go
@@ -23,11 +23,34 @@ import (
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
 	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/metrics"
+	"github.com/Azure/ARO-RP/pkg/util/changefeed"
 	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
 	testdatabase "github.com/Azure/ARO-RP/test/database"
 	testlog "github.com/Azure/ARO-RP/test/util/log"
 	testmetrics "github.com/Azure/ARO-RP/test/util/metrics"
 )
+
+// withChangefeedGauges returns assertions together with the metrics the
+// service's two changefeeds emit on every poll. Tests which run the service
+// need them so that the fake emitter, which requires every emitted metric to
+// be accounted for, is satisfied; the values themselves are covered by the
+// changefeed's own tests.
+func withChangefeedGauges(assertions []testmetrics.MetricsAssertion[int64]) []testmetrics.MetricsAssertion[int64] {
+	all := make([]testmetrics.MetricsAssertion[int64], 0, len(assertions)+4)
+	all = append(all, assertions...)
+
+	for _, name := range []string{"OpenShiftClusterDocument", "SubscriptionDocument"} {
+		for _, metric := range []string{changefeed.MetricStaleness, changefeed.MetricConsecutiveFailures} {
+			all = append(all, testmetrics.MetricsAssertion[int64]{
+				MetricName: metric,
+				Dimensions: map[string]string{"name": name},
+				Value:      0,
+			})
+		}
+	}
+
+	return all
+}
 
 func TestSchedulerPolling(t *testing.T) {
 	testCases := []struct {
@@ -374,7 +397,7 @@ func TestSchedulerGoesReady(t *testing.T) {
 	r.Equal(int32(0), svc.workerCount.Load())
 
 	m.AssertFloats()
-	m.AssertGauges([]testmetrics.MetricsAssertion[int64]{
+	m.AssertGauges(withChangefeedGauges([]testmetrics.MetricsAssertion[int64]{
 		{
 			MetricName: "changefeed.caches.size",
 			Dimensions: map[string]string{
@@ -388,7 +411,7 @@ func TestSchedulerGoesReady(t *testing.T) {
 			Dimensions: map[string]string{},
 			Value:      0,
 		},
-	}...)
+	})...)
 }
 
 func TestSchedulerStopsIfBucketFailure(t *testing.T) {
@@ -576,7 +599,7 @@ func TestSchedulerServesBucket(t *testing.T) {
 	r.Equal(int32(0), svc.workerCount.Load())
 
 	m.AssertFloats()
-	m.AssertGauges([]testmetrics.MetricsAssertion[int64]{
+	m.AssertGauges(withChangefeedGauges([]testmetrics.MetricsAssertion[int64]{
 		{
 			MetricName: "changefeed.caches.size",
 			Dimensions: map[string]string{
@@ -614,7 +637,7 @@ func TestSchedulerServesBucket(t *testing.T) {
 			Dimensions: map[string]string{},
 			Value:      0,
 		},
-	}...)
+	})...)
 }
 
 func TestSchedulerServesBucketWhenChanges(t *testing.T) {
@@ -773,7 +796,7 @@ func TestSchedulerServesBucketWhenChanges(t *testing.T) {
 	r.Equal(int32(0), svc.workerCount.Load())
 
 	m.AssertFloats()
-	m.AssertGauges([]testmetrics.MetricsAssertion[int64]{
+	m.AssertGauges(withChangefeedGauges([]testmetrics.MetricsAssertion[int64]{
 		{
 			MetricName: "changefeed.caches.size",
 			Dimensions: map[string]string{
@@ -821,7 +844,7 @@ func TestSchedulerServesBucketWhenChanges(t *testing.T) {
 			Dimensions: map[string]string{},
 			Value:      0,
 		},
-	}...)
+	})...)
 }
 
 func TestSchedulerDoesNotProcessConstantlyIfNoUpdates(t *testing.T) {
@@ -937,7 +960,7 @@ func TestSchedulerDoesNotProcessConstantlyIfNoUpdates(t *testing.T) {
 			r.Equal(int32(0), svc.workerCount.Load())
 
 			m.AssertFloats()
-			m.AssertGauges([]testmetrics.MetricsAssertion[int64]{
+			m.AssertGauges(withChangefeedGauges([]testmetrics.MetricsAssertion[int64]{
 				{
 					MetricName: "changefeed.caches.size",
 					Dimensions: map[string]string{
@@ -951,7 +974,7 @@ func TestSchedulerDoesNotProcessConstantlyIfNoUpdates(t *testing.T) {
 					Dimensions: map[string]string{},
 					Value:      0,
 				},
-			}...)
+			})...)
 		})
 	}
 }

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -206,7 +206,8 @@ func (mon *monitor) startChangefeeds(ctx context.Context, stop <-chan struct{}) 
 
 	// fill the cache from the database change feed
 	go changefeed.RunChangefeed(
-		ctx, mon.baseLog.WithField("component", "changefeed"), dbOpenShiftClusters.ChangeFeed(),
+		ctx, mon.baseLog.WithField("component", "changefeed"), mon.m, "OpenShiftClusterDocument",
+		dbOpenShiftClusters.ChangeFeed(),
 		// Align this time with the deletion mechanism.
 		// Go to docs/monitoring.md for the details.
 		mon.changefeedInterval,
@@ -215,7 +216,8 @@ func (mon *monitor) startChangefeeds(ctx context.Context, stop <-chan struct{}) 
 
 	// fill the cache from the database change feed
 	go changefeed.RunChangefeed(
-		ctx, mon.baseLog.WithField("component", "changefeed"), dbSubscriptions.ChangeFeed(),
+		ctx, mon.baseLog.WithField("component", "changefeed"), mon.m, "SubscriptionDocument",
+		dbSubscriptions.ChangeFeed(),
 		mon.changefeedInterval,
 		changefeedBatchSize, mon.subs, stop,
 	)

--- a/pkg/otel/gatewayauth/gatewayauth.go
+++ b/pkg/otel/gatewayauth/gatewayauth.go
@@ -67,6 +67,7 @@ var _ client.AuthData = gatewayAuthInfo{}
 type authManager struct {
 	_env env.Core
 	log  *logrus.Entry
+	m    metrics.Emitter
 
 	// Underlying TLS transport configuration (serving key/cert)
 	tls credentials.TransportCredentials
@@ -94,6 +95,7 @@ func newAuthManager(
 	return &authManager{
 		_env: _env,
 		log:  _env.LoggerForComponent("auth"),
+		m:    m,
 
 		tls: tls,
 
@@ -105,7 +107,8 @@ func newAuthManager(
 
 func (m *authManager) startChangefeed(ctx context.Context, db database.Gateway) {
 	go changefeed.RunChangefeed(
-		ctx, m._env.LoggerForComponent("changefeed"), db.ChangeFeed(),
+		ctx, m._env.LoggerForComponent("changefeed"), m.m, "GatewayDocument",
+		db.ChangeFeed(),
 		m.changefeedRefreshInterval,
 		m.changefeedBatchSize, m.gatewayCache, ctx.Done(),
 	)

--- a/pkg/util/changefeed/changefeed.go
+++ b/pkg/util/changefeed/changefeed.go
@@ -11,7 +11,19 @@ import (
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/database"
+	"github.com/Azure/ARO-RP/pkg/metrics"
 	"github.com/Azure/ARO-RP/pkg/util/recover"
+)
+
+const (
+	// MetricStaleness is the number of seconds since the changefeed last
+	// completed a poll without error. It rises without bound while a feed is
+	// stalled, and is the signal to alert on.
+	MetricStaleness = "changefeed.poll.staleness"
+
+	// MetricConsecutiveFailures is the number of polls which have failed in
+	// succession. It tells a stalled feed apart from a quiet one.
+	MetricConsecutiveFailures = "changefeed.poll.failures"
 )
 
 // Generic interface of a consumer that NewChangefeed will call with documents,
@@ -28,16 +40,30 @@ type ChangefeedConsumer[F any] interface {
 	Unlock()
 }
 
+// RunChangefeed polls iterator until stop is closed, passing each document to
+// responder.
+//
+// name identifies the feed in logs and metrics; it is conventionally the
+// document type, as for changefeed.caches.size.
 func RunChangefeed[F any, X api.DocumentList[F]](
 	ctx context.Context,
 	log *logrus.Entry,
+	m metrics.Emitter,
+	name string,
 	iterator database.DocumentIterator[F, X],
 	changefeedInterval time.Duration,
 	changefeedBatchSize int,
 	responder ChangefeedConsumer[F],
 	stop <-chan struct{},
 ) {
+	log = log.WithField("changefeed", name)
+
 	defer recover.Panic(log)
+
+	dimensions := map[string]string{"name": name}
+
+	lastSuccessfulPoll := time.Now()
+	consecutiveFailures := 0
 
 	t := time.NewTicker(changefeedInterval)
 	defer t.Stop()
@@ -67,8 +93,18 @@ func RunChangefeed[F any, X api.DocumentList[F]](
 		}
 
 		if successful {
+			lastSuccessfulPoll = time.Now()
+			consecutiveFailures = 0
 			responder.OnAllPendingProcessed(documentsRetrieved)
+		} else {
+			consecutiveFailures++
 		}
+
+		// Emitted on every poll, successful or not. A feed which has stopped
+		// advancing is otherwise indistinguishable from one with nothing to
+		// report, which is how a month-long stall went unnoticed.
+		m.EmitGauge(MetricStaleness, int64(time.Since(lastSuccessfulPoll).Seconds()), dimensions)
+		m.EmitGauge(MetricConsecutiveFailures, int64(consecutiveFailures), dimensions)
 
 		select {
 		case <-t.C:

--- a/pkg/util/changefeed/changefeed.go
+++ b/pkg/util/changefeed/changefeed.go
@@ -24,7 +24,19 @@ const (
 	// MetricConsecutiveFailures is the number of polls which have failed in
 	// succession. It tells a stalled feed apart from a quiet one.
 	MetricConsecutiveFailures = "changefeed.poll.failures"
+
+	// MetricPagesSkipped is the number of pages the feed has given up on and
+	// advanced past, whose contents were therefore never delivered. It only
+	// rises, so that a skip stays visible after the feed recovers and the
+	// failure count resets.
+	MetricPagesSkipped = "changefeed.pages.skipped"
 )
+
+// A skipReporter is an iterator which can say how many pages it has given up
+// on. Iterators which cannot skip do not implement it, and report nothing.
+type skipReporter interface {
+	PagesSkipped() int
+}
 
 // Generic interface of a consumer that NewChangefeed will call with documents,
 // completed pages, etc.
@@ -105,6 +117,10 @@ func RunChangefeed[F any, X api.DocumentList[F]](
 		// report, which is how a month-long stall went unnoticed.
 		m.EmitGauge(MetricStaleness, int64(time.Since(lastSuccessfulPoll).Seconds()), dimensions)
 		m.EmitGauge(MetricConsecutiveFailures, int64(consecutiveFailures), dimensions)
+
+		if s, ok := iterator.(skipReporter); ok {
+			m.EmitGauge(MetricPagesSkipped, int64(s.PagesSkipped()), dimensions)
+		}
 
 		select {
 		case <-t.C:

--- a/pkg/util/changefeed/changefeed_test.go
+++ b/pkg/util/changefeed/changefeed_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/metrics/noop"
 	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
@@ -68,7 +69,7 @@ func TestChangefeedEmpty(t *testing.T) {
 	r := &fakeResponder{}
 	// not run in a goroutine because fakeChangefeed will deterministically
 	// close stopchan and cause the changefeed loop to exit
-	RunChangefeed(t.Context(), log, &fakeChangefeed{stopChan: stopChan, expectedPages: 1}, 100*time.Millisecond, 1, r, stopChan)
+	RunChangefeed(t.Context(), log, &noop.Noop{}, "OpenShiftClusterDocument", &fakeChangefeed{stopChan: stopChan, expectedPages: 1}, 100*time.Millisecond, 1, r, stopChan)
 
 	err := testlog.AssertLoggingOutput(h, []testlog.ExpectedLogEntry{})
 	if err != nil {
@@ -97,7 +98,7 @@ func TestChangefeedSuccessfulDocs(t *testing.T) {
 	r := &fakeResponder{}
 	// not run in a goroutine because fakeChangefeed will deterministically
 	// close stopchan and cause the changefeed loop to exit
-	RunChangefeed(t.Context(), log, cf, 100*time.Millisecond, 1, r, stopChan)
+	RunChangefeed(t.Context(), log, &noop.Noop{}, "OpenShiftClusterDocument", cf, 100*time.Millisecond, 1, r, stopChan)
 
 	err := testlog.AssertLoggingOutput(h, []testlog.ExpectedLogEntry{})
 	if err != nil {
@@ -133,7 +134,7 @@ func TestChangefeedProcessErrorContinuesProcessing(t *testing.T) {
 	r := &fakeResponder{}
 	// not run in a goroutine because fakeChangefeed will deterministically
 	// close stopchan and cause the changefeed loop to exit
-	RunChangefeed(t.Context(), log, cf, 1*time.Millisecond, 1, r, stopChan)
+	RunChangefeed(t.Context(), log, &noop.Noop{}, "OpenShiftClusterDocument", cf, 1*time.Millisecond, 1, r, stopChan)
 
 	err := testlog.AssertLoggingOutput(h, []testlog.ExpectedLogEntry{
 		{
@@ -147,4 +148,87 @@ func TestChangefeedProcessErrorContinuesProcessing(t *testing.T) {
 
 	assert.Equal(t, 3, r.docCount, "doc count")
 	assert.Equal(t, 2, r.allPendingProcessed, "successful times all pending was processed")
+}
+
+// recordingEmitter records every gauge emitted, in order.
+type recordingEmitter struct {
+	gauges     map[string][]int64
+	dimensions map[string]map[string]string
+}
+
+func newRecordingEmitter() *recordingEmitter {
+	return &recordingEmitter{
+		gauges:     map[string][]int64{},
+		dimensions: map[string]map[string]string{},
+	}
+}
+
+func (e *recordingEmitter) EmitFloat(string, float64, map[string]string) {}
+
+func (e *recordingEmitter) EmitGauge(name string, value int64, dimensions map[string]string) {
+	e.gauges[name] = append(e.gauges[name], value)
+	e.dimensions[name] = dimensions
+}
+
+// scriptedChangefeed returns errs in order, one per poll, and stops the
+// changefeed once the script is exhausted.
+type scriptedChangefeed struct {
+	errs     []error
+	polls    int
+	stopChan chan struct{}
+}
+
+func (f *scriptedChangefeed) Next(ctx context.Context, limit int) (*api.OpenShiftClusterDocuments, error) {
+	if f.polls >= len(f.errs) {
+		return nil, nil
+	}
+
+	err := f.errs[f.polls]
+	f.polls++
+	if f.polls == len(f.errs) {
+		close(f.stopChan)
+	}
+
+	return nil, err
+}
+
+// TestChangefeedEmitsFailureMetrics covers the half of this fix with value
+// beyond the incident which prompted it. A stalled changefeed produced no
+// signal at all for over a month; it must now report itself on every poll.
+func TestChangefeedEmitsFailureMetrics(t *testing.T) {
+	fail := errors.New("test error")
+
+	for _, tt := range []struct {
+		name         string
+		errs         []error
+		wantFailures []int64
+	}{
+		{
+			name:         "a feed which cannot poll",
+			errs:         []error{fail, fail, fail},
+			wantFailures: []int64{1, 2, 3},
+		},
+		{
+			name:         "a feed which recovers",
+			errs:         []error{fail, fail, nil},
+			wantFailures: []int64{1, 2, 0},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
+			stopChan := make(chan struct{})
+			m := newRecordingEmitter()
+
+			// Not run in a goroutine: scriptedChangefeed deterministically
+			// closes stopChan and causes the changefeed loop to exit.
+			RunChangefeed(t.Context(), log, m, "OpenShiftClusterDocument",
+				&scriptedChangefeed{errs: tt.errs, stopChan: stopChan},
+				time.Millisecond, 1, &fakeResponder{}, stopChan)
+
+			assert.Equal(t, tt.wantFailures, m.gauges[MetricConsecutiveFailures], MetricConsecutiveFailures)
+			assert.Len(t, m.gauges[MetricStaleness], len(tt.errs), MetricStaleness+" is emitted on every poll")
+			assert.Equal(t, map[string]string{"name": "OpenShiftClusterDocument"}, m.dimensions[MetricConsecutiveFailures], "dimensions")
+		})
+	}
 }

--- a/pkg/util/changefeed/changefeed_test.go
+++ b/pkg/util/changefeed/changefeed_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/database"
 	"github.com/Azure/ARO-RP/pkg/metrics/noop"
 	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
@@ -229,6 +230,52 @@ func TestChangefeedEmitsFailureMetrics(t *testing.T) {
 			assert.Equal(t, tt.wantFailures, m.gauges[MetricConsecutiveFailures], MetricConsecutiveFailures)
 			assert.Len(t, m.gauges[MetricStaleness], len(tt.errs), MetricStaleness+" is emitted on every poll")
 			assert.Equal(t, map[string]string{"name": "OpenShiftClusterDocument"}, m.dimensions[MetricConsecutiveFailures], "dimensions")
+		})
+	}
+}
+
+// skippingChangefeed reports skipped pages, as the resilient iterator does.
+type skippingChangefeed struct {
+	*scriptedChangefeed
+	skipped int
+}
+
+func (f *skippingChangefeed) PagesSkipped() int { return f.skipped }
+
+func TestChangefeedEmitsSkippedPagesOnlyWhenReported(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		iterator func(*scriptedChangefeed) database.DocumentIterator[*api.OpenShiftClusterDocument, *api.OpenShiftClusterDocuments]
+		want     []int64
+	}{
+		{
+			// An iterator which cannot skip must not emit the metric at all,
+			// rather than emitting a permanent zero which would read as a
+			// feed known to have lost nothing.
+			name: "an iterator which cannot skip reports nothing",
+			iterator: func(s *scriptedChangefeed) database.DocumentIterator[*api.OpenShiftClusterDocument, *api.OpenShiftClusterDocuments] {
+				return s
+			},
+		},
+		{
+			name: "a skipped page stays visible after the feed recovers",
+			iterator: func(s *scriptedChangefeed) database.DocumentIterator[*api.OpenShiftClusterDocument, *api.OpenShiftClusterDocuments] {
+				return &skippingChangefeed{scriptedChangefeed: s, skipped: 2}
+			},
+			want: []int64{2, 2},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, log := testlog.LogForTesting(t)
+
+			stopChan := make(chan struct{})
+			m := newRecordingEmitter()
+			s := &scriptedChangefeed{errs: []error{errors.New("test error"), nil}, stopChan: stopChan}
+
+			RunChangefeed(t.Context(), log, m, "OpenShiftClusterDocument",
+				tt.iterator(s), time.Millisecond, 1, &fakeResponder{}, stopChan)
+
+			assert.Equal(t, tt.want, m.gauges[MetricPagesSkipped], MetricPagesSkipped)
 		})
 	}
 }

--- a/pkg/util/changefeed/subscriptioncache_test.go
+++ b/pkg/util/changefeed/subscriptioncache_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/metrics/noop"
 	testdatabase "github.com/Azure/ARO-RP/test/database"
 	testlog "github.com/Azure/ARO-RP/test/util/log"
 	testmetrics "github.com/Azure/ARO-RP/test/util/metrics"
@@ -148,7 +149,7 @@ func TestSubscriptionChangefeed(t *testing.T) {
 			stop := make(chan struct{})
 			defer close(stop)
 
-			go RunChangefeed(t.Context(), log, subscriptionChangefeed, 100*time.Microsecond, 1, cache, stop)
+			go RunChangefeed(t.Context(), log, &noop.Noop{}, "SubscriptionDocument", subscriptionChangefeed, 100*time.Microsecond, 1, cache, stop)
 
 			cache.WaitForInitialPopulation()
 			require.Eventually(t, func() bool {
@@ -307,7 +308,7 @@ func TestSubscriptionChangefeedError(t *testing.T) {
 	defer close(stop)
 
 	// set it on a massive loop so it only runs once
-	go RunChangefeed(t.Context(), log, subscriptionChangefeed, 10000*time.Hour, 1, cache, stop)
+	go RunChangefeed(t.Context(), log, &noop.Noop{}, "SubscriptionDocument", subscriptionChangefeed, 10000*time.Hour, 1, cache, stop)
 
 	// it'll print the log when on the first loop, use Eventually so that we're
 	// not in a race with the goroutine we spawned


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://redhat.atlassian.net/browse/ARO-29321

### What this PR does / why we need it:

The generated change feed iterators advance their continuation only after a successful read.
A page which fails deterministically is therefore requested again from the same position on
every poll, for as long as the process runs, and nothing downstream of the feed is updated
again.

A single document which cannot be decoded is enough to do this: `pkg/database/extensions.go`
panics when a secure field cannot be decrypted, and the codec turns that into a decode
error. The change feeds behind the MIMO scheduler, the monitor and the gateway auth cache
all stall on the same document.

Since #4718 the scheduler's readiness check consults changefeed freshness, so a stalled
instance reports itself unready. Reporting does not clear it: the feed does not advance on
its own, so the state persists until the process is restarted. Readiness coverage also
differs between the consumers. Correcting the iterator covers all of them uniformly and
makes the condition recoverable rather than merely visible.

This PR adds a hand-written resilient iterator in `pkg/database/cosmosdb` which
re-implements `Next` with that error path corrected, and substitutes it at the three
`pkg/database` change feed wrappers. All five consumers are covered without a change to any
call site or interface.

The position to advance to is already in hand at the point of failure: `do` copies the
response headers into the caller's map whenever there was a response, and `_do` returns the
response alongside a decode error, so the `Etag` naming the next page is present. It is
absent when there was no response at all — a transport error, or a wrong content type — and
the advance is conditional on it: an empty `If-None-Match` asks Cosmos DB to read from the
beginning of the feed, so advancing to `""` would re-read the whole collection and arrive
back at the same page.

Combined with a threshold of thirty consecutive failures, reset on any success, a page is
only ever skipped when it cannot be read at all, never during a passing fault.

The iterators are generated by an external tool, so the generated files are left alone. If
this approach is preferred in the generator instead, the new file can simply be deleted.

This PR also adds the visibility the failure mode needed and did not have. `RunChangefeed`
now takes a metrics emitter and a feed name, emits seconds since the last successful poll
and the count of consecutive failures on every poll, and carries the feed name as a log
field. A stalled feed previously produced nothing but undistinguished error lines.

### Test plan for issue:

Unit tests in `pkg/database/cosmosdb/changefeed_test.go`, against `httptest.NewTLSServer`,
covering: normal iteration; recovery from an undecodable page; that the continuation is not
advanced when no `Etag` was returned; and the consecutive-failure threshold.

`pkg/util/changefeed/changefeed_test.go` gains `TestChangefeedEmitsFailureMetrics`, which
asserts the exact sequence of the failure counter across a scripted feed.

As a negative control, neutering the recovery path was confirmed to fail three of the four
new iterator tests.

`make unit-test-go` passes in full (4129 tests). No e2e coverage: reproducing this requires a
document in Cosmos DB which cannot be decoded, which is not something the e2e suite can
arrange.

### Is there any documentation that needs to be updated for this PR?

No. The change is behind the existing `DocumentIterator` interface. The new metrics
follow the existing `changefeed.*` naming and the `{"name": "<DocumentType>"}` dimension
convention already used by `changefeed.caches.size`. `changefeed.pages.skipped` is reported
through an optional interface, so an iterator which cannot skip emits nothing rather than a
permanent zero, which would read as a feed known to have lost nothing.

### How do you know this will function as expected in production?

The new metrics are the answer to this question for the failure mode itself: a stalled feed
is now visible as rising `changefeed.poll.staleness` with a non-zero
`changefeed.poll.failures`, per feed, where previously it was visible only as log
noise.

Both of those reset once the feed recovers, so `changefeed.pages.skipped` counts pages
given up on and only ever rises. A page whose contents were never delivered is a fault
which should outlive the recovery, and it should be a metric rather than a log line for
anything to alert on it.

The recovery itself is conservative by design. It skips a page only after thirty consecutive
failures, and only when it has a continuation which is known to move forward; without one it
declines to advance rather than risk re-reading the collection from the start. Any success
resets the counter, so a transient fault cannot accumulate towards a skip.

The residual risk is that a skipped page is a page of updates which the consumer never sees.
All three consumers are caches rebuilt from a full initial read, and the alternative today
is that they see nothing further at all.


