### PR TITLE
[ARO-29322] Bound MIMO manifest retries when the cluster document cannot be read

### DIFF
--- a/pkg/mimo/actuator/manager.go
+++ b/pkg/mimo/actuator/manager.go
@@ -204,11 +204,14 @@ func (a *actuator) Process(ctx context.Context) (bool, error) {
 		// marked RetriesExceeded.
 		oc, err := ocDb.Get(ctx, a.clusterResourceID)
 		if err != nil {
+			// Logged in the original wording, before wrapping, so that queries
+			// and alerting over the actuator's logs are unaffected.
+			taskLog.Errorf("failed fetching cluster document: %s", err.Error())
+
 			// Marked transient so that a momentary failure to read the document
 			// is retried rather than failing the manifest outright. A durable
 			// one is still bounded, by maxDequeueCount.
 			err = utilmimo.TransientError(fmt.Errorf("failed getting cluster document: %w", err))
-			taskLog.Error(err)
 
 			state, msg := manifestStateForError(doc.Dequeues, err.Error(), err)
 			if _, endErr := mmf.EndLease(ctx, doc.ClusterResourceID, doc.ID, state, &msg); endErr != nil {

--- a/pkg/mimo/actuator/manager.go
+++ b/pkg/mimo/actuator/manager.go
@@ -294,6 +294,13 @@ func (a *actuator) Process(ctx context.Context) (bool, error) {
 // error, so that a manifest which keeps failing transiently is eventually given
 // up on rather than retried indefinitely. That bound relies on the manifest
 // having been leased, since Lease is what increments Dequeues.
+//
+// RetriesExceeded is terminal: the dequeue query matches Pending only, so such
+// a manifest is not picked up again even once whatever caused the failure has
+// been resolved. The window it was scheduled for is therefore missed rather
+// than deferred. This is bounded rather than permanent, because schedules are
+// recurring and the scheduler creates a fresh manifest for the next window, but
+// it does mean a durable fault costs a maintenance window per manifest.
 func manifestStateForError(dequeues int, msg string, err error) (api.MaintenanceManifestState, string) {
 	switch {
 	case dequeues >= maxDequeueCount:

--- a/pkg/mimo/actuator/manager.go
+++ b/pkg/mimo/actuator/manager.go
@@ -186,19 +186,39 @@ func (a *actuator) Process(ctx context.Context) (bool, error) {
 		})
 		taskLog.Info("begin processing manifest")
 
-		// Fetch a fresh OpenShift cluster document, in case the previous task/a
-		// concurrent action updated anything
-		oc, err := ocDb.Get(ctx, a.clusterResourceID)
-		if err != nil {
-			taskLog.Errorf("failed fetching cluster document: %s", err.Error())
-			return false, fmt.Errorf("failed getting cluster document: %w", err)
-		}
-
 		// Attempt a dequeue
 		doc, err = mmf.Lease(ctx, a.clusterResourceID, doc.ID)
 		if err != nil {
 			// log and continue to the next task if it doesn't work
 			taskLog.Error(err)
+			continue
+		}
+
+		// Fetch a fresh OpenShift cluster document, in case the previous task/a
+		// concurrent action updated anything.
+		//
+		// This is deliberately done after leasing. Lease is what increments
+		// Dequeues, so fetching beforehand meant that a cluster document which
+		// could not be read left the manifest's attempt count untouched, and
+		// the manifest was retried indefinitely rather than eventually being
+		// marked RetriesExceeded.
+		oc, err := ocDb.Get(ctx, a.clusterResourceID)
+		if err != nil {
+			// Marked transient so that a momentary failure to read the document
+			// is retried rather than failing the manifest outright. A durable
+			// one is still bounded, by maxDequeueCount.
+			err = utilmimo.TransientError(fmt.Errorf("failed getting cluster document: %w", err))
+			taskLog.Error(err)
+
+			state, msg := manifestStateForError(doc.Dequeues, err.Error(), err)
+			if _, endErr := mmf.EndLease(ctx, doc.ClusterResourceID, doc.ID, state, &msg); endErr != nil {
+				taskLog.Error(fmt.Errorf("failed ending lease on manifest: %w", endErr))
+			}
+
+			// Continue rather than return: being unable to read this cluster's
+			// document says nothing about the other manifests queued against
+			// it, and returning here abandoned them for the whole run.
+			doneSomeWork = true
 			continue
 		}
 
@@ -238,19 +258,14 @@ func (a *actuator) Process(ctx context.Context) (bool, error) {
 		msg := taskContext.getResultMessage()
 
 		if err != nil {
-			if doc.Dequeues >= maxDequeueCount {
-				msg = fmt.Sprintf("did not succeed after %d times, failing -- %s", doc.Dequeues, err.Error())
-				state = api.MaintenanceManifestStateRetriesExceeded
+			state, msg = manifestStateForError(doc.Dequeues, msg, err)
+
+			switch state {
+			case api.MaintenanceManifestStateRetriesExceeded:
 				taskLog.Error(msg)
-			} else if utilmimo.IsRetryableError(err) {
-				// If an error is retryable (i.e explicitly marked as a transient error
-				// by wrapping it in utilmimo.TransientError), then mark it back as
-				// Pending so that it will get picked up and retried.
-				state = api.MaintenanceManifestStatePending
+			case api.MaintenanceManifestStatePending:
 				taskLog.Error(fmt.Errorf("task returned a retryable error: %w", err))
-			} else {
-				// Terminal errors (explicitly marked or unwrapped) cause task failure
-				state = api.MaintenanceManifestStateFailed
+			default:
 				taskLog.Error(fmt.Errorf("task returned a terminal error: %w", err))
 			}
 		} else {
@@ -269,4 +284,29 @@ func (a *actuator) Process(ctx context.Context) (bool, error) {
 	}
 
 	return doneSomeWork, nil
+}
+
+// manifestStateForError returns the state in which a manifest should be left
+// after an attempt to action it returned err, together with the status text to
+// record against it.
+//
+// Attempts are bounded by maxDequeueCount rather than by the nature of the
+// error, so that a manifest which keeps failing transiently is eventually given
+// up on rather than retried indefinitely. That bound relies on the manifest
+// having been leased, since Lease is what increments Dequeues.
+func manifestStateForError(dequeues int, msg string, err error) (api.MaintenanceManifestState, string) {
+	switch {
+	case dequeues >= maxDequeueCount:
+		return api.MaintenanceManifestStateRetriesExceeded,
+			fmt.Sprintf("did not succeed after %d times, failing -- %s", dequeues, err.Error())
+	case utilmimo.IsRetryableError(err):
+		// An error explicitly marked as transient, by wrapping it in
+		// utilmimo.TransientError, is marked back to Pending so that it is
+		// picked up and retried.
+		return api.MaintenanceManifestStatePending, msg
+	default:
+		// Terminal errors, whether explicitly marked or unwrapped, fail the
+		// manifest.
+		return api.MaintenanceManifestStateFailed, msg
+	}
 }

--- a/pkg/mimo/actuator/manager_test.go
+++ b/pkg/mimo/actuator/manager_test.go
@@ -1,0 +1,202 @@
+package actuator
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+	"github.com/Azure/ARO-RP/pkg/database"
+	"github.com/Azure/ARO-RP/pkg/mimo/tasks"
+	utilmimo "github.com/Azure/ARO-RP/pkg/util/mimo"
+	mock_env "github.com/Azure/ARO-RP/pkg/util/mocks/env"
+	testdatabase "github.com/Azure/ARO-RP/test/database"
+	testlog "github.com/Azure/ARO-RP/test/util/log"
+)
+
+func TestManifestStateForError(t *testing.T) {
+	terminal := errors.New("terminal")
+	transient := utilmimo.TransientError(errors.New("transient"))
+
+	manifestStateForErrorTests := []struct {
+		name      string
+		dequeues  int
+		msg       string
+		err       error
+		wantState api.MaintenanceManifestState
+		wantMsg   string
+	}{
+		{
+			name:      "terminalFails",
+			dequeues:  1,
+			msg:       "result",
+			err:       terminal,
+			wantState: api.MaintenanceManifestStateFailed,
+			wantMsg:   "result",
+		},
+		{
+			name:      "transientRetries",
+			dequeues:  1,
+			msg:       "result",
+			err:       transient,
+			wantState: api.MaintenanceManifestStatePending,
+			wantMsg:   "result",
+		},
+		{
+			name:      "transientExhaustedStopsRetrying",
+			dequeues:  maxDequeueCount,
+			msg:       "result",
+			err:       transient,
+			wantState: api.MaintenanceManifestStateRetriesExceeded,
+			wantMsg:   fmt.Sprintf("did not succeed after %d times, failing -- %s", maxDequeueCount, transient.Error()),
+		},
+		{
+			name:      "terminalExhaustedStopsRetrying",
+			dequeues:  maxDequeueCount + 1,
+			msg:       "result",
+			err:       terminal,
+			wantState: api.MaintenanceManifestStateRetriesExceeded,
+			wantMsg:   fmt.Sprintf("did not succeed after %d times, failing -- terminal", maxDequeueCount+1),
+		},
+	}
+
+	for _, tt := range manifestStateForErrorTests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotState, gotMsg := manifestStateForError(tt.dequeues, tt.msg, tt.err)
+			if gotState != tt.wantState {
+				t.Errorf("manifestStateForError(%d, %q, %v) state = %q, want %q", tt.dequeues, tt.msg, tt.err, gotState, tt.wantState)
+			}
+			if gotMsg != tt.wantMsg {
+				t.Errorf("manifestStateForError(%d, %q, %v) msg = %q, want %q", tt.dequeues, tt.msg, tt.err, gotMsg, tt.wantMsg)
+			}
+		})
+	}
+}
+
+// TestProcessWhenClusterDocumentUnreadable covers the case where the cluster
+// document cannot be read while manifests are queued against it, which is what
+// happens when the actuator cannot decrypt it.
+//
+// The manifests must be dequeued, so that repeated failures are bounded by
+// maxDequeueCount, and every queued manifest must be attempted, rather than the
+// run being abandoned at the first one.
+func TestProcessWhenClusterDocumentUnreadable(t *testing.T) {
+	const mockSubID = "00000000-0000-0000-0000-000000000000"
+	clusterResourceID := strings.ToLower(fmt.Sprintf("/subscriptions/%s/resourcegroups/resourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/resourceName", mockSubID))
+
+	manifestIDs := []string{
+		"07070707-0707-0707-0707-070707070001",
+		"07070707-0707-0707-0707-070707070002",
+	}
+
+	processWhenClusterDocumentUnreadableTests := []struct {
+		name          string
+		dequeues      int
+		wantState     api.MaintenanceManifestState
+		wantStatusTex string
+	}{
+		{
+			name:          "retriesWhileAttemptsRemain",
+			dequeues:      0,
+			wantState:     api.MaintenanceManifestStatePending,
+			wantStatusTex: "TransientError: failed getting cluster document: 404 : ",
+		},
+		{
+			name:          "givesUpOnceAttemptsAreExhausted",
+			dequeues:      maxDequeueCount - 1,
+			wantState:     api.MaintenanceManifestStateRetriesExceeded,
+			wantStatusTex: fmt.Sprintf("did not succeed after %d times, failing -- TransientError: failed getting cluster document: 404 : ", maxDequeueCount),
+		},
+	}
+
+	for _, tt := range processWhenClusterDocumentUnreadableTests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := require.New(t)
+			controller := gomock.NewController(t)
+
+			_env := mock_env.NewMockInterface(controller)
+			_env.EXPECT().Now().AnyTimes().DoAndReturn(func() time.Time {
+				return time.Unix(120, 0)
+			})
+
+			manifests, manifestsClient := testdatabase.NewFakeMaintenanceManifests(_env.Now)
+			clusters, _ := testdatabase.NewFakeOpenShiftClusters()
+			subscriptions, _ := testdatabase.NewFakeSubscriptions()
+
+			fixtures := testdatabase.NewFixture()
+			fixtures.AddSubscriptionDocuments(&api.SubscriptionDocument{ID: mockSubID})
+
+			// Deliberately no OpenShiftClusterDocument, so that the actuator's
+			// read of it fails in the same way as an undecryptable document.
+			for _, id := range manifestIDs {
+				fixtures.AddMaintenanceManifestDocuments(&api.MaintenanceManifestDocument{
+					ID:                id,
+					ClusterResourceID: clusterResourceID,
+					Dequeues:          tt.dequeues,
+					MaintenanceManifest: api.MaintenanceManifest{
+						State:             api.MaintenanceManifestStatePending,
+						MaintenanceTaskID: "0",
+						RunBefore:         600,
+						RunAfter:          0,
+					},
+				})
+			}
+
+			r.NoError(fixtures.WithOpenShiftClusters(clusters).
+				WithMaintenanceManifests(manifests).
+				WithSubscriptions(subscriptions).Create())
+
+			_, log := testlog.LogForTesting(t)
+
+			a := &actuator{
+				log:                      log,
+				env:                      _env,
+				clusterResourceID:        clusterResourceID,
+				dbs:                      database.NewDBGroup().WithMaintenanceManifests(manifests).WithSubscriptions(subscriptions).WithOpenShiftClusters(clusters),
+				tasks:                    map[api.MIMOTaskID]tasks.MaintenanceTask{},
+				taskRunTimeout:           time.Second,
+				manifestQueryBatchLength: -1,
+			}
+			a.AddMaintenanceTasks(map[api.MIMOTaskID]tasks.MaintenanceTask{
+				"0": func(th utilmimo.TaskContext, mmd *api.MaintenanceManifestDocument, oscd *api.OpenShiftClusterDocument) error {
+					t.Error("the task ran, but the cluster document could not be read")
+					return nil
+				},
+			})
+
+			// A failure to read the cluster document is not returned: it says
+			// nothing about the other clusters the actuator has to service.
+			didWork, err := a.Process(t.Context())
+			r.NoError(err)
+			r.True(didWork, "Process() reported no work, so the failure would not be visible")
+
+			checker := testdatabase.NewChecker()
+			for _, id := range manifestIDs {
+				checker.AddMaintenanceManifestDocuments(&api.MaintenanceManifestDocument{
+					ID:                id,
+					ClusterResourceID: clusterResourceID,
+					// Incremented by the lease, which is what bounds retries.
+					Dequeues: tt.dequeues + 1,
+					MaintenanceManifest: api.MaintenanceManifest{
+						State:             tt.wantState,
+						StatusText:        tt.wantStatusTex,
+						MaintenanceTaskID: "0",
+						RunBefore:         600,
+						RunAfter:          0,
+					},
+				})
+			}
+
+			errs := checker.CheckMaintenanceManifests(manifestsClient)
+			r.Empty(errs, "MaintenanceManifests don't match")
+		})
+	}
+}

--- a/pkg/mimo/actuator/manager_test.go
+++ b/pkg/mimo/actuator/manager_test.go
@@ -98,22 +98,22 @@ func TestProcessWhenClusterDocumentUnreadable(t *testing.T) {
 	}
 
 	processWhenClusterDocumentUnreadableTests := []struct {
-		name          string
-		dequeues      int
-		wantState     api.MaintenanceManifestState
-		wantStatusTex string
+		name           string
+		dequeues       int
+		wantState      api.MaintenanceManifestState
+		wantStatusText string
 	}{
 		{
-			name:          "retriesWhileAttemptsRemain",
-			dequeues:      0,
-			wantState:     api.MaintenanceManifestStatePending,
-			wantStatusTex: "TransientError: failed getting cluster document: 404 : ",
+			name:           "retriesWhileAttemptsRemain",
+			dequeues:       0,
+			wantState:      api.MaintenanceManifestStatePending,
+			wantStatusText: "TransientError: failed getting cluster document: 404 : ",
 		},
 		{
-			name:          "givesUpOnceAttemptsAreExhausted",
-			dequeues:      maxDequeueCount - 1,
-			wantState:     api.MaintenanceManifestStateRetriesExceeded,
-			wantStatusTex: fmt.Sprintf("did not succeed after %d times, failing -- TransientError: failed getting cluster document: 404 : ", maxDequeueCount),
+			name:           "givesUpOnceAttemptsAreExhausted",
+			dequeues:       maxDequeueCount - 1,
+			wantState:      api.MaintenanceManifestStateRetriesExceeded,
+			wantStatusText: fmt.Sprintf("did not succeed after %d times, failing -- TransientError: failed getting cluster document: 404 : ", maxDequeueCount),
 		},
 	}
 
@@ -187,7 +187,7 @@ func TestProcessWhenClusterDocumentUnreadable(t *testing.T) {
 					Dequeues: tt.dequeues + 1,
 					MaintenanceManifest: api.MaintenanceManifest{
 						State:             tt.wantState,
-						StatusText:        tt.wantStatusTex,
+						StatusText:        tt.wantStatusText,
 						MaintenanceTaskID: "0",
 						RunBefore:         600,
 						RunAfter:          0,


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://redhat.atlassian.net/browse/ARO-29322

### What this PR does / why we need it:

The actuator fetched a fresh cluster document before leasing the manifest it was about to
action, and returned outright if that fetch failed. Two consequences followed, both of which
the fetch failing durably makes permanent.

`Lease` is what increments `Dequeues`, so a manifest whose cluster document could not be
read never had its attempt count raised. `maxDequeueCount` was therefore unreachable on this
path, and the manifest was retried on every pass, indefinitely, rather than eventually being
marked `RetriesExceeded`.

The early return also abandoned every remaining manifest queued against that cluster, unlike
the adjacent error branches, which log and continue. Being unable to read the cluster
document says nothing about the other manifests in the batch, and they were not attempted at
all.

This PR fetches after leasing, so the attempt is counted, and ends the lease rather than
returning. The error is marked transient, so a momentary read failure is retried rather than
failing the manifest outright, while a durable one is now bounded by `maxDequeueCount` as
any other repeated failure is.

The existing state mapping is extracted into `manifestStateForError` so that both this path
and task execution share it, rather than restating the dequeue bound. Log output is
unchanged.

### Test plan for issue:

Unit tests in `pkg/mimo/actuator/manager_test.go`:

- `TestManifestStateForError` covers the four combinations of retryable/terminal error and
  under/at the dequeue bound;
- `TestProcessWhenClusterDocumentUnreadable` covers the two behaviours directly — that the
  manifest is left `Pending` with its dequeue count raised while under the bound, and moved
  to `RetriesExceeded` at it, and that a second manifest queued against the same cluster is
  still attempted.

As a negative control, restoring the original ordering was confirmed to fail the new test,
with the log output showing the second manifest abandoned.

The existing actuator tests pass unchanged, which is the point of preserving the log
wording: the assertions on those strings are untouched.

### Is there any documentation that needs to be updated for this PR?

No. This corrects the accounting to match the documented retry semantics rather than
changing them.

### How do you know this will function as expected in production?

The change makes an existing, documented bound reachable on a path where it was not, so the
behaviour it produces is the behaviour the surrounding code already expects and already has
handling for: a manifest which exhausts its retries becomes `RetriesExceeded`, exactly as it
does for every other repeated failure.

The error is marked transient rather than terminal, so a single failed read does not fail a
manifest; it costs one dequeue, as an ordinary failure does.

Log output is unchanged, so existing queries and alerting over the actuator's logs continue
to work. The visible difference is that a cluster whose document cannot be read now stops
producing the same manifest forever, and stops suppressing its siblings.
