### PR TITLE
fixed Machine object to use FQDN

### DIFF
--- a/pkg/frontend/admin_openshiftcluster_resize_controlplane.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_controlplane.go
@@ -349,7 +349,7 @@ func updateMachineVMSize(ctx context.Context, k adminactions.KubeActions, machin
 }
 
 func doUpdateMachineVMSize(ctx context.Context, k adminactions.KubeActions, machineName, vmSize string) error {
-	rawMachine, err := k.KubeGet(ctx, "Machine.machine.openshift.io", machineNamespace, machineName)
+	rawMachine, err := k.KubeGet(ctx, machineGroupKind, machineNamespace, machineName)
 	if err != nil {
 		return err
 	}

--- a/pkg/frontend/admin_openshiftcluster_resize_controlplane_recovery_test.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_controlplane_recovery_test.go
@@ -172,7 +172,7 @@ func TestResizeControlPlaneRollback(t *testing.T) {
 		k := mock_adminactions.NewMockKubeActions(ctrl)
 		a := mock_adminactions.NewMockAzureActions(ctrl)
 
-		k.EXPECT().KubeList(gomock.Any(), "Machine", machineNamespace).Return(
+		k.EXPECT().KubeList(gomock.Any(), machineGroupKind, machineNamespace).Return(
 			masterMachineListJSON(masterMachine("master-0", "Standard_D8s_v3", running)), nil)
 
 		gomock.InOrder(
@@ -216,7 +216,7 @@ func TestResizeControlPlaneRollback(t *testing.T) {
 		k := mock_adminactions.NewMockKubeActions(ctrl)
 		a := mock_adminactions.NewMockAzureActions(ctrl)
 
-		k.EXPECT().KubeList(gomock.Any(), "Machine", machineNamespace).Return(
+		k.EXPECT().KubeList(gomock.Any(), machineGroupKind, machineNamespace).Return(
 			masterMachineListJSON(
 				masterMachine("master-0", desiredSize, running),
 				masterMachine("master-1", "Standard_D8s_v3", running),
@@ -288,7 +288,7 @@ func TestResizeControlPlaneRollback(t *testing.T) {
 		k := mock_adminactions.NewMockKubeActions(ctrl)
 		a := mock_adminactions.NewMockAzureActions(ctrl)
 
-		k.EXPECT().KubeList(gomock.Any(), "Machine", machineNamespace).Return(
+		k.EXPECT().KubeList(gomock.Any(), machineGroupKind, machineNamespace).Return(
 			masterMachineListJSON(
 				masterMachine("master-0", desiredSize, running),
 				masterMachine("master-1", "Standard_D8s_v3", running),
@@ -347,7 +347,7 @@ func TestResizeControlPlaneRollback(t *testing.T) {
 		k := mock_adminactions.NewMockKubeActions(ctrl)
 		a := mock_adminactions.NewMockAzureActions(ctrl)
 
-		k.EXPECT().KubeList(gomock.Any(), "Machine", machineNamespace).Return(
+		k.EXPECT().KubeList(gomock.Any(), machineGroupKind, machineNamespace).Return(
 			masterMachineListJSON(
 				masterMachine("master-0", desiredSize, running),
 				masterMachine("master-1", "Standard_D8s_v3", running),

--- a/pkg/frontend/admin_openshiftcluster_resize_controlplane_test.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_controlplane_test.go
@@ -331,7 +331,7 @@ func TestResizeControlPlane(t *testing.T) {
 					masterMachine("master-1", desiredSize, running),
 					masterMachine("master-2", desiredSize, running),
 				)
-				k.EXPECT().KubeList(gomock.Any(), "Machine", machineNamespace).Return(machines, nil)
+				k.EXPECT().KubeList(gomock.Any(), machineGroupKind, machineNamespace).Return(machines, nil)
 				gomock.InOrder(
 					k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-2").
 						Return(nodeJSON("master-2", true), nil),
@@ -362,7 +362,7 @@ func TestResizeControlPlane(t *testing.T) {
 					masterMachine("master-1", desiredSize, running),
 					masterMachine("master-2", "Standard_D8s_v3", running),
 				)
-				k.EXPECT().KubeList(gomock.Any(), "Machine", machineNamespace).Return(machines, nil)
+				k.EXPECT().KubeList(gomock.Any(), machineGroupKind, machineNamespace).Return(machines, nil)
 
 				gomock.InOrder(
 					k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-2").
@@ -407,7 +407,7 @@ func TestResizeControlPlane(t *testing.T) {
 		{
 			name: "pre-loop gate fails when node is not ready",
 			mocks: func(k *mock_adminactions.MockKubeActions, a *mock_adminactions.MockAzureActions) {
-				k.EXPECT().KubeList(gomock.Any(), "Machine", machineNamespace).Return(
+				k.EXPECT().KubeList(gomock.Any(), machineGroupKind, machineNamespace).Return(
 					masterMachineListJSON(masterMachine("master-0", desiredSize, running)), nil)
 				k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-0").
 					Return(nodeJSON("master-0", false), nil)
@@ -417,7 +417,7 @@ func TestResizeControlPlane(t *testing.T) {
 		{
 			name: "pre-loop gate fails when node is unschedulable",
 			mocks: func(k *mock_adminactions.MockKubeActions, a *mock_adminactions.MockAzureActions) {
-				k.EXPECT().KubeList(gomock.Any(), "Machine", machineNamespace).Return(
+				k.EXPECT().KubeList(gomock.Any(), machineGroupKind, machineNamespace).Return(
 					masterMachineListJSON(masterMachine("master-0", desiredSize, running)), nil)
 				k.EXPECT().KubeGet(gomock.Any(), "Node", "", "master-0").
 					Return(nodeJSONWithSchedulability("master-0", true, true), nil)
@@ -427,7 +427,7 @@ func TestResizeControlPlane(t *testing.T) {
 		{
 			name: "no control plane machines found",
 			mocks: func(k *mock_adminactions.MockKubeActions, a *mock_adminactions.MockAzureActions) {
-				k.EXPECT().KubeList(gomock.Any(), "Machine", machineNamespace).Return(masterMachineListJSON(), nil)
+				k.EXPECT().KubeList(gomock.Any(), machineGroupKind, machineNamespace).Return(masterMachineListJSON(), nil)
 			},
 			wantErr: "409: RequestNotAllowed: : No control plane machines found. Resize cannot proceed.",
 		},

--- a/pkg/frontend/admin_openshiftcluster_resize_validation_helpers.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_validation_helpers.go
@@ -33,6 +33,7 @@ const (
 	controlPlaneReplicaCount = azurezones.CONTROL_PLANE_MACHINE_COUNT
 
 	machineNamespace           = "openshift-machine-api"
+	machineGroupKind           = "Machine.machine.openshift.io"
 	machineLabelClusterAPIRole = "machine.openshift.io/cluster-api-machine-role"
 	machineLabelZone           = "machine.openshift.io/zone"
 	machineLabelInstanceType   = "machine.openshift.io/instance-type"
@@ -98,7 +99,7 @@ func unmarshalAzureMachineProviderSpec(machine *machinev1beta1.Machine) (*machin
 func getClusterMachines(ctx context.Context, kubeActions adminactions.KubeActions) (map[string]machineValidationData, error) {
 	machines := make(map[string]machineValidationData)
 
-	rawMachines, err := kubeActions.KubeList(ctx, "Machine.machine.openshift.io", machineNamespace)
+	rawMachines, err := kubeActions.KubeList(ctx, machineGroupKind, machineNamespace)
 	if err != nil {
 		return nil, api.NewCloudError(
 			http.StatusInternalServerError,

--- a/pkg/frontend/admin_openshiftcluster_resize_validation_helpers.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_validation_helpers.go
@@ -98,7 +98,7 @@ func unmarshalAzureMachineProviderSpec(machine *machinev1beta1.Machine) (*machin
 func getClusterMachines(ctx context.Context, kubeActions adminactions.KubeActions) (map[string]machineValidationData, error) {
 	machines := make(map[string]machineValidationData)
 
-	rawMachines, err := kubeActions.KubeList(ctx, "Machine", machineNamespace)
+	rawMachines, err := kubeActions.KubeList(ctx, "Machine.machine.openshift.io", machineNamespace)
 	if err != nil {
 		return nil, api.NewCloudError(
 			http.StatusInternalServerError,

--- a/pkg/frontend/admin_openshiftcluster_resize_validation_helpers_test.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_validation_helpers_test.go
@@ -345,7 +345,7 @@ func TestGetClusterMachines(t *testing.T) {
 					createMachine("master-1", "master", "2", "2", "Standard_D8s_v3", "Standard_D8s_v3", "Running"),
 					createMachine("master-2", "master", "3", "3", "Standard_D8s_v3", "Standard_D8s_v3", "Running"),
 				)
-				k.EXPECT().KubeList(ctx, "Machine", machineNamespace).Return(machines, nil)
+				k.EXPECT().KubeList(ctx, machineGroupKind, machineNamespace).Return(machines, nil)
 			},
 			wantCount: 3,
 		},
@@ -359,7 +359,7 @@ func TestGetClusterMachines(t *testing.T) {
 					createMachine("worker-0", "worker", "1", "1", "Standard_D4s_v3", "Standard_D4s_v3", "Running"),
 					createMachine("worker-1", "worker", "2", "2", "Standard_D4s_v3", "Standard_D4s_v3", "Running"),
 				)
-				k.EXPECT().KubeList(ctx, "Machine", machineNamespace).Return(machines, nil)
+				k.EXPECT().KubeList(ctx, machineGroupKind, machineNamespace).Return(machines, nil)
 			},
 			wantCount: 3, // Only masters
 		},
@@ -372,7 +372,7 @@ func TestGetClusterMachines(t *testing.T) {
 					createMachine("master-2", "master", "3", "3", "Standard_D8s_v3", "Standard_D8s_v3", "Running"),
 					createMachine("master-3", "", "1", "1", "Standard_D8s_v3", "", "Running"), // No role label
 				)
-				k.EXPECT().KubeList(ctx, "Machine", machineNamespace).Return(machines, nil)
+				k.EXPECT().KubeList(ctx, machineGroupKind, machineNamespace).Return(machines, nil)
 			},
 			wantCount: 3, // Only masters with proper role label
 		},
@@ -385,7 +385,7 @@ func TestGetClusterMachines(t *testing.T) {
 					createMachine("master-2", "master", "3", "3", "Standard_D8s_v3", "Standard_D8s_v3", "Running"),
 					createMachine("master-infra-0", "infra", "1", "1", "Standard_D8s_v3", "", "Running"), // Has "master" in name but wrong role
 				)
-				k.EXPECT().KubeList(ctx, "Machine", machineNamespace).Return(machines, nil)
+				k.EXPECT().KubeList(ctx, machineGroupKind, machineNamespace).Return(machines, nil)
 			},
 			wantCount: 3, // Only masters with role=master
 		},
@@ -397,7 +397,7 @@ func TestGetClusterMachines(t *testing.T) {
 					createMachine("master-1", "master", "2", "2", "Standard_D8s_v3", "Standard_D8s_v3", ""), // nil phase
 					createMachine("master-2", "master", "3", "3", "Standard_D8s_v3", "Standard_D8s_v3", "Running"),
 				)
-				k.EXPECT().KubeList(ctx, "Machine", machineNamespace).Return(machines, nil)
+				k.EXPECT().KubeList(ctx, machineGroupKind, machineNamespace).Return(machines, nil)
 			},
 			wantCount: 3,
 		},
@@ -409,7 +409,7 @@ func TestGetClusterMachines(t *testing.T) {
 					createMachine("master-1", "master", "2", "2", "Standard_D8s_v3", "Standard_D8s_v3", "Failed"),
 					createMachine("master-2", "master", "3", "3", "Standard_D8s_v3", "Standard_D8s_v3", "Running"),
 				)
-				k.EXPECT().KubeList(ctx, "Machine", machineNamespace).Return(machines, nil)
+				k.EXPECT().KubeList(ctx, machineGroupKind, machineNamespace).Return(machines, nil)
 			},
 			wantCount: 3,
 		},
@@ -420,7 +420,7 @@ func TestGetClusterMachines(t *testing.T) {
 					createMachine("master-0", "master", "1", "1", "Standard_D8s_v3", "Standard_D8s_v3", "Running"),
 					createMachine("master-1", "master", "2", "2", "Standard_D8s_v3", "Standard_D8s_v3", "Running"),
 				)
-				k.EXPECT().KubeList(ctx, "Machine", machineNamespace).Return(machines, nil)
+				k.EXPECT().KubeList(ctx, machineGroupKind, machineNamespace).Return(machines, nil)
 			},
 			wantCount: 2,
 		},
@@ -435,7 +435,7 @@ func TestGetClusterMachines(t *testing.T) {
 					machineWithNilProviderSpec,
 					createMachine("master-2", "master", "3", "3", "Standard_D8s_v3", "Standard_D8s_v3", "Running"),
 				)
-				k.EXPECT().KubeList(ctx, "Machine", machineNamespace).Return(machines, nil)
+				k.EXPECT().KubeList(ctx, machineGroupKind, machineNamespace).Return(machines, nil)
 			},
 			wantErr: "controlPlaneMachine/master-1: failed to parse provider spec for machine master-1: provider spec value is nil",
 		},

--- a/pkg/frontend/admin_openshiftcluster_vmresize_pre_validation_test.go
+++ b/pkg/frontend/admin_openshiftcluster_vmresize_pre_validation_test.go
@@ -277,7 +277,7 @@ func allKubeChecksHealthyMockWithMachineList(k *mock_adminactions.MockKubeAction
 		Return(nil, kerrors.NewNotFound(schema.GroupResource{Group: "machine.openshift.io", Resource: "controlplanemachinesets"}, "cluster")).
 		AnyTimes()
 	k.EXPECT().
-		KubeList(gomock.Any(), "Machine", machineNamespace).
+		KubeList(gomock.Any(), machineGroupKind, machineNamespace).
 		Return(machineList, nil).
 		AnyTimes()
 }
@@ -285,7 +285,7 @@ func allKubeChecksHealthyMockWithMachineList(k *mock_adminactions.MockKubeAction
 func healthyControlPlaneInventoryMock(k *mock_adminactions.MockKubeActions, a *mock_adminactions.MockAzureActions, resourceGroupName string, vmSize string) {
 	if k != nil {
 		k.EXPECT().
-			KubeList(gomock.Any(), "Machine", machineNamespace).
+			KubeList(gomock.Any(), machineGroupKind, machineNamespace).
 			Return(masterMachineListJSON(
 				masterMachineWithZone("master-0", vmSize, "1"),
 				masterMachineWithZone("master-1", vmSize, "2"),
@@ -322,7 +322,7 @@ func TestValidateResizeControlPlaneInventory(t *testing.T) {
 		a := mock_adminactions.NewMockAzureActions(ctrl)
 
 		k.EXPECT().
-			KubeList(gomock.Any(), "Machine", machineNamespace).
+			KubeList(gomock.Any(), machineGroupKind, machineNamespace).
 			Return(masterMachineListJSON(
 				masterMachineWithZone("master-0", "Standard_D8s_v3", "1"),
 				masterMachineWithZone("master-1", "Standard_D8s_v3", "2"),
@@ -353,7 +353,7 @@ func TestValidateResizeControlPlaneInventory(t *testing.T) {
 		a := mock_adminactions.NewMockAzureActions(ctrl)
 
 		k.EXPECT().
-			KubeList(gomock.Any(), "Machine", machineNamespace).
+			KubeList(gomock.Any(), machineGroupKind, machineNamespace).
 			Return(nil, fmt.Errorf("connection refused"))
 
 		err := validateResizeControlPlaneInventory(ctx, log, k, a, "/subscriptions/000/resourceGroups/test-cluster")
@@ -374,7 +374,7 @@ func TestValidateResizeControlPlaneInventory(t *testing.T) {
 		a := mock_adminactions.NewMockAzureActions(ctrl)
 
 		k.EXPECT().
-			KubeList(gomock.Any(), "Machine", machineNamespace).
+			KubeList(gomock.Any(), machineGroupKind, machineNamespace).
 			Return(masterMachineListJSON(
 				masterMachineWithZone("master-0", "Standard_D8s_v3", "1"),
 				masterMachineWithZone("master-1", "Standard_D8s_v3", "2"),
@@ -980,7 +980,7 @@ func TestPreResizeControlPlaneVMsValidation(t *testing.T) {
 					Return(nil, kerrors.NewNotFound(schema.GroupResource{Group: "machine.openshift.io", Resource: "controlplanemachinesets"}, "cluster")).
 					AnyTimes()
 				k.EXPECT().
-					KubeList(gomock.Any(), "Machine", machineNamespace).
+					KubeList(gomock.Any(), machineGroupKind, machineNamespace).
 					Return(masterMachineListJSON(
 						masterMachine("master-0", "Standard_D8s_v3", running),
 						masterMachine("master-1", "Standard_D8s_v3", running),
@@ -1101,7 +1101,7 @@ func TestValidateResizeControlPlaneInventoryNormalizesJoinedErrorLineEndings(t *
 	a := mock_adminactions.NewMockAzureActions(ctrl)
 	log := logrus.NewEntry(logrus.New())
 
-	k.EXPECT().KubeList(gomock.Any(), "Machine", machineNamespace).
+	k.EXPECT().KubeList(gomock.Any(), machineGroupKind, machineNamespace).
 		Return(masterMachineListJSON(
 			zonedMasterMachine("master-0", "Standard_D8s_v3", "Running", "1"),
 			zonedMasterMachine("master-1", "Standard_D8s_v3", "Running", "2"),


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes the issue with Post Resize Validation steps Geneva Actoin
```
failed with status InternalServerError. Response content:
{
    "error": {
        "code": "InternalServerError",
        "message": "500: InternalServerError: controlPlaneMachines: no matches for /, Resource=Machine"
    }
}
```
### Test plan for issue:
Minor change
- [x] e2e

### Is there any documentation that needs to be updated for this PR?
No

### Context
