### PR TITLE
[ARO-29413] Forward machine reconcile errors to kusto 

### DIFF
--- a/pkg/operator/controllers/genevalogging/staticfiles/otel-config.yaml.tmpl
+++ b/pkg/operator/controllers/genevalogging/staticfiles/otel-config.yaml.tmpl
@@ -412,6 +412,7 @@ not ((IsString(body) and (
     IsMatch(body, "level=(error|warn|warning)")
     or IsMatch(body, "\\bE[0-9]{4}\\b|\\bW[0-9]{4}\\b")
     or IsMatch(body, "Update error .*: ClusterOperatorDegraded")
+    or IsMatch(body, "failed to reconcile machine")
     or IsMatch(body, "\\terror\\t|\\twarn\\t")))
   or (IsMap(body) and (
     (IsString(body["severity"]) and (
@@ -420,6 +421,7 @@ not ((IsString(body) and (
     or (IsString(body["message"]) and (
       IsMatch(body["message"], "level=(error|warn|warning)")
       or IsMatch(body["message"], "\\bE[0-9]{4}\\b|\\bW[0-9]{4}\\b")
+      or IsMatch(body["message"], "failed to reconcile machine")
       or IsMatch(body["message"], "Update error .*: ClusterOperatorDegraded"))))))
 {{- end -}}
 {{- define "keep-journald-high-signal-expr" -}}


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes https://redhat.atlassian.net/browse/ARO-29413

### What this PR does / why we need it:

- machine-controller logs forwarded to kusto don't include the full error message when reconciliation for a specific machine fails.
- Full error message is logged only with an Info log level, but only warn and higher are forwarded
- This PR adds a filter to the otel config to specifically forward machine-controller reconcile errors

### Test plan for issue:

- Unit tests passing, no errors in configuration

### Is there any documentation that needs to be updated for this PR?

No, this restores expected behavior.