### PR TITLE
[ARO-29392] Report errors raised by a scale set run command

### DIFF
--- a/pkg/util/azureclient/mgmt/compute/virtualmachinescalesetvms_addons.go
+++ b/pkg/util/azureclient/mgmt/compute/virtualmachinescalesetvms_addons.go
@@ -36,7 +36,7 @@ func (c *virtualMachineScaleSetVMsClient) RunCommandAndWait(ctx context.Context,
 		return err
 	}
 
-	return runCommandResultError(result)
+	return runCommandResultError(VMScaleSetName, instanceID, result)
 }
 
 // runCommandResultError reports any error the instance raised while running the
@@ -47,7 +47,11 @@ func (c *virtualMachineScaleSetVMsClient) RunCommandAndWait(ctx context.Context,
 // it establishes only that the command was delivered. Anything the instance has
 // to say about the outcome arrives in the result, which was previously
 // discarded, leaving a failed command indistinguishable from a successful one.
-func runCommandResultError(result mgmtcompute.RunCommandResult) error {
+//
+// The scale set and instance are named in the error because both callers run
+// commands across many instances, and a failure which does not say where it
+// happened leaves the reader to work that out from surrounding log lines.
+func runCommandResultError(vmScaleSetName, instanceID string, result mgmtcompute.RunCommandResult) error {
 	if result.Value == nil {
 		return nil
 	}
@@ -75,7 +79,7 @@ func runCommandResultError(result mgmtcompute.RunCommandResult) error {
 		return nil
 	}
 
-	return fmt.Errorf("run command reported an error: %s", strings.Join(reported, "; "))
+	return fmt.Errorf("run command on scale set %s instance %s reported an error: %s", vmScaleSetName, instanceID, strings.Join(reported, "; "))
 }
 
 func (c *virtualMachineScaleSetVMsClient) List(ctx context.Context, resourceGroupName string, virtualMachineScaleSetName string, filter string, selectParameter string, expand string) ([]mgmtcompute.VirtualMachineScaleSetVM, error) {

--- a/pkg/util/azureclient/mgmt/compute/virtualmachinescalesetvms_addons.go
+++ b/pkg/util/azureclient/mgmt/compute/virtualmachinescalesetvms_addons.go
@@ -5,6 +5,8 @@ package compute
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	mgmtcompute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
 )
@@ -20,7 +22,60 @@ func (c *virtualMachineScaleSetVMsClient) RunCommandAndWait(ctx context.Context,
 		return err
 	}
 
-	return future.WaitForCompletionRef(ctx, c.Client)
+	err = future.WaitForCompletionRef(ctx, c.Client)
+	if err != nil {
+		return err
+	}
+
+	if future.Result == nil {
+		return nil
+	}
+
+	result, err := future.Result(c.VirtualMachineScaleSetVMsClient)
+	if err != nil {
+		return err
+	}
+
+	return runCommandResultError(result)
+}
+
+// runCommandResultError reports any error the instance raised while running the
+// command.
+//
+// The long-running operation completes successfully whenever the extension
+// managed to run the script at all, whatever the script then did, so waiting on
+// it establishes only that the command was delivered. Anything the instance has
+// to say about the outcome arrives in the result, which was previously
+// discarded, leaving a failed command indistinguishable from a successful one.
+func runCommandResultError(result mgmtcompute.RunCommandResult) error {
+	if result.Value == nil {
+		return nil
+	}
+
+	var reported []string
+	for _, status := range *result.Value {
+		if status.Level != mgmtcompute.Error {
+			continue
+		}
+
+		parts := make([]string, 0, 2)
+		for _, s := range []*string{status.Code, status.Message} {
+			if s != nil && *s != "" {
+				parts = append(parts, *s)
+			}
+		}
+		if len(parts) == 0 {
+			parts = append(parts, "no detail reported")
+		}
+
+		reported = append(reported, strings.Join(parts, ": "))
+	}
+
+	if len(reported) == 0 {
+		return nil
+	}
+
+	return fmt.Errorf("run command reported an error: %s", strings.Join(reported, "; "))
 }
 
 func (c *virtualMachineScaleSetVMsClient) List(ctx context.Context, resourceGroupName string, virtualMachineScaleSetName string, filter string, selectParameter string, expand string) ([]mgmtcompute.VirtualMachineScaleSetVM, error) {

--- a/pkg/util/azureclient/mgmt/compute/virtualmachinescalesetvms_addons_test.go
+++ b/pkg/util/azureclient/mgmt/compute/virtualmachinescalesetvms_addons_test.go
@@ -1,0 +1,116 @@
+package compute
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"testing"
+
+	mgmtcompute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
+
+	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
+	utilerror "github.com/Azure/ARO-RP/test/util/error"
+)
+
+func TestRunCommandResultError(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		result  mgmtcompute.RunCommandResult
+		wantErr string
+	}{
+		{
+			name:   "no value reported",
+			result: mgmtcompute.RunCommandResult{},
+		},
+		{
+			name: "no statuses reported",
+			result: mgmtcompute.RunCommandResult{
+				Value: &[]mgmtcompute.InstanceViewStatus{},
+			},
+		},
+		{
+			name: "informational status is not an error",
+			result: mgmtcompute.RunCommandResult{
+				Value: &[]mgmtcompute.InstanceViewStatus{
+					{
+						Code:    pointerutils.ToPtr("ProvisioningState/succeeded"),
+						Level:   mgmtcompute.Info,
+						Message: pointerutils.ToPtr("Enable succeeded: \n[stdout]\n\n[stderr]\n"),
+					},
+				},
+			},
+		},
+		{
+			name: "warning is not an error",
+			result: mgmtcompute.RunCommandResult{
+				Value: &[]mgmtcompute.InstanceViewStatus{
+					{
+						Code:  pointerutils.ToPtr("ComponentStatus/StdErr/succeeded"),
+						Level: mgmtcompute.Warning,
+					},
+				},
+			},
+		},
+		{
+			name: "error status is reported with its code and message",
+			result: mgmtcompute.RunCommandResult{
+				Value: &[]mgmtcompute.InstanceViewStatus{
+					{
+						Code:    pointerutils.ToPtr("ComponentStatus/StdErr/failed"),
+						Level:   mgmtcompute.Error,
+						Message: pointerutils.ToPtr("Failed to restart aro-portal.service: Unit not found."),
+					},
+				},
+			},
+			wantErr: "run command reported an error: ComponentStatus/StdErr/failed: Failed to restart aro-portal.service: Unit not found.",
+		},
+		{
+			name: "error status carrying no detail is still reported",
+			result: mgmtcompute.RunCommandResult{
+				Value: &[]mgmtcompute.InstanceViewStatus{
+					{
+						Level: mgmtcompute.Error,
+					},
+				},
+			},
+			wantErr: "run command reported an error: no detail reported",
+		},
+		{
+			name: "an error among informational statuses is not lost",
+			result: mgmtcompute.RunCommandResult{
+				Value: &[]mgmtcompute.InstanceViewStatus{
+					{
+						Code:  pointerutils.ToPtr("ProvisioningState/succeeded"),
+						Level: mgmtcompute.Info,
+					},
+					{
+						Code:  pointerutils.ToPtr("ComponentStatus/StdErr/failed"),
+						Level: mgmtcompute.Error,
+					},
+				},
+			},
+			wantErr: "run command reported an error: ComponentStatus/StdErr/failed",
+		},
+		{
+			name: "every error is reported, not just the first",
+			result: mgmtcompute.RunCommandResult{
+				Value: &[]mgmtcompute.InstanceViewStatus{
+					{
+						Code:  pointerutils.ToPtr("first"),
+						Level: mgmtcompute.Error,
+					},
+					{
+						Code:  pointerutils.ToPtr("second"),
+						Level: mgmtcompute.Error,
+					},
+				},
+			},
+			wantErr: "run command reported an error: first; second",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			err := runCommandResultError(tt.result)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
+		})
+	}
+}

--- a/pkg/util/azureclient/mgmt/compute/virtualmachinescalesetvms_addons_test.go
+++ b/pkg/util/azureclient/mgmt/compute/virtualmachinescalesetvms_addons_test.go
@@ -13,6 +13,11 @@ import (
 )
 
 func TestRunCommandResultError(t *testing.T) {
+	const (
+		vmScaleSetName = "rp-vmss-test"
+		instanceID     = "3"
+	)
+
 	for _, tt := range []struct {
 		name    string
 		result  mgmtcompute.RunCommandResult
@@ -62,7 +67,7 @@ func TestRunCommandResultError(t *testing.T) {
 					},
 				},
 			},
-			wantErr: "run command reported an error: ComponentStatus/StdErr/failed: Failed to restart aro-portal.service: Unit not found.",
+			wantErr: "run command on scale set rp-vmss-test instance 3 reported an error: ComponentStatus/StdErr/failed: Failed to restart aro-portal.service: Unit not found.",
 		},
 		{
 			name: "error status carrying no detail is still reported",
@@ -73,7 +78,7 @@ func TestRunCommandResultError(t *testing.T) {
 					},
 				},
 			},
-			wantErr: "run command reported an error: no detail reported",
+			wantErr: "run command on scale set rp-vmss-test instance 3 reported an error: no detail reported",
 		},
 		{
 			name: "an error among informational statuses is not lost",
@@ -89,7 +94,7 @@ func TestRunCommandResultError(t *testing.T) {
 					},
 				},
 			},
-			wantErr: "run command reported an error: ComponentStatus/StdErr/failed",
+			wantErr: "run command on scale set rp-vmss-test instance 3 reported an error: ComponentStatus/StdErr/failed",
 		},
 		{
 			name: "every error is reported, not just the first",
@@ -105,11 +110,11 @@ func TestRunCommandResultError(t *testing.T) {
 					},
 				},
 			},
-			wantErr: "run command reported an error: first; second",
+			wantErr: "run command on scale set rp-vmss-test instance 3 reported an error: first; second",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			err := runCommandResultError(tt.result)
+			err := runCommandResultError(vmScaleSetName, instanceID, tt.result)
 			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-29392](https://redhat.atlassian.net/browse/ARO-29392)

### What this PR does / why we need it:

`RunCommandAndWait` waited for the long-running operation to complete and returned without fetching its result. The operation succeeds whenever the extension managed to run the script, irrespective of what the script then did, so waiting on it establishes only that the command was delivered. The instance reports the outcome in the result, which was discarded, leaving a failed command indistinguishable from a successful one.

This fetches the result and returns any error-level status, with its code and message.

Two callers are affected. `restartOldScaleset` in `PreDeploy` uses it to restart services after a secret is rotated so that they pick up the new version, where a service that did not come back up is currently reported as restarted and the secret treated as propagated when it is not. `runCommandWithRetry` uses it during teardown.

### Test plan for issue:

- [x] Unit tests. `TestRunCommandResultError` covers a result with no value, no statuses, informational and warning statuses, an error with and without detail, an error among informational statuses, and several errors together.

Each assertion was checked by mutation: never reporting an error, treating warnings as errors, and reporting only the first error each cause the expected cases to fail.

### Is there any documentation that needs to be updated for this PR?

No.

### How do you know this will function as expected in production?

The change is confined to reading a field of a response the client already receives, and returns an error only where the instance itself reports one at error level. Where no error is reported the behaviour is unchanged.

Failures surface to the existing callers as a returned error, so a failed restart during `PreDeploy` now stops the deployment rather than passing silently.

### Scope

This catches what Azure reports as an error: a failure to deliver or run the script, and any error-level status on the instance.

It does not catch a script that runs and exits non-zero. This API version's `InstanceViewStatus` carries `code`, `level` and `message` but no exit code; the provisioning state remains `succeeded` for a non-zero exit, and `level` is not dependably set to `Error`.

Closing that gap properly means moving to managed Run Commands (`VirtualMachineScaleSetVMRunCommands`), which expose `exitCode` and `error` directly. That is a larger change touching both callers and their mocks, and is raised separately as [ARO-29433](https://redhat.atlassian.net/browse/ARO-29433). This change stands on its own in the meantime: it reports failures that are currently silent, and reports none that are not.

A sentinel emitted by the caller's script was considered and rejected. It would be smaller, but it introduces a convention the deployment scripts must keep honouring — the same class of hand-maintained coupling that caused the incident this work came from.
