### PR TITLE
Follow-up to further refine identity replacement test

### DIFF
--- a/test/e2e/update.go
+++ b/test/e2e/update.go
@@ -209,6 +209,8 @@ var _ = Describe("Update clusters", func() {
 			var err error
 			originalMsi, err = clients.UserAssignedIdentities.Get(ctx, vnetResourceGroup, operatorName, nil)
 			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(originalMsi.Properties).NotTo(BeNil())
+			g.Expect(originalMsi.Properties.PrincipalID).NotTo(BeNil())
 		}).WithContext(ctx).WithTimeout(DefaultEventuallyTimeout).Should(Succeed())
 
 		DeferCleanup(func(ctx context.Context) {

--- a/test/e2e/update.go
+++ b/test/e2e/update.go
@@ -203,12 +203,16 @@ var _ = Describe("Update clusters", func() {
 		replacementResourceID := *msiResp.ID
 		replacementPrincipalID := *msiResp.Properties.PrincipalID
 
+		By("getting the original identity")
+		var originalMsi armmsi.UserAssignedIdentitiesClientGetResponse
+		Eventually(func(g Gomega, ctx context.Context) {
+			var err error
+			originalMsi, err = clients.UserAssignedIdentities.Get(ctx, vnetResourceGroup, operatorName, nil)
+			g.Expect(err).NotTo(HaveOccurred())
+		}).WithContext(ctx).WithTimeout(DefaultEventuallyTimeout).Should(Succeed())
+
 		DeferCleanup(func(ctx context.Context) {
-			By("cleaning up the original identity and its role assignments")
-			originalMsi, err := clients.UserAssignedIdentities.Get(ctx, vnetResourceGroup, operatorName, nil)
-			if err != nil {
-				return
-			}
+			By("cleaning up any remaining role assignments for the original identity")
 			if originalMsi.Properties != nil && originalMsi.Properties.PrincipalID != nil {
 				roleAssignments, err := clients.RoleAssignments.ListForResourceGroup(ctx, vnetResourceGroup, fmt.Sprintf("principalId eq '%s'", *originalMsi.Properties.PrincipalID))
 				if err == nil {
@@ -219,8 +223,17 @@ var _ = Describe("Update clusters", func() {
 					}
 				}
 			}
-			_, _ = clients.UserAssignedIdentities.Delete(ctx, vnetResourceGroup, operatorName, nil)
 		})
+
+		// After the operator restart later in the test, all the ServicePrincipalValid status tells us is that
+		// the operator can start up and can acquire an Azure auth token using whatever identity is provided to it.
+		// Deleting the original identity before doing the replacement and restart ensures that the operator can't
+		// pass the status condition checks by starting up using the old identity.
+		By("deleting the original identity")
+		Eventually(func(g Gomega, ctx context.Context) {
+			_, err := clients.UserAssignedIdentities.Delete(ctx, vnetResourceGroup, operatorName, nil)
+			g.Expect(err).NotTo(HaveOccurred())
+		}).WithContext(ctx).WithTimeout(DefaultEventuallyTimeout).Should(Succeed())
 
 		By("assigning the operator's role to the replacement identity at VNet scope")
 		vnetRoleAssignmentName := uuid.DefaultGenerator.Generate()
@@ -334,10 +347,6 @@ var _ = Describe("Update clusters", func() {
 
 		By("verifying the old identity no longer has any role assignments at managed resource group scope")
 		Eventually(func(g Gomega, ctx context.Context) {
-			originalMsi, err := clients.UserAssignedIdentities.Get(ctx, vnetResourceGroup, operatorName, nil)
-			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(originalMsi.Properties).NotTo(BeNil())
-			g.Expect(originalMsi.Properties.PrincipalID).NotTo(BeNil())
 			roleAssignments, err := clients.RoleAssignments.ListForResourceGroup(ctx, stringutils.LastTokenByte(*oc.Properties.ClusterProfile.ResourceGroupID, '/'), "atScope()")
 			g.Expect(err).NotTo(HaveOccurred())
 			for _, ra := range roleAssignments {

--- a/test/e2e/update.go
+++ b/test/e2e/update.go
@@ -203,7 +203,11 @@ var _ = Describe("Update clusters", func() {
 		replacementResourceID := *msiResp.ID
 		replacementPrincipalID := *msiResp.Properties.PrincipalID
 
-		By("getting the original identity")
+		// After the operator restart later in the test, all the ServicePrincipalValid status tells us is that
+		// the operator can start up and can acquire an Azure auth token using whatever identity is provided to it.
+		// Deleting the original identity before doing the replacement and restart ensures that the operator can't
+		// pass the status condition checks by starting up using the old identity.
+		By("deleting the original identity")
 		var originalMsi armmsi.UserAssignedIdentitiesClientGetResponse
 		Eventually(func(g Gomega, ctx context.Context) {
 			var err error
@@ -211,6 +215,11 @@ var _ = Describe("Update clusters", func() {
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(originalMsi.Properties).NotTo(BeNil())
 			g.Expect(originalMsi.Properties.PrincipalID).NotTo(BeNil())
+		}).WithContext(ctx).WithTimeout(DefaultEventuallyTimeout).Should(Succeed())
+
+		Eventually(func(g Gomega, ctx context.Context) {
+			_, err := clients.UserAssignedIdentities.Delete(ctx, vnetResourceGroup, operatorName, nil)
+			g.Expect(err).NotTo(HaveOccurred())
 		}).WithContext(ctx).WithTimeout(DefaultEventuallyTimeout).Should(Succeed())
 
 		DeferCleanup(func(ctx context.Context) {
@@ -226,16 +235,6 @@ var _ = Describe("Update clusters", func() {
 				}
 			}
 		})
-
-		// After the operator restart later in the test, all the ServicePrincipalValid status tells us is that
-		// the operator can start up and can acquire an Azure auth token using whatever identity is provided to it.
-		// Deleting the original identity before doing the replacement and restart ensures that the operator can't
-		// pass the status condition checks by starting up using the old identity.
-		By("deleting the original identity")
-		Eventually(func(g Gomega, ctx context.Context) {
-			_, err := clients.UserAssignedIdentities.Delete(ctx, vnetResourceGroup, operatorName, nil)
-			g.Expect(err).NotTo(HaveOccurred())
-		}).WithContext(ctx).WithTimeout(DefaultEventuallyTimeout).Should(Succeed())
 
 		By("assigning the operator's role to the replacement identity at VNet scope")
 		vnetRoleAssignmentName := uuid.DefaultGenerator.Generate()


### PR DESCRIPTION
### Which issue this PR addresses:

https://redhat.atlassian.net/browse/ARO-29384

Follow up on https://github.com/Azure/ARO-RP/pull/5067

### What this PR does / why we need it:

By deleting the old identity before doing the replacement, we can make certain that the operator starts up with the new identity following the update that performs the replacement.

Copilot correctly pointed out that deleting the old identity mid-test can break the operator and cause cascading test failures, but the fact that we attempt to replace the identity at all creates the possibility of those same cascading failures. Perhaps we're increasing the chance of a cascading failure, but I don't think it's by much. I think this change adds enough value that it's worth it.

### Test plan for issue:

E2E

### Is there any documentation that needs to be updated for this PR?

N/A

### How do you know this will function as expected in production? 

E2E