### PR TITLE
[CLI] backport azure-cli changes from most recent publish

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -430,8 +430,9 @@ lint-admin-portal:
 .PHONY: test-python
 test-python: pyenv az
 	. pyenv/bin/activate && \
-		azdev linter && \
-		azdev style && \
+		azdev test aro && \
+		azdev linter aro && \
+		azdev style aro && \
 		hack/unit-test-python.sh
 
 .PHONY: test-python-podman

--- a/docs/az-aro-python-development.md
+++ b/docs/az-aro-python-development.md
@@ -2,24 +2,25 @@
 
 There are two codebases for the `az aro` command:
 
-- the [downstream] `az aro` extension in this repo, and
-- the [upstream] `az aro` module
+- the [upstream] `az aro` extension in this repo, and
+- the [downstream] `az aro` module in azure-cli proper
 
-[upstream]: https://github.com/Azure/azure-cli/tree/dev/src/azure-cli/azure/cli/command_modules/aro
-[downstream]: https://github.com/Azure/ARO-RP/tree/master/python/az/aro
+[upstream]: https://github.com/Azure/ARO-RP/tree/master/python/az/aro
+[downstream]: https://github.com/Azure/azure-cli/tree/dev/src/azure-cli/azure/cli/command_modules/aro
 
-The upstream `az aro` command module is distributed with `az` and is present in
-the Azure cloud shell. Development/maintenance of this module within the Azure
-CLI is treated as a first-party Azure CLI module. Please see [upstream
+The downstream `az aro` command module is distributed with `az` and is present
+in the Azure cloud shell. Development/maintenance of this module within the
+Azure CLI is treated as a first-party Azure CLI module. Please see [downstream
 documentation] for more info on command module authoring and maintenance.
 
-[upstream documentation]: https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules
+[downstream documentation]: https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules
 
-The downstream extension may be installed by an end user to override the command module
-(for example: to use preview features). We use the extension directly from this
-codebase for development and testing of new API versions. Customers are
-advised to use the upstream CLI. You can read more about how extensions are
-authored [here](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/authoring.md),
+The upstream extension may be installed by an end user to override the command
+module (for example: to use preview features). We use the extension directly
+from this codebase for development and testing of new API versions. Customers
+are advised to use the downstream CLI module. You can read more about how
+extensions are authored
+[here](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/authoring.md),
 and some of the differences between extensions and command modules
 [here](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/faq.md).
 
@@ -34,8 +35,8 @@ cd azure-cli
 
 python3 -m venv env
 . ./env/bin/activate
-pip install azdev
-azdev setup -c
+pip install --upgrade pip && pip install azdev
+azdev setup -c .
 ```
 
 The `az aro` command is located in
@@ -55,10 +56,6 @@ source ./pyenv/bin/activate
 
 The `az aro` extension is located in `python/az/aro/azext_aro` with tests in
 the corresponding `tests` folder.
-
-There is a useful guide for authoring commands in the
-[azure-cli](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules)
-repository.
 
 ## `az aro` Extension Code Structure/Organization
 
@@ -80,7 +77,7 @@ Helpful to reference, but these don't need edits:
 - `python/az/aro/build`
 - `python/az/client`
 
-## Tests
+## Downstream Azure CLI tests
 
 Tests are run as follows:
 
@@ -117,31 +114,33 @@ repository.
 Tests can be recorded live, which enables the next run to take place against
 the recorded values. For the recording, the Python VCR library is used;
 recorded "tapes" are stored in
-`src/azure-cli/azure/cli/command_modules/aro/tests/latest/recordings`.
+`src/azure-cli/azure/cli/command_modules/aro/tests/latest/integration/recordings`.
 
 When the `--live` flag is passed, the tests run against the Azure API and are
 recorded. Failed tests can be re-run using the `--lf` flag.
 
 Recorded tests are run when the `--live` flag is not passed.
 
+Before committing new recordings, sanitize them for UUIDs and email addresses.
+
 ## Contributing
 
 Changes made to the `az aro` command will be made to `Azure/ARO-RP` **before**
-being contributed [upstream]. This will allow synchronization between the two
+being contributed [downstream]. This will allow synchronization between the two
 repositories to be consistent. Once changes are made and approved to
-[downstream], pull requests to upstream can then be opened.
+[upstream], pull requests to downstream can then be opened.
 
-When contributing to the `az aro` command upstream, imports will be different
+When contributing to the `az aro` command downstream, imports will be different
 for testing. When submitting pull requests, tests that include `azdev style`,
-`azdev linter`, and `azdev test aro` should pass to ensure that changes will not
-impact CI pipelines.
+`azdev linter`, and `azdev test aro` should pass to ensure that changes will
+not impact CI pipelines.
 
-Additional instructions for merging changes upstream are contained in internal
-documentation.
+Additional instructions for merging changes downstream are contained in
+internal documentation.
 
 ## Updating Azure CLI version
 
-When upstream azure-cli releases a new version that we need to adopt, follow
+When downstream azure-cli releases a new version that we need to adopt, follow
 these steps to regenerate `requirements.txt`:
 
 ```sh
@@ -170,6 +169,13 @@ This lets pip resolve all SDK dependencies automatically rather than manually
 editing individual packages.
 
 ## Caveats
+
+> [!NOTE]
+> Be aware that code beneath the `python/az/aro/azext_aro/` dir does not all
+> share the same license. Microsoft code and Microsoft generated code (`aaz/`
+> and `vendored_sdks/`) seem to generally be MIT, whereas `ARO` CLI extension
+> code (`tests/` and everything else in `python/az/aro/azext_aro/`) is Apache
+> 2.0.
 
 - `azure-cli` CI is not entirely isolated. Test runs may pass or fail depending
   on the state of `dev` branch. Force push to rerun the tests.

--- a/python/az/aro/azext_aro/_validators.py
+++ b/python/az/aro/azext_aro/_validators.py
@@ -42,7 +42,8 @@ def validate_client_id(isCreate):
         if namespace.client_id is None:
             return
         if hasattr(namespace, 'enable_managed_identity') and namespace.enable_managed_identity is True:
-            raise MutuallyExclusiveArgumentError('Must not specify --client-id when --enable-managed-identity is True')  # pylint: disable=line-too-long
+            raise MutuallyExclusiveArgumentError("Must not specify --client-id when "
+                                                 "--enable-managed-identity/--enable-mi is True")
         if namespace.platform_workload_identities is not None:
             raise MutuallyExclusiveArgumentError('Must not specify --client-id when --assign-platform-workload-identity is used')  # pylint: disable=line-too-long
         try:
@@ -62,7 +63,8 @@ def validate_client_secret(isCreate):
         if namespace.client_secret is None:
             return
         if hasattr(namespace, 'enable_managed_identity') and namespace.enable_managed_identity is True:
-            raise MutuallyExclusiveArgumentError('Must not specify --client-secret when --enable-managed-identity is True')  # pylint: disable=line-too-long
+            raise MutuallyExclusiveArgumentError("Must not specify --client-secret when "
+                                                 "--enable-managed-identity/--enable-mi is True")
         if namespace.platform_workload_identities is not None:
             raise MutuallyExclusiveArgumentError('Must not specify --client-secret when --assign-platform-workload-identity is used')  # pylint: disable=line-too-long
         if isCreate and (namespace.client_id is None or not str(namespace.client_id)):

--- a/python/az/aro/azext_aro/custom.py
+++ b/python/az/aro/azext_aro/custom.py
@@ -1013,7 +1013,7 @@ def ensure_resource_permissions(cli_ctx, oc, fail, sp_obj_ids) -> None:
                     role_definition_id = resource_id(
                         subscription=get_subscription_id(cli_ctx),
                         namespace="Microsoft.Authorization",
-                        type="roleDefinition",
+                        type="roleDefinitions",
                         name=role,
                     )
                     create_role_assignment(cli_ctx, sp_id, role_definition_id, resource)
@@ -1059,7 +1059,7 @@ def _determine_required_scopes_from_role_set(cmd, role) -> list[RoleAssignmentSc
             if action.startswith("Microsoft.Network/networkSecurityGroups/"):
                 scopes.add(RoleAssignmentScope.NSG)
 
-            if action.startswith("Microsoft.Network/routeTable/"):
+            if action.startswith("Microsoft.Network/routeTables/"):
                 scopes.add(RoleAssignmentScope.ROUTE_TABLE)
 
     # We're converting the set to a list to maintain a deterministic order.
@@ -1106,10 +1106,19 @@ def create_identity_and_role_assignments(*,
         if not network_scopes[scope]:
             continue
 
+        role_definition_id = role.role_definition_id
+        if not role_definition_id.startswith("/"):
+            role_definition_id = resource_id(
+                subscription=get_subscription_id(cmd.cli_ctx),
+                namespace="Microsoft.Authorization",
+                type="roleDefinitions",
+                name=role_definition_id
+            )
+
         create_role_assignment(
             cmd.cli_ctx,
             identity["principalId"],
-            f"{resource_id(subscription=get_subscription_id(cmd.cli_ctx))}{role.role_definition_id}",
+            role_definition_id,
             network_scopes[scope]
         )
 


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://redhat.atlassian.net/browse/ARO-29268

### What this PR does / why we need it:

This reduces the code drift between the ARO extension that lives in this repo, with the downstream ARO module that lives in Azure CLI.

### Test plan for issue:

```
rm -rf pyenv/
make clean test-python
# => all passed
```

### Is there any documentation that needs to be updated for this PR?

Yes. ~~Documentation for the Python CLI in this repo needs updating. That will arrive in a commit to the pull request after opening.~~ Documentation updates are included in this PR.

### How do you know this will function as expected in production? 

This code has been smoke tested, scenario tested, and unit tested.