### PR TITLE
Deploy RP and Gateway VMSS instances sequentially

### DIFF
--- a/cmd/aro/deploy.go
+++ b/cmd/aro/deploy.go
@@ -110,35 +110,33 @@ func deploy(ctx context.Context, _log *logrus.Entry) error {
 
 	deployer, err := pkgdeploy.New(ctx, env, config, deployVersion, tokenCredential)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create deployer: %w", err)
 	}
 
-	err = deployer.PreDeploy(ctx, 30)
-	if err != nil {
-		return err
+	if err := deployer.PreDeploy(ctx, 30); err != nil {
+		return fmt.Errorf("pre-deploy failed: %w", err)
 	}
 
-	err = deployer.DeployRP(ctx)
-	if err != nil {
-		return err
+	if err := deployer.DeployRP(ctx); err != nil {
+		return fmt.Errorf("deploy RP failed: %w", err)
 	}
 
-	err = deployer.UpgradeRP(ctx)
-	if err != nil {
-		return err
+	if err := deployer.UpgradeRP(ctx); err != nil {
+		return fmt.Errorf("upgrade RP failed: %w", err)
 	}
 
-	err = deployer.DeployGateway(ctx)
-	if err != nil {
-		return err
+	if err := deployer.DeployGateway(ctx); err != nil {
+		return fmt.Errorf("deploy gateway failed: %w", err)
 	}
 
-	err = deployer.UpgradeGateway(ctx)
-	if err != nil {
-		return err
+	if err := deployer.UpgradeGateway(ctx); err != nil {
+		return fmt.Errorf("upgrade gateway failed: %w", err)
 	}
 
 	// Must be last step so we can be sure there are no RPs at older versions
 	// still serving
-	return deployer.SaveVersion(ctx)
+	if err := deployer.SaveVersion(ctx); err != nil {
+		return fmt.Errorf("save version failed: %w", err)
+	}
+	return nil
 }

--- a/cmd/aro/deploy.go
+++ b/cmd/aro/deploy.go
@@ -118,53 +118,24 @@ func deploy(ctx context.Context, _log *logrus.Entry) error {
 		return err
 	}
 
-	errch := make(chan error, 2)
-	go func() {
-		err := deployer.DeployRP(ctx)
-		if err != nil {
-			log.Error(err)
-			errch <- err
-			return
-		}
-
-		err = deployer.UpgradeRP(ctx)
-		if err != nil {
-			log.Error(err)
-			errch <- err
-			return
-		}
-
-		errch <- nil
-	}()
-
-	go func() {
-		err := deployer.DeployGateway(ctx)
-		if err != nil {
-			log.Error(err)
-			errch <- err
-			return
-		}
-
-		err = deployer.UpgradeGateway(ctx)
-		if err != nil {
-			log.Error(err)
-			errch <- err
-			return
-		}
-
-		errch <- nil
-	}()
-
-	var errorOccurred bool
-	for i := 0; i < 2; i++ {
-		err = <-errch
-		if err != nil {
-			errorOccurred = true
-		}
+	err = deployer.DeployRP(ctx)
+	if err != nil {
+		return err
 	}
 
-	if errorOccurred {
-		return fmt.Errorf("an error occurred")
+	err = deployer.UpgradeRP(ctx)
+	if err != nil {
+		return err
+	}
+
+	err = deployer.DeployGateway(ctx)
+	if err != nil {
+		return err
+	}
+
+	err = deployer.UpgradeGateway(ctx)
+	if err != nil {
+		return err
 	}
 
 	// Must be last step so we can be sure there are no RPs at older versions


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-29390](https://redhat.atlassian.net/browse/ARO-29390)

### What this PR does / why we need it:

The current VMSS deployment within aro deploy deploys the new RP and Gateway VMSS resources in-parallel, alongside the existing VMSS resources, before switching traffic over to the new VM instances and tearing down the old. However, in compute-quota-constrained deployments, this operation regularly fails as one VMSS deployment consumes the remaining quota, leaving not enough available for the other VMSS. This results in a failed deployment stage with mismatched gateway and RP VMSS versions, that requires a manual rerun in order to deploy the other service's VMSS. 

This PR updates this deployment to deploy the RP and Gateway VMSS resources in sequence, only deploying the gateway VMSS after the new RP VMSS has fully rolled out and the old VMSS has been fully torn down. 

### Test plan for issue:

- [ ] Post-merge validation in deployments to int and stg before promoting this change to production rollouts 

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

Above testing and validation in int and stg before the next production rollout that includes this change. 