### PR TITLE
[ARO-29482] refactor pre resize validation

### DIFF
--- a/pkg/frontend/admin_openshiftcluster_resize_controlplane.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_controlplane.go
@@ -20,13 +20,10 @@ import (
 	"github.com/sirupsen/logrus"
 
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	kruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 
-	machinev1 "github.com/openshift/api/machine/v1"
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 
 	"github.com/Azure/ARO-RP/pkg/api"
@@ -158,7 +155,7 @@ func (f *frontend) _postAdminResizeControlPlane(log *logrus.Entry, ctx context.C
 	}
 
 	// Run all pre-flight validations (API server health, etcd health, SP, VM SKU, quota).
-	_, err = f.preResizeControlPlaneVMsValidation(ctx, doc, subscriptionDoc, k, a, vmSize, log)
+	err = f.preResizeControlPlaneVMsValidation(ctx, doc, subscriptionDoc, k, a, vmSize, log)
 	if err != nil {
 		return err
 	}
@@ -243,41 +240,6 @@ func cordonNode(ctx context.Context, k adminactions.KubeActions, nodeName string
 
 func uncordonNode(ctx context.Context, k adminactions.KubeActions, nodeName string) error {
 	return k.CordonNode(ctx, nodeName, false)
-}
-
-// getControlPlaneMachines is a thin wrapper around getClusterMachines that
-// makes the intent explicit at the call site. getClusterMachines already
-// filters by the machine.openshift.io/cluster-api-machine-role=master label.
-func getControlPlaneMachines(ctx context.Context, k adminactions.KubeActions) (map[string]machineValidationData, error) {
-	return getClusterMachines(ctx, k)
-}
-
-// checkCPMSNotActive verifies that the ControlPlaneMachineSet is not Active.
-// If it is active, direct VM manipulation would conflict with the CPMS operator.
-// Only NotFound / CRD-not-installed errors are treated as "CPMS absent";
-// all other errors fail the operation closed so we don't bypass the safety check.
-func checkCPMSNotActive(ctx context.Context, k adminactions.KubeActions) error {
-	rawCPMS, err := k.KubeGet(ctx, "ControlPlaneMachineSet.machine.openshift.io", machineNamespace, "cluster")
-	if err != nil {
-		if kerrors.IsNotFound(err) || meta.IsNoMatchError(err) {
-			return nil
-		}
-		return api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "",
-			fmt.Sprintf("failed to check ControlPlaneMachineSet state: %v", err))
-	}
-
-	var cpms machinev1.ControlPlaneMachineSet
-	if err := json.Unmarshal(rawCPMS, &cpms); err != nil {
-		return api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "",
-			fmt.Sprintf("failed to parse ControlPlaneMachineSet object: %v", err))
-	}
-
-	if cpms.Spec.State == machinev1.ControlPlaneMachineSetStateActive {
-		return api.NewCloudError(http.StatusConflict, api.CloudErrorCodeRequestNotAllowed, "",
-			"ControlPlaneMachineSet is currently Active. Deactivate CPMS before running this operation.")
-	}
-
-	return nil
 }
 
 func waitForNodeReady(ctx context.Context, log *logrus.Entry, k adminactions.KubeActions, nodeName string) error {

--- a/pkg/frontend/admin_openshiftcluster_resize_controlplane_recovery.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_controlplane_recovery.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
 	"strings"
 	"time"
 
@@ -315,18 +314,19 @@ func (o *resizeControlPlaneOperation) resizeNode(ctx context.Context, state *con
 }
 
 func waitForEtcdHealthy(ctx context.Context, log *logrus.Entry, k adminactions.KubeActions) error {
-	return wait.PollUntilContextTimeout(ctx, etcdHealthPollInterval, etcdHealthPollTimeout, true, func(innerCtx context.Context) (bool, error) {
-		err := validateEtcdHealth(innerCtx, k)
-		if err != nil {
-			var cloudErr *api.CloudError
-			if errors.As(err, &cloudErr) && cloudErr.StatusCode == http.StatusConflict {
-				log.Infof("Waiting for etcd to become healthy: %v", err)
-				return false, nil
-			}
-			return false, err
+	var lastErr error
+	waitErr := wait.PollUntilContextTimeout(ctx, etcdHealthPollInterval, etcdHealthPollTimeout, true, func(innerCtx context.Context) (bool, error) {
+		lastErr = validateEtcdHealth(innerCtx, k)
+		if lastErr != nil {
+			log.Infof("Waiting for etcd to become healthy: %v", lastErr)
+			return false, nil
 		}
 		return true, nil
 	})
+	if waitErr != nil {
+		return errors.Join(waitErr, lastErr)
+	}
+	return nil
 }
 
 func ensureControlPlaneAndEtcdHealthy(ctx context.Context, k adminactions.KubeActions, nodeNames []string) error {

--- a/pkg/frontend/admin_openshiftcluster_resize_controlplane_recovery_test.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_controlplane_recovery_test.go
@@ -151,7 +151,7 @@ func TestWaitForEtcdHealthyBoundsHealthCheckByEtcdTimeout(t *testing.T) {
 
 		err := waitForEtcdHealthy(ctx, log, k)
 		assertErrorContainsAll(t, err,
-			"Failed to retrieve etcd ClusterOperator",
+			"failed to retrieve etcd ClusterOperator",
 			context.DeadlineExceeded.Error(),
 		)
 	})

--- a/pkg/frontend/admin_openshiftcluster_resize_controlplane_test.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_controlplane_test.go
@@ -15,11 +15,9 @@ import (
 	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	kruntime "k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7"
 	mgmtcompute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
@@ -155,81 +153,6 @@ func machineJSONWithoutProviderSpecValue(name, vmSize string) []byte {
 	}
 	b, _ := json.Marshal(obj)
 	return b
-}
-
-func TestCheckCPMSNotActive(t *testing.T) {
-	ctx := context.Background()
-
-	cpmsGR := schema.GroupResource{Group: "machine.openshift.io", Resource: "controlplanemachinesets"}
-
-	for _, tt := range []struct {
-		name    string
-		mocks   func(*mock_adminactions.MockKubeActions)
-		wantErr string
-	}{
-		{
-			name: "CPMS not found - safe to proceed",
-			mocks: func(k *mock_adminactions.MockKubeActions) {
-				k.EXPECT().
-					KubeGet(gomock.Any(), "ControlPlaneMachineSet.machine.openshift.io", machineNamespace, "cluster").
-					Return(nil, kerrors.NewNotFound(cpmsGR, "cluster"))
-			},
-		},
-		{
-			name: "CPMS inactive - safe to proceed",
-			mocks: func(k *mock_adminactions.MockKubeActions) {
-				k.EXPECT().
-					KubeGet(gomock.Any(), "ControlPlaneMachineSet.machine.openshift.io", machineNamespace, "cluster").
-					Return(cpmsJSON("Inactive"), nil)
-			},
-		},
-		{
-			name: "CPMS active - blocked",
-			mocks: func(k *mock_adminactions.MockKubeActions) {
-				k.EXPECT().
-					KubeGet(gomock.Any(), "ControlPlaneMachineSet.machine.openshift.io", machineNamespace, "cluster").
-					Return(cpmsJSON("Active"), nil)
-			},
-			wantErr: "409: RequestNotAllowed: : ControlPlaneMachineSet is currently Active. Deactivate CPMS before running this operation.",
-		},
-		{
-			name: "CPMS with empty state - safe to proceed",
-			mocks: func(k *mock_adminactions.MockKubeActions) {
-				k.EXPECT().
-					KubeGet(gomock.Any(), "ControlPlaneMachineSet.machine.openshift.io", machineNamespace, "cluster").
-					Return(cpmsJSON(""), nil)
-			},
-		},
-		{
-			name: "KubeGet returns non-NotFound error - fails closed",
-			mocks: func(k *mock_adminactions.MockKubeActions) {
-				k.EXPECT().
-					KubeGet(gomock.Any(), "ControlPlaneMachineSet.machine.openshift.io", machineNamespace, "cluster").
-					Return(nil, errors.New("connection refused"))
-			},
-			wantErr: "500: InternalServerError: : failed to check ControlPlaneMachineSet state: connection refused",
-		},
-		{
-			name: "CPMS returns invalid JSON - fails closed",
-			mocks: func(k *mock_adminactions.MockKubeActions) {
-				k.EXPECT().
-					KubeGet(gomock.Any(), "ControlPlaneMachineSet.machine.openshift.io", machineNamespace, "cluster").
-					Return([]byte("not-json"), nil)
-			},
-			wantErr: "500: InternalServerError: : failed to parse ControlPlaneMachineSet object: invalid character 'o' in literal null (expecting 'u')",
-		},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
-
-			k := mock_adminactions.NewMockKubeActions(ctrl)
-			tt.mocks(k)
-
-			err := checkCPMSNotActive(ctx, k)
-			utilerror.AssertErrorMessage(t, err, tt.wantErr)
-		})
-	}
 }
 
 func TestIsNodeReady(t *testing.T) {
@@ -825,9 +748,6 @@ func TestAdminResizeControlPlane(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-
-			// Avoid creating real Azure quota clients in handler tests.
-			f.validateResizeQuota = quotaCheckDisabled
 
 			go f.Run(ctx, nil, nil)
 

--- a/pkg/frontend/admin_openshiftcluster_resize_validation_helpers.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_validation_helpers.go
@@ -96,7 +96,7 @@ func unmarshalAzureMachineProviderSpec(machine *machinev1beta1.Machine) (*machin
 	return providerSpec, nil
 }
 
-func getClusterMachines(ctx context.Context, kubeActions adminactions.KubeActions) (map[string]machineValidationData, error) {
+func getControlPlaneMachines(ctx context.Context, kubeActions adminactions.KubeActions) (map[string]machineValidationData, error) {
 	machines := make(map[string]machineValidationData)
 
 	rawMachines, err := kubeActions.KubeList(ctx, machineGroupKind, machineNamespace)

--- a/pkg/frontend/admin_openshiftcluster_resize_validation_helpers_test.go
+++ b/pkg/frontend/admin_openshiftcluster_resize_validation_helpers_test.go
@@ -447,7 +447,7 @@ func TestGetClusterMachines(t *testing.T) {
 			kubeActions := mock_adminactions.NewMockKubeActions(ctrl)
 			tt.mocks(kubeActions)
 
-			machines, err := getClusterMachines(ctx, kubeActions)
+			machines, err := getControlPlaneMachines(ctx, kubeActions)
 
 			if tt.wantErr != "" {
 				if err == nil {

--- a/pkg/frontend/admin_openshiftcluster_validatefullresize.go
+++ b/pkg/frontend/admin_openshiftcluster_validatefullresize.go
@@ -39,7 +39,7 @@ func validateLiveControlPlaneInventory(
 	azureActions adminactions.AzureActions,
 	clusterResourceGroupID string,
 ) error {
-	machines, err := getClusterMachines(ctx, kubeActions)
+	machines, err := getControlPlaneMachines(ctx, kubeActions)
 	if err != nil {
 		return err
 	}

--- a/pkg/frontend/admin_openshiftcluster_vmresize_pre_validation.go
+++ b/pkg/frontend/admin_openshiftcluster_vmresize_pre_validation.go
@@ -6,34 +6,33 @@ package frontend
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"maps"
 	"net/http"
 	"path/filepath"
-	"runtime/debug"
 	"slices"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/sirupsen/logrus"
 
 	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 
 	configv1 "github.com/openshift/api/config/v1"
+	machinev1 "github.com/openshift/api/machine/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 
 	"github.com/Azure/ARO-RP/pkg/api"
 	"github.com/Azure/ARO-RP/pkg/api/validate"
 	"github.com/Azure/ARO-RP/pkg/database/cosmosdb"
-	"github.com/Azure/ARO-RP/pkg/env"
 	"github.com/Azure/ARO-RP/pkg/frontend/adminactions"
 	"github.com/Azure/ARO-RP/pkg/frontend/middleware"
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
-	"github.com/Azure/ARO-RP/pkg/util/azureclient/mgmt/compute"
 	"github.com/Azure/ARO-RP/pkg/util/clusteroperators"
+	"github.com/Azure/ARO-RP/pkg/util/steps"
 	"github.com/Azure/ARO-RP/pkg/util/stringutils"
 )
 
@@ -50,9 +49,9 @@ func (f *frontend) getPreResizeControlPlaneVMsValidation(w http.ResponseWriter, 
 	resourceID := strings.TrimPrefix(r.URL.Path, "/admin")
 	desiredVMSize := r.URL.Query().Get("vmSize")
 
-	b, err := f._getPreResizeControlPlaneVMsValidation(ctx, resType, resName, resGroupName, resourceID, desiredVMSize, log)
+	err := f._getPreResizeControlPlaneVMsValidation(ctx, resType, resName, resGroupName, resourceID, desiredVMSize, log)
 
-	adminReply(log, w, nil, b, err)
+	adminReply(log, w, nil, nil, err)
 }
 
 // _getPreResizeControlPlaneVMsValidation runs all pre-flight checks before
@@ -62,40 +61,40 @@ func (f *frontend) _getPreResizeControlPlaneVMsValidation(
 	ctx context.Context,
 	resType, resName, resGroupName, resourceID, desiredVMSize string,
 	log *logrus.Entry,
-) ([]byte, error) {
+) error {
 	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
 
 	dbOpenShiftClusters, err := f.dbGroup.OpenShiftClusters()
 	if err != nil {
-		return nil, api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "", err.Error())
+		return api.NewCloudError(http.StatusInternalServerError, api.CloudErrorCodeInternalServerError, "", err.Error())
 	}
 
 	doc, err := dbOpenShiftClusters.Get(ctx, resourceID)
 	switch {
 	case cosmosdb.IsErrorStatusCode(err, http.StatusNotFound):
-		return nil, api.NewCloudError(http.StatusNotFound, api.CloudErrorCodeResourceNotFound, "",
+		return api.NewCloudError(http.StatusNotFound, api.CloudErrorCodeResourceNotFound, "",
 			fmt.Sprintf(
 				"The Resource '%s/%s' under resource group '%s' was not found.",
 				resType, resName, resGroupName,
 			))
 	case err != nil:
-		return nil, err
+		return err
 	}
 
 	subscriptionDoc, err := f.getSubscriptionDocument(ctx, doc.Key)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	k, err := f.kubeActionsFactory(log, f.env, doc.OpenShiftCluster)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	a, err := f.azureActionsFactory(log, f.env, doc.OpenShiftCluster, subscriptionDoc)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	return f.preResizeControlPlaneVMsValidation(ctx, doc, subscriptionDoc, k, a, desiredVMSize, log)
@@ -109,147 +108,52 @@ func (f *frontend) preResizeControlPlaneVMsValidation(
 	a adminactions.AzureActions,
 	desiredVMSize string,
 	log *logrus.Entry,
-) ([]byte, error) {
-	// Run checks in parallel, collecting all errors so the caller sees every
-	// failure at once. For API server checks, run ClusterOperator status first
-	// and only run per-pod validation if the operator-level gate is healthy.
-	var (
-		mu      sync.Mutex
-		details []api.CloudErrorBody
-	)
-	collect := func(err error) {
-		if err == nil {
-			return
-		}
-		mu.Lock()
-		defer mu.Unlock()
-		var ce *api.CloudError
-		if errors.As(err, &ce) && ce.CloudErrorBody != nil {
-			details = append(details, *ce.CloudErrorBody)
-		} else {
-			details = append(details, api.CloudErrorBody{
-				Code:    api.CloudErrorCodeInternalServerError,
-				Message: err.Error(),
-			})
-		}
-	}
-
-	if err := k.CheckAPIServerReadyz(ctx); err != nil {
-		return nil, api.NewCloudError(
-			http.StatusInternalServerError,
-			api.CloudErrorCodeInternalServerError,
-			"kube-apiserver",
-			fmt.Sprintf("API server is reporting a non-ready status: %v", err),
-		)
-	}
-
-	// safeGo wraps a validation function with panic recovery. The
-	// dynamicRESTMapper in controller-runtime v0.11.2 (pinned via replace
-	// directive in go.mod) can nil-pointer panic when the API server is
-	// unreachable (lazy init leaves staticMapper nil). Since these run in
-	// child goroutines, the HTTP Panic middleware cannot catch them — an
-	// unrecovered panic here would crash the entire RP process.
-	safeGo := func(checkName string, fn func() error) func() {
-		return func() {
-			defer func() {
-				if r := recover(); r != nil {
-					log.Errorf("recovered panic during %s pre-flight validation: %#v\n%s", checkName, r, debug.Stack())
-					collect(api.NewCloudError(
-						http.StatusInternalServerError,
-						api.CloudErrorCodeInternalServerError,
-						checkName,
-						fmt.Sprintf("Recovered panic during %s pre-flight validation. Check RP logs for details.", checkName),
-					))
-				}
-			}()
-			collect(fn())
-		}
-	}
-
-	var wg sync.WaitGroup
-
-	wg.Go(safeGo("vmSKUQuota", func() error { return f.validateVMSKU(ctx, doc, subscriptionDoc, desiredVMSize, k, a) }))
-	wg.Go(safeGo("kube-apiserver", func() error {
-		if err := validateAPIServerHealth(ctx, k); err != nil {
-			return err
-		}
-		return validateAPIServerPods(ctx, k)
-	}))
-	wg.Go(safeGo("etcd", func() error { return validateEtcdHealth(ctx, k) }))
-	wg.Go(safeGo("servicePrincipal", func() error { return validateClusterSP(ctx, k) }))
-	wg.Go(safeGo("controlPlaneMachineSet", func() error { return checkCPMSNotActive(ctx, k) }))
-
-	wg.Wait()
-
-	if len(details) > 0 {
-		return nil, preResizeControlPlaneValidationError(details)
-	}
-
-	if err := validateResizeControlPlaneInventory(ctx, log, k, a, doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID); err != nil {
-		var ce *api.CloudError
-		if errors.As(err, &ce) && ce.StatusCode == http.StatusBadRequest && ce.CloudErrorBody != nil {
-			return nil, preResizeControlPlaneValidationError([]api.CloudErrorBody{*ce.CloudErrorBody})
-		}
-		return nil, err
-	}
-
-	return json.Marshal("All pre-flight checks passed")
-}
-
-func preResizeControlPlaneValidationError(details []api.CloudErrorBody) *api.CloudError {
-	return &api.CloudError{
-		StatusCode: http.StatusBadRequest,
-		CloudErrorBody: &api.CloudErrorBody{
-			Code:    api.CloudErrorCodeInvalidParameter,
-			Message: "Pre-flight validation failed.",
-			Details: details,
-		},
-	}
-}
-
-// classifyInventoryError passes through infrastructure errors (already
-// wrapped as *api.CloudError with 500 by the helper that hit Kube/Azure)
-// and wraps pure-validation errors as 400 InvalidParameter.
-func classifyInventoryError(err error) error {
-	var ce *api.CloudError
-	if errors.As(err, &ce) {
-		return ce
-	}
-	err = convertErrorLineEndings(err)
-	return api.NewCloudError(
-		http.StatusBadRequest,
-		api.CloudErrorCodeInvalidParameter,
-		"controlPlaneInventory",
-		err.Error(),
-	)
-}
-
-func validateResizeControlPlaneInventory(
-	ctx context.Context,
-	log *logrus.Entry,
-	k adminactions.KubeActions,
-	a adminactions.AzureActions,
-	clusterResourceGroupID string,
 ) error {
-	if err := validateLiveControlPlaneInventory(log, ctx, k, a, clusterResourceGroupID); err != nil {
-		return classifyInventoryError(err)
+	preValidator := &preResizeValidator{
+		doc:             doc,
+		log:             log,
+		subscriptionDoc: subscriptionDoc,
+		k:               k,
+		a:               a,
+		desiredVMSize:   desiredVMSize,
 	}
-	return nil
+	validationSteps := []steps.Step{
+		steps.Action(preValidator.validateAPIServerReadyz),
+		steps.Action(preValidator.validateVMSKU),
+		steps.Concurrent("preresize", []steps.Step{
+			steps.Action(preValidator.validateAPIServerHealth),
+			steps.Action(preValidator.validateAPIServerPods),
+			steps.Action(preValidator.validateEtcdHealth),
+			steps.Action(preValidator.validateClusterSP),
+			steps.Action(preValidator.validateCPMSNotActive),
+		}),
+		steps.Action(preValidator.validateResizeControlPlaneInventory),
+	}
+
+	_, err := steps.RunWithWrappedError(ctx, log, validationSteps)
+
+	return err
 }
 
-// defaultValidateResizeQuota creates an FP-authorized compute usage client and
-// delegates to checkResizeComputeQuota. Injected via f.validateResizeQuota so
-// tests can swap it with quotaCheckDisabled.
-func defaultValidateResizeQuota(ctx context.Context, environment env.Interface, subscriptionDoc *api.SubscriptionDocument, location string, currentVMSizes []string, desiredVMSize string) error {
-	tenantID := subscriptionDoc.Subscription.Properties.TenantID
+// preResizeValidator wraps the validation functions and stores the clients and
+// request metadata. This makes it possible to let the individual functions
+// only take context.Context as their single argument. This is needed so we can
+// use them as argument to steps.Action(...).
+type preResizeValidator struct {
+	doc             *api.OpenShiftClusterDocument
+	log             *logrus.Entry
+	subscriptionDoc *api.SubscriptionDocument
+	k               adminactions.KubeActions
+	a               adminactions.AzureActions
+	desiredVMSize   string
+}
 
-	fpAuthorizer, err := environment.FPAuthorizer(tenantID, nil, environment.Environment().ResourceManagerScope)
-	if err != nil {
-		return err
-	}
+func (v *preResizeValidator) validateAPIServerReadyz(ctx context.Context) error {
+	return v.k.CheckAPIServerReadyz(ctx)
+}
 
-	spComputeUsage := compute.NewUsageClient(environment.Environment(), subscriptionDoc.ID, fpAuthorizer)
-	return checkResizeComputeQuota(ctx, spComputeUsage, location, currentVMSizes, desiredVMSize)
+func (v *preResizeValidator) validateResizeControlPlaneInventory(ctx context.Context) error {
+	return validateLiveControlPlaneInventory(v.log, ctx, v.k, v.a, v.doc.OpenShiftCluster.Properties.ClusterProfile.ResourceGroupID)
 }
 
 // checkResizeComputeQuota verifies that the subscription has enough remaining
@@ -268,11 +172,10 @@ func defaultValidateResizeQuota(ctx context.Context, environment env.Interface, 
 // This checks subscription-level quota only, not Azure regional datacenter
 // capacity — without a capacity reservation, AllocationFailed errors can only
 // be detected at ARM PUT time.
-func checkResizeComputeQuota(ctx context.Context, spComputeUsage compute.UsageClient, location string, currentVMSizes []string, desiredVMSize string) error {
+func checkResizeComputeQuota(ctx context.Context, a adminactions.AzureActions, location string, currentVMSizes []string, desiredVMSize string) error {
 	newSizeStruct, ok := validate.VMSizeFromName(api.VMSize(desiredVMSize))
 	if !ok {
-		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, "vmSize",
-			fmt.Sprintf("The provided VM SKU '%s' is not supported.", desiredVMSize))
+		return fmt.Errorf("the provided VM SKU '%s' is not supported", desiredVMSize)
 	}
 
 	requiredByQuota := map[string]int{}
@@ -310,7 +213,7 @@ func checkResizeComputeQuota(ctx context.Context, spComputeUsage compute.UsageCl
 		return nil
 	}
 
-	usages, err := spComputeUsage.List(ctx, location)
+	usages, err := a.ListComputeUsage(ctx, location)
 	if err != nil {
 		return err
 	}
@@ -338,67 +241,66 @@ func checkResizeComputeQuota(ctx context.Context, spComputeUsage compute.UsageCl
 	return nil
 }
 
-// quotaCheckDisabled is a no-op replacement for f.validateResizeQuota in tests.
-func quotaCheckDisabled(_ context.Context, _ env.Interface, _ *api.SubscriptionDocument, _ string, _ []string, _ string) error {
+// validateCPMSNotActive verifies that the ControlPlaneMachineSet is not Active.
+// If it is active, direct VM manipulation would conflict with the CPMS operator.
+// Only NotFound / CRD-not-installed errors are treated as "CPMS absent";
+// all other errors fail the operation closed so we don't bypass the safety check.
+func (v *preResizeValidator) validateCPMSNotActive(ctx context.Context) error {
+	rawCPMS, err := v.k.KubeGet(ctx, "ControlPlaneMachineSet.machine.openshift.io", machineNamespace, "cluster")
+	if err != nil {
+		if kerrors.IsNotFound(err) || meta.IsNoMatchError(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to check ControlPlaneMachineSet state: %w", err)
+	}
+
+	var cpms machinev1.ControlPlaneMachineSet
+	if err := json.Unmarshal(rawCPMS, &cpms); err != nil {
+		return fmt.Errorf("failed to parse ControlPlaneMachineSet object: %w", err)
+	}
+
+	if cpms.Spec.State == machinev1.ControlPlaneMachineSetStateActive {
+		return fmt.Errorf("the ControlPlaneMachineSet is currently Active: Deactivate CPMS before running this operation")
+	}
+
 	return nil
 }
 
 // validateAPIServerHealth verifies that the kube-apiserver ClusterOperator is healthy
 // (Available=True, Progressing=False, Degraded=False).
 // Note: API server reachability is checked earlier via CheckAPIServerReadyz
-func validateAPIServerHealth(ctx context.Context, k adminactions.KubeActions) error {
-	rawCO, err := k.KubeGet(ctx, "ClusterOperator.config.openshift.io", "", "kube-apiserver")
+func (v *preResizeValidator) validateAPIServerHealth(ctx context.Context) error {
+	rawCO, err := v.k.KubeGet(ctx, "ClusterOperator.config.openshift.io", "", "kube-apiserver")
 	if err != nil {
-		return api.NewCloudError(
-			http.StatusInternalServerError,
-			api.CloudErrorCodeInternalServerError, "kube-apiserver",
-			fmt.Sprintf("Failed to retrieve kube-apiserver ClusterOperator: %v", err),
-		)
+		return fmt.Errorf("failed to retrieve kube-apiserver ClusterOperator: %w", err)
 	}
 
 	var co configv1.ClusterOperator
 	if err := json.Unmarshal(rawCO, &co); err != nil {
-		return api.NewCloudError(
-			http.StatusInternalServerError,
-			api.CloudErrorCodeInternalServerError, "kube-apiserver",
-			fmt.Sprintf("Failed to parse kube-apiserver ClusterOperator: %v", err),
-		)
+		return fmt.Errorf("failed to parse kube-apiserver ClusterOperator: %w", err)
 	}
 
 	if !clusteroperators.IsOperatorAvailable(&co) {
-		return api.NewCloudError(
-			http.StatusConflict,
-			api.CloudErrorCodeRequestNotAllowed, "kube-apiserver",
-			fmt.Sprintf("kube-apiserver is not healthy: %s. Resize is not safe while the API server is degraded.",
-				clusteroperators.OperatorStatusText(&co)),
-		)
+		return fmt.Errorf("kube-apiserver is not healthy: %s. Resize is not safe while the API server is degraded", clusteroperators.OperatorStatusText(&co))
 	}
 
 	return nil
 }
 
-func validateAPIServerPods(ctx context.Context, k adminactions.KubeActions) error {
+func (v *preResizeValidator) validateAPIServerPods(ctx context.Context) error {
 	const (
 		kubeAPIServerNamespace     = "openshift-kube-apiserver"
 		kubeAPIServerLabelSelector = "app=openshift-kube-apiserver"
 	)
 
-	rawPods, err := k.KubeList(ctx, "Pod", kubeAPIServerNamespace, kubeAPIServerLabelSelector)
+	rawPods, err := v.k.KubeList(ctx, "Pod", kubeAPIServerNamespace, kubeAPIServerLabelSelector)
 	if err != nil {
-		return api.NewCloudError(
-			http.StatusInternalServerError,
-			api.CloudErrorCodeInternalServerError, "kube-apiserver-pods",
-			fmt.Sprintf("Failed to list pods in %s namespace: %v", kubeAPIServerNamespace, err),
-		)
+		return fmt.Errorf("failed to list pods in %s namespace: %w", kubeAPIServerNamespace, err)
 	}
 
 	var podList corev1.PodList
 	if err := json.Unmarshal(rawPods, &podList); err != nil {
-		return api.NewCloudError(
-			http.StatusInternalServerError,
-			api.CloudErrorCodeInternalServerError, "kube-apiserver-pods",
-			fmt.Sprintf("Failed to parse pod list: %v", err),
-		)
+		return fmt.Errorf("failed to parse pod list: %w", err)
 	}
 
 	var unhealthyPods []string
@@ -411,21 +313,11 @@ func validateAPIServerPods(ctx context.Context, k adminactions.KubeActions) erro
 	apiServerPodCount := len(podList.Items)
 
 	if apiServerPodCount != api.ControlPlaneNodeCount {
-		return api.NewCloudError(
-			http.StatusConflict,
-			api.CloudErrorCodeRequestNotAllowed, "kube-apiserver-pods",
-			fmt.Sprintf("Expected %d kube-apiserver pods, found %d. Resize is not safe without full API server redundancy.",
-				api.ControlPlaneNodeCount, apiServerPodCount),
-		)
+		return fmt.Errorf("expected %d kube-apiserver pods, found %d. Resize is not safe without full API server redundancy", api.ControlPlaneNodeCount, apiServerPodCount)
 	}
 
 	if len(unhealthyPods) > 0 {
-		return api.NewCloudError(
-			http.StatusConflict,
-			api.CloudErrorCodeRequestNotAllowed, "kube-apiserver-pods",
-			fmt.Sprintf("Unhealthy kube-apiserver pods: %v. Resize is not safe without full API server redundancy.",
-				unhealthyPods),
-		)
+		return fmt.Errorf("unhealthy kube-apiserver pods: %v. Resize is not safe without full API server redundancy", unhealthyPods)
 	}
 
 	return nil
@@ -450,32 +342,25 @@ func validatePodHealth(pod *corev1.Pod) error {
 
 // validateEtcdHealth verifies that the etcd ClusterOperator is healthy.
 // Resizing takes a master offline, so all etcd members must be healthy.
+func (v *preResizeValidator) validateEtcdHealth(ctx context.Context) error {
+	return validateEtcdHealth(ctx, v.k)
+}
+
+// validateEtcdHealth verifies that the etcd ClusterOperator is healthy.
+// Resizing takes a master offline, so all etcd members must be healthy.
 func validateEtcdHealth(ctx context.Context, k adminactions.KubeActions) error {
 	rawCO, err := k.KubeGet(ctx, "ClusterOperator.config.openshift.io", "", "etcd")
 	if err != nil {
-		return api.NewCloudError(
-			http.StatusInternalServerError,
-			api.CloudErrorCodeInternalServerError, "etcd",
-			fmt.Sprintf("Failed to retrieve etcd ClusterOperator: %v", err),
-		)
+		return fmt.Errorf("failed to retrieve etcd ClusterOperator: %w", err)
 	}
 
 	var co configv1.ClusterOperator
 	if err := json.Unmarshal(rawCO, &co); err != nil {
-		return api.NewCloudError(
-			http.StatusInternalServerError,
-			api.CloudErrorCodeInternalServerError, "etcd",
-			fmt.Sprintf("Failed to parse etcd ClusterOperator: %v", err),
-		)
+		return fmt.Errorf("failed to parse etcd ClusterOperator: %w", err)
 	}
 
 	if !clusteroperators.IsOperatorAvailable(&co) {
-		return api.NewCloudError(
-			http.StatusConflict,
-			api.CloudErrorCodeRequestNotAllowed, "etcd",
-			fmt.Sprintf("etcd is not healthy: %s. Resize is not safe while etcd quorum is at risk.",
-				clusteroperators.OperatorStatusText(&co)),
-		)
+		return fmt.Errorf("etcd is not healthy: %s - Resize is not safe while etcd quorum is at risk", clusteroperators.OperatorStatusText(&co))
 	}
 
 	return nil
@@ -483,23 +368,15 @@ func validateEtcdHealth(ctx context.Context, k adminactions.KubeActions) error {
 
 // validateClusterSP checks the ServicePrincipalValid condition on the ARO
 // Cluster CRD. The SP is required for the ARM VM PUT during resize.
-func validateClusterSP(ctx context.Context, k adminactions.KubeActions) error {
-	rawCluster, err := k.KubeGet(ctx, "Cluster.aro.openshift.io", "", arov1alpha1.SingletonClusterName)
+func (v *preResizeValidator) validateClusterSP(ctx context.Context) error {
+	rawCluster, err := v.k.KubeGet(ctx, "Cluster.aro.openshift.io", "", arov1alpha1.SingletonClusterName)
 	if err != nil {
-		return api.NewCloudError(
-			http.StatusInternalServerError,
-			api.CloudErrorCodeInternalServerError, "servicePrincipal",
-			fmt.Sprintf("Failed to retrieve ARO Cluster resource: %v", err),
-		)
+		return fmt.Errorf("failed to retrieve ARO Cluster resource: %w", err)
 	}
 
 	var cluster arov1alpha1.Cluster
 	if err := json.Unmarshal(rawCluster, &cluster); err != nil {
-		return api.NewCloudError(
-			http.StatusInternalServerError,
-			api.CloudErrorCodeInternalServerError, "servicePrincipal",
-			fmt.Sprintf("Failed to parse ARO Cluster resource: %v", err),
-		)
+		return fmt.Errorf("failed to parse ARO Cluster resource: %w", err)
 	}
 
 	for _, cond := range cluster.Status.Conditions {
@@ -507,45 +384,30 @@ func validateClusterSP(ctx context.Context, k adminactions.KubeActions) error {
 			if cond.Status == operatorv1.ConditionTrue {
 				return nil
 			}
-			return api.NewCloudError(
-				http.StatusConflict,
-				api.CloudErrorCodeInvalidServicePrincipalCredentials, "servicePrincipal",
-				fmt.Sprintf("Cluster Service Principal is invalid: %s", cond.Message),
-			)
+			return fmt.Errorf("cluster Service Principal is invalid: %s", cond.Message)
 		}
 	}
 
-	return api.NewCloudError(
-		http.StatusConflict,
-		api.CloudErrorCodeInvalidServicePrincipalCredentials, "servicePrincipal",
-		"ServicePrincipalValid condition not found on the ARO Cluster resource. The ARO operator may not have reconciled yet.",
-	)
+	return fmt.Errorf("the ServicePrincipalValid condition not found on the ARO Cluster resource: The ARO operator may not have reconciled yet")
 }
 
-func (f *frontend) validateVMSKU(
-	ctx context.Context,
-	doc *api.OpenShiftClusterDocument,
-	subscriptionDoc *api.SubscriptionDocument,
-	desiredVMSize string,
-	k adminactions.KubeActions,
-	a adminactions.AzureActions,
-) error {
-	if desiredVMSize == "" {
+func (v *preResizeValidator) validateVMSKU(ctx context.Context) error {
+	if v.desiredVMSize == "" {
 		return api.NewCloudError(http.StatusBadRequest, api.CloudErrorCodeInvalidParameter, "vmSize", "The provided vmSize is empty.")
 	}
 
-	err := validateAdminMasterVMSize(desiredVMSize)
+	err := validateAdminMasterVMSize(v.desiredVMSize)
 	if err != nil {
 		return err
 	}
 
-	filteredSkus, err := a.VMGetSKUs(ctx, []string{desiredVMSize})
+	filteredSkus, err := v.a.VMGetSKUs(ctx, []string{v.desiredVMSize})
 	if err != nil {
 		return err
 	}
 
-	location := doc.OpenShiftCluster.Location
-	sku, err := checkSKUAvailability(filteredSkus, location, "vmSize", desiredVMSize)
+	location := v.doc.OpenShiftCluster.Location
+	sku, err := checkSKUAvailability(filteredSkus, location, "vmSize", v.desiredVMSize)
 	if err != nil {
 		return err
 	}
@@ -555,12 +417,12 @@ func (f *frontend) validateVMSKU(
 		return err
 	}
 
-	currentVMSizes, err := currentControlPlaneVMSizes(ctx, doc, k, a)
+	currentVMSizes, err := currentControlPlaneVMSizes(ctx, v.doc, v.k, v.a)
 	if err != nil {
 		return err
 	}
 
-	err = f.validateResizeQuota(ctx, f.env, subscriptionDoc, location, currentVMSizes, desiredVMSize)
+	err = checkResizeComputeQuota(ctx, v.a, location, currentVMSizes, v.desiredVMSize)
 	if err != nil {
 		return err
 	}

--- a/pkg/frontend/admin_openshiftcluster_vmresize_pre_validation_test.go
+++ b/pkg/frontend/admin_openshiftcluster_vmresize_pre_validation_test.go
@@ -34,11 +34,9 @@ import (
 	"github.com/Azure/ARO-RP/pkg/metrics/noop"
 	arov1alpha1 "github.com/Azure/ARO-RP/pkg/operator/apis/aro.openshift.io/v1alpha1"
 	mock_adminactions "github.com/Azure/ARO-RP/pkg/util/mocks/adminactions"
-	mock_compute "github.com/Azure/ARO-RP/pkg/util/mocks/azureclient/mgmt/compute"
 	"github.com/Azure/ARO-RP/pkg/util/pointerutils"
 	testdatabase "github.com/Azure/ARO-RP/test/database"
 	utilerror "github.com/Azure/ARO-RP/test/util/error"
-	testlog "github.com/Azure/ARO-RP/test/util/log"
 )
 
 func fakeClusterOperatorJSON(name string, conditions []configv1.ClusterOperatorStatusCondition) []byte {
@@ -225,23 +223,6 @@ func controlPlaneNodeListJSON(nodes ...corev1.Node) []byte {
 	return b
 }
 
-func inventoryValidationVM(vmSize, zone string) mgmtcompute.VirtualMachine {
-	return virtualMachineValidationWithSizeAndZone(vmSize, zone)
-}
-
-func zonedMasterMachine(name, vmSize, phase, zone string) machinev1beta1.Machine {
-	machine := masterMachine(name, vmSize, phase)
-	providerSpec := &machinev1beta1.AzureMachineProviderSpec{
-		Zone:   zone,
-		VMSize: vmSize,
-	}
-	rawProviderSpec, _ := json.Marshal(providerSpec)
-
-	machine.Labels[machineLabelZone] = zone
-	machine.Spec.ProviderSpec.Value = &kruntime.RawExtension{Raw: rawProviderSpec}
-	return machine
-}
-
 func allKubeChecksHealthyMock(k *mock_adminactions.MockKubeActions) {
 	running := "Running"
 	allKubeChecksHealthyMockWithMachineList(k, masterMachineListJSON(
@@ -307,119 +288,6 @@ func healthyControlPlaneInventoryMock(k *mock_adminactions.MockKubeActions, a *m
 			Return(virtualMachineValidationWithSizeAndZone(vmSize, "2"), nil)
 		a.EXPECT().GetVirtualMachine(gomock.Any(), resourceGroupName, "master-2", mgmtcompute.InstanceView).
 			Return(virtualMachineValidationWithSizeAndZone(vmSize, "3"), nil)
-	}
-}
-
-func TestValidateResizeControlPlaneInventory(t *testing.T) {
-	ctx := context.Background()
-	_, log := testlog.New()
-
-	t.Run("propagates Azure SDK error from GetVirtualMachine as 500", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-
-		k := mock_adminactions.NewMockKubeActions(ctrl)
-		a := mock_adminactions.NewMockAzureActions(ctrl)
-
-		k.EXPECT().
-			KubeList(gomock.Any(), machineGroupKind, machineNamespace).
-			Return(masterMachineListJSON(
-				masterMachineWithZone("master-0", "Standard_D8s_v3", "1"),
-				masterMachineWithZone("master-1", "Standard_D8s_v3", "2"),
-				masterMachineWithZone("master-2", "Standard_D8s_v3", "3"),
-			), nil)
-		a.EXPECT().GetVirtualMachine(gomock.Any(), "test-cluster", gomock.Any(), mgmtcompute.InstanceView).
-			Return(mgmtcompute.VirtualMachine{}, fmt.Errorf("azure auth timeout")).
-			AnyTimes()
-
-		err := validateResizeControlPlaneInventory(ctx, log, k, a, "/subscriptions/000/resourceGroups/test-cluster")
-		var ce *api.CloudError
-		if !errors.As(err, &ce) {
-			t.Fatalf("expected *api.CloudError, got %T: %v", err, err)
-		}
-		if ce.StatusCode != http.StatusInternalServerError {
-			t.Errorf("expected status 500, got %d", ce.StatusCode)
-		}
-		if !strings.HasPrefix(ce.Target, "controlPlaneVM/master-") {
-			t.Errorf("expected target to include controlPlaneVM/master-*, got %q", ce.Target)
-		}
-	})
-
-	t.Run("propagates Kube API error from getClusterMachines as 500", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-
-		k := mock_adminactions.NewMockKubeActions(ctrl)
-		a := mock_adminactions.NewMockAzureActions(ctrl)
-
-		k.EXPECT().
-			KubeList(gomock.Any(), machineGroupKind, machineNamespace).
-			Return(nil, fmt.Errorf("connection refused"))
-
-		err := validateResizeControlPlaneInventory(ctx, log, k, a, "/subscriptions/000/resourceGroups/test-cluster")
-		var ce *api.CloudError
-		if !errors.As(err, &ce) {
-			t.Fatalf("expected *api.CloudError, got %T: %v", err, err)
-		}
-		if ce.StatusCode != http.StatusInternalServerError {
-			t.Errorf("expected status 500, got %d", ce.StatusCode)
-		}
-	})
-
-	t.Run("rejects inconsistent control plane node labels", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-
-		k := mock_adminactions.NewMockKubeActions(ctrl)
-		a := mock_adminactions.NewMockAzureActions(ctrl)
-
-		k.EXPECT().
-			KubeList(gomock.Any(), machineGroupKind, machineNamespace).
-			Return(masterMachineListJSON(
-				masterMachineWithZone("master-0", "Standard_D8s_v3", "1"),
-				masterMachineWithZone("master-1", "Standard_D8s_v3", "2"),
-				masterMachineWithZone("master-2", "Standard_D8s_v3", "3"),
-			), nil)
-		k.EXPECT().
-			KubeList(gomock.Any(), "Node", "").
-			Return(controlPlaneNodeListJSON(
-				controlPlaneNode("master-0", "Standard_D8s_v3", "Standard_D8s_v3", true, false),
-				controlPlaneNode("master-1", "Standard_D16s_v5", "Standard_D16s_v5", true, false),
-				controlPlaneNode("master-2", "Standard_D8s_v3", "Standard_D8s_v3", true, false),
-			), nil)
-		a.EXPECT().GetVirtualMachine(gomock.Any(), "test-cluster", "master-0", mgmtcompute.InstanceView).
-			Return(inventoryValidationVM("Standard_D8s_v3", "1"), nil)
-		a.EXPECT().GetVirtualMachine(gomock.Any(), "test-cluster", "master-1", mgmtcompute.InstanceView).
-			Return(inventoryValidationVM("Standard_D8s_v3", "2"), nil)
-		a.EXPECT().GetVirtualMachine(gomock.Any(), "test-cluster", "master-2", mgmtcompute.InstanceView).
-			Return(inventoryValidationVM("Standard_D8s_v3", "3"), nil)
-
-		err := validateResizeControlPlaneInventory(ctx, log, k, a, "/subscriptions/000/resourceGroups/test-cluster")
-		assertErrorContainsAll(t, err,
-			"control plane machine and node inventory is inconsistent",
-			"machine master-1 has size Standard_D8s_v3 in its spec, however node has instance-type Standard_D16s_v5",
-		)
-	})
-}
-
-func TestClassifyInventoryErrorPreservesCloudErrorTarget(t *testing.T) {
-	t.Parallel()
-
-	original := api.NewCloudError(
-		http.StatusInternalServerError,
-		api.CloudErrorCodeInternalServerError,
-		"controlPlaneVM/master-0",
-		"failed to get Azure VM master-0: VM not found",
-	)
-
-	classified := classifyInventoryError(original)
-	var ce *api.CloudError
-	if !errors.As(classified, &ce) {
-		t.Fatalf("expected *api.CloudError, got %T: %v", classified, classified)
-	}
-
-	if ce.Target != "controlPlaneVM/master-0" {
-		t.Fatalf("expected target controlPlaneVM/master-0, got %q", ce.Target)
 	}
 }
 
@@ -513,7 +381,6 @@ func TestPreResizeControlPlaneVMsValidation(t *testing.T) {
 					), nil)
 			},
 			wantStatusCode: http.StatusOK,
-			wantResponse:   []byte(`"All pre-flight checks passed"` + "\n"),
 		},
 		{
 			name:       "missing vmSize parameter",
@@ -547,8 +414,8 @@ func TestPreResizeControlPlaneVMsValidation(t *testing.T) {
 			},
 			mocks:          func(tt *test, a *mock_adminactions.MockAzureActions) {},
 			kubeMocks:      allKubeChecksHealthyMock,
-			wantStatusCode: http.StatusBadRequest,
-			wantError:      `400: InvalidParameter: : Pre-flight validation failed. Details: InvalidParameter: vmSize: The provided vmSize is empty.`,
+			wantStatusCode: http.StatusInternalServerError,
+			wantError:      `500: InternalServerError: : step [Action pkg/frontend.(*preResizeValidator).validateVMSKU] encountered error: 400: InvalidParameter: vmSize: The provided vmSize is empty.`,
 		},
 		{
 			name:       "unsupported master VM size",
@@ -582,8 +449,8 @@ func TestPreResizeControlPlaneVMsValidation(t *testing.T) {
 			},
 			mocks:          func(tt *test, a *mock_adminactions.MockAzureActions) {},
 			kubeMocks:      allKubeChecksHealthyMock,
-			wantStatusCode: http.StatusBadRequest,
-			wantError:      `400: InvalidParameter: : Pre-flight validation failed. Details: InvalidParameter: : The provided vmSize 'Standard_D2s_v3' is unsupported for master.`,
+			wantStatusCode: http.StatusInternalServerError,
+			wantError:      `500: InternalServerError: : step [Action pkg/frontend.(*preResizeValidator).validateVMSKU] encountered error: 400: InvalidParameter: : The provided vmSize 'Standard_D2s_v3' is unsupported for master.`,
 		},
 		{
 			name:       "cluster not found",
@@ -665,8 +532,8 @@ func TestPreResizeControlPlaneVMsValidation(t *testing.T) {
 					Return(map[string]*armcompute.ResourceSKU{}, nil)
 			},
 			kubeMocks:      allKubeChecksHealthyMock,
-			wantStatusCode: http.StatusBadRequest,
-			wantError:      `400: InvalidParameter: : Pre-flight validation failed. Details: InvalidParameter: vmSize: The selected SKU 'Standard_D8s_v3' is unavailable in region 'eastus'`,
+			wantStatusCode: http.StatusInternalServerError,
+			wantError:      `500: InternalServerError: : step [Action pkg/frontend.(*preResizeValidator).validateVMSKU] encountered error: 400: InvalidParameter: vmSize: The selected SKU 'Standard_D8s_v3' is unavailable in region 'eastus'`,
 		},
 		{
 			name:       "SKU restricted in subscription",
@@ -724,8 +591,8 @@ func TestPreResizeControlPlaneVMsValidation(t *testing.T) {
 					}, nil)
 			},
 			kubeMocks:      allKubeChecksHealthyMock,
-			wantStatusCode: http.StatusBadRequest,
-			wantError:      `400: InvalidParameter: : Pre-flight validation failed. Details: InvalidParameter: vmSize: The selected SKU 'Standard_D8s_v3' is restricted in region 'eastus' for selected subscription`,
+			wantStatusCode: http.StatusInternalServerError,
+			wantError:      `500: InternalServerError: : step [Action pkg/frontend.(*preResizeValidator).validateVMSKU] encountered error: 400: InvalidParameter: vmSize: The selected SKU 'Standard_D8s_v3' is restricted in region 'eastus' for selected subscription`,
 		},
 		{
 			name:       "GetVirtualMachine returns error",
@@ -779,8 +646,8 @@ func TestPreResizeControlPlaneVMsValidation(t *testing.T) {
 					Return(mgmtcompute.VirtualMachine{}, fmt.Errorf("authorization denied"))
 			},
 			kubeMocks:      allKubeChecksHealthyMock,
-			wantStatusCode: http.StatusBadRequest,
-			wantError:      `400: InvalidParameter: : Pre-flight validation failed. Details: InternalServerError: controlPlaneVM/master-0: Failed to retrieve current control plane VM "master-0" from Azure: authorization denied`,
+			wantStatusCode: http.StatusInternalServerError,
+			wantError:      `500: InternalServerError: : step [Action pkg/frontend.(*preResizeValidator).validateVMSKU] encountered error: 500: InternalServerError: controlPlaneVM/master-0: Failed to retrieve current control plane VM "master-0" from Azure: authorization denied`,
 		},
 		{
 			name:       "control plane VM missing HardwareProfile",
@@ -837,8 +704,8 @@ func TestPreResizeControlPlaneVMsValidation(t *testing.T) {
 					Return(mgmtcompute.VirtualMachine{}, nil)
 			},
 			kubeMocks:      allKubeChecksHealthyMock,
-			wantStatusCode: http.StatusBadRequest,
-			wantError:      `400: InvalidParameter: : Pre-flight validation failed. Details: InternalServerError: controlPlaneVM/master-1: Control plane VM "master-1" has no HardwareProfile in Azure. Resize cannot proceed until all control plane VM details are available.`,
+			wantStatusCode: http.StatusInternalServerError,
+			wantError:      `500: InternalServerError: : step [Action pkg/frontend.(*preResizeValidator).validateVMSKU] encountered error: 500: InternalServerError: controlPlaneVM/master-1: Control plane VM "master-1" has no HardwareProfile in Azure. Resize cannot proceed until all control plane VM details are available.`,
 		},
 		{
 			name:       "control plane machine inventory incomplete",
@@ -895,102 +762,8 @@ func TestPreResizeControlPlaneVMsValidation(t *testing.T) {
 					masterMachine("master-1", "Standard_D8s_v3", running),
 				))
 			},
-			wantStatusCode: http.StatusBadRequest,
-			wantError:      `400: InvalidParameter: : Pre-flight validation failed. Details: InternalServerError: controlPlaneMachines: Expected 3 control plane machines but found 2. Resize cannot proceed until all control plane machines are present.`,
-		},
-		{
-			name:       "panic recovery is sanitized",
-			resourceID: testdatabase.GetResourcePath(mockSubID, "resourceName"),
-			vmSize:     "Standard_D8s_v3",
-			fixture: func(f *testdatabase.Fixture) {
-				f.AddOpenShiftClusterDocuments(&api.OpenShiftClusterDocument{
-					Key: strings.ToLower(testdatabase.GetResourcePath(mockSubID, "resourceName")),
-					OpenShiftCluster: &api.OpenShiftCluster{
-						ID:       testdatabase.GetResourcePath(mockSubID, "resourceName"),
-						Location: "eastus",
-						Properties: api.OpenShiftClusterProperties{
-							MasterProfile: api.MasterProfile{
-								VMSize: api.VMSizeStandardD8sV3,
-							},
-							ClusterProfile: api.ClusterProfile{
-								ResourceGroupID: fmt.Sprintf("/subscriptions/%s/resourceGroups/test-cluster", mockSubID),
-							},
-						},
-					},
-				})
-				f.AddSubscriptionDocuments(&api.SubscriptionDocument{
-					ID: mockSubID,
-					Subscription: &api.Subscription{
-						State: api.SubscriptionStateRegistered,
-						Properties: &api.SubscriptionProperties{
-							TenantID: mockTenantID,
-						},
-					},
-				})
-			},
-			mocks: func(tt *test, a *mock_adminactions.MockAzureActions) {
-				a.EXPECT().
-					VMGetSKUs(gomock.Any(), []string{"Standard_D8s_v3"}).
-					Return(map[string]*armcompute.ResourceSKU{
-						"Standard_D8s_v3": {
-							Name:         pointerutils.ToPtr("Standard_D8s_v3"),
-							ResourceType: pointerutils.ToPtr("virtualMachines"),
-							Locations:    pointerutils.ToSlicePtr([]string{"eastus"}),
-							LocationInfo: []*armcompute.ResourceSKULocationInfo{
-								{
-									Location: pointerutils.ToPtr("eastus"),
-								},
-							},
-							Restrictions: pointerutils.ToSlicePtr([]armcompute.ResourceSKURestrictions{}),
-							Capabilities: []*armcompute.ResourceSKUCapabilities{},
-						},
-					}, nil)
-				expectControlPlaneVMGetCalls(a, "test-cluster", map[string]string{
-					"master-0": "Standard_D8s_v3",
-					"master-1": "Standard_D8s_v3",
-					"master-2": "Standard_D8s_v3",
-				})
-			},
-			kubeMocks: func(k *mock_adminactions.MockKubeActions) {
-				running := "Running"
-				k.EXPECT().
-					CheckAPIServerReadyz(gomock.Any()).
-					Return(nil).
-					AnyTimes()
-				k.EXPECT().
-					KubeGet(gomock.Any(), "ClusterOperator.config.openshift.io", "", "kube-apiserver").
-					Return(healthyKubeAPIServerJSON(), nil).
-					AnyTimes()
-				k.EXPECT().
-					KubeList(gomock.Any(), "Pod", "openshift-kube-apiserver", "app=openshift-kube-apiserver").
-					Return(healthyKubeAPIServerPodsJSON(), nil).
-					AnyTimes()
-				k.EXPECT().
-					KubeGet(gomock.Any(), "ClusterOperator.config.openshift.io", "", "etcd").
-					DoAndReturn(func(context.Context, string, string, string) ([]byte, error) {
-						panic("simulated panic")
-					}).
-					AnyTimes()
-				k.EXPECT().
-					KubeGet(gomock.Any(), "Cluster.aro.openshift.io", "", arov1alpha1.SingletonClusterName).
-					Return(validServicePrincipalJSON(), nil).
-					AnyTimes()
-				k.EXPECT().
-					KubeGet(gomock.Any(), "ControlPlaneMachineSet.machine.openshift.io", "openshift-machine-api", "cluster").
-					Return(nil, kerrors.NewNotFound(schema.GroupResource{Group: "machine.openshift.io", Resource: "controlplanemachinesets"}, "cluster")).
-					AnyTimes()
-				k.EXPECT().
-					KubeList(gomock.Any(), machineGroupKind, machineNamespace).
-					Return(masterMachineListJSON(
-						masterMachine("master-0", "Standard_D8s_v3", running),
-						masterMachine("master-1", "Standard_D8s_v3", running),
-						masterMachine("master-2", "Standard_D8s_v3", running),
-					), nil).
-					AnyTimes()
-			},
-			wantStatusCode: http.StatusBadRequest,
-			wantError:      `400: InvalidParameter: : Pre-flight validation failed. Details: InternalServerError: etcd: Recovered panic during etcd pre-flight validation. Check RP logs for details.`,
-			notContains:    []string{"runtime/debug.Stack", "goroutine", "simulated panic"},
+			wantStatusCode: http.StatusInternalServerError,
+			wantError:      `500: InternalServerError: : step [Action pkg/frontend.(*preResizeValidator).validateVMSKU] encountered error: 500: InternalServerError: controlPlaneMachines: Expected 3 control plane machines but found 2. Resize cannot proceed until all control plane machines are present.`,
 		},
 		{
 			name:       "API server unreachable",
@@ -1029,7 +802,7 @@ func TestPreResizeControlPlaneVMsValidation(t *testing.T) {
 					Return(fmt.Errorf("connection refused"))
 			},
 			wantStatusCode: http.StatusInternalServerError,
-			wantError:      `500: InternalServerError: kube-apiserver: API server is reporting a non-ready status: connection refused`,
+			wantError:      `500: InternalServerError: : step [Action pkg/frontend.(*preResizeValidator).validateAPIServerReadyz] encountered error: connection refused`,
 		},
 	} {
 		tt := tt
@@ -1061,9 +834,6 @@ func TestPreResizeControlPlaneVMsValidation(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			// Override quota validation to avoid creating real Azure clients in tests
-			f.validateResizeQuota = quotaCheckDisabled
-
 			go f.Run(ctx, nil, nil)
 
 			url := fmt.Sprintf("https://server/admin%s/preresizevalidation", tt.resourceID)
@@ -1090,67 +860,6 @@ func TestPreResizeControlPlaneVMsValidation(t *testing.T) {
 	}
 }
 
-func TestValidateResizeControlPlaneInventoryNormalizesJoinedErrorLineEndings(t *testing.T) {
-	t.Parallel()
-
-	ctx := context.Background()
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	k := mock_adminactions.NewMockKubeActions(ctrl)
-	a := mock_adminactions.NewMockAzureActions(ctrl)
-	log := logrus.NewEntry(logrus.New())
-
-	k.EXPECT().KubeList(gomock.Any(), machineGroupKind, machineNamespace).
-		Return(masterMachineListJSON(
-			zonedMasterMachine("master-0", "Standard_D8s_v3", "Running", "1"),
-			zonedMasterMachine("master-1", "Standard_D8s_v3", "Running", "2"),
-			zonedMasterMachine("master-2", "Standard_D8s_v3", "Running", "3"),
-		), nil)
-	a.EXPECT().GetVirtualMachine(gomock.Any(), "test-cluster", "master-0", mgmtcompute.InstanceView).
-		Return(inventoryValidationVM("Standard_D8s_v3", "1"), nil)
-	a.EXPECT().GetVirtualMachine(gomock.Any(), "test-cluster", "master-1", mgmtcompute.InstanceView).
-		Return(inventoryValidationVM("Standard_D8s_v3", "2"), nil)
-	a.EXPECT().GetVirtualMachine(gomock.Any(), "test-cluster", "master-2", mgmtcompute.InstanceView).
-		Return(inventoryValidationVM("Standard_D8s_v3", "3"), nil)
-	k.EXPECT().KubeList(gomock.Any(), "Node", "").
-		Return(controlPlaneNodeListJSON(
-			controlPlaneNode("master-0", "Standard_D8s_v3", "Standard_D8s_v3", true, false),
-			controlPlaneNode("master-1", "Standard_D8s_v3", "Standard_D8s_v3", true, true),
-			controlPlaneNode("master-2", "Standard_D8s_v3", "Standard_D4s_v3", true, false),
-		), nil)
-
-	err := validateResizeControlPlaneInventory(
-		ctx,
-		log,
-		k,
-		a,
-		"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-cluster",
-	)
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-
-	var cloudErr *api.CloudError
-	if !errors.As(err, &cloudErr) || cloudErr.CloudErrorBody == nil {
-		t.Fatalf("expected cloud error with body, got %T: %v", err, err)
-	}
-
-	message := cloudErr.Message
-	if strings.Contains(message, "\n") {
-		t.Fatalf("expected normalized inventory error message without newlines, got %q", message)
-	}
-	for _, expected := range []string{
-		"node master-1 is unschedulable",
-		"node master-2 has a mismatch between labels.",
-		" | ",
-	} {
-		if !strings.Contains(message, expected) {
-			t.Fatalf("error message %q does not contain %q", message, expected)
-		}
-	}
-}
-
 func TestCheckResizeComputeQuota(t *testing.T) {
 	t.Parallel()
 
@@ -1160,7 +869,7 @@ func TestCheckResizeComputeQuota(t *testing.T) {
 		name           string
 		currentVMSizes []string
 		vmSize         string
-		mocks          func(*mock_compute.MockUsageClient)
+		mocks          func(*mock_adminactions.MockAzureActions)
 		wantErr        string
 	}
 
@@ -1174,9 +883,9 @@ func TestCheckResizeComputeQuota(t *testing.T) {
 			name:           "same family upsize - enough quota for delta across all masters",
 			currentVMSizes: threeMasters("Standard_D8s_v3"),
 			vmSize:         "Standard_D16s_v3",
-			mocks: func(cuc *mock_compute.MockUsageClient) {
+			mocks: func(cuc *mock_adminactions.MockAzureActions) {
 				cuc.EXPECT().
-					List(ctx, "eastus").
+					ListComputeUsage(ctx, "eastus").
 					Return([]mgmtcompute.Usage{
 						{
 							Name: &mgmtcompute.UsageName{
@@ -1201,9 +910,9 @@ func TestCheckResizeComputeQuota(t *testing.T) {
 			name:           "same family upsize - not enough quota for all masters",
 			currentVMSizes: threeMasters("Standard_D8s_v3"),
 			vmSize:         "Standard_D16s_v3",
-			mocks: func(cuc *mock_compute.MockUsageClient) {
+			mocks: func(cuc *mock_adminactions.MockAzureActions) {
 				cuc.EXPECT().
-					List(ctx, "eastus").
+					ListComputeUsage(ctx, "eastus").
 					Return([]mgmtcompute.Usage{
 						{
 							Name: &mgmtcompute.UsageName{
@@ -1227,13 +936,13 @@ func TestCheckResizeComputeQuota(t *testing.T) {
 			name:           "same family downsize - no quota check needed",
 			currentVMSizes: threeMasters("Standard_D16s_v3"),
 			vmSize:         "Standard_D8s_v3",
-			mocks:          func(cuc *mock_compute.MockUsageClient) {},
+			mocks:          func(cuc *mock_adminactions.MockAzureActions) {},
 		},
 		{
 			name:           "same family same size - no quota check needed",
 			currentVMSizes: threeMasters("Standard_D8s_v3"),
 			vmSize:         "Standard_D8s_v3",
-			mocks:          func(cuc *mock_compute.MockUsageClient) {},
+			mocks:          func(cuc *mock_adminactions.MockAzureActions) {},
 		},
 		{
 			// D8s_v3 → E8s_v3, cross family.  Full new cores: 8 × 3 = 24.
@@ -1242,9 +951,9 @@ func TestCheckResizeComputeQuota(t *testing.T) {
 			name:           "cross family - full new cores checked for all masters",
 			currentVMSizes: threeMasters("Standard_D8s_v3"),
 			vmSize:         "Standard_E8s_v3",
-			mocks: func(cuc *mock_compute.MockUsageClient) {
+			mocks: func(cuc *mock_adminactions.MockAzureActions) {
 				cuc.EXPECT().
-					List(ctx, "eastus").
+					ListComputeUsage(ctx, "eastus").
 					Return([]mgmtcompute.Usage{
 						{
 							Name: &mgmtcompute.UsageName{
@@ -1269,9 +978,9 @@ func TestCheckResizeComputeQuota(t *testing.T) {
 			name:           "cross family - not enough quota for all masters",
 			currentVMSizes: threeMasters("Standard_D8s_v3"),
 			vmSize:         "Standard_E8s_v3",
-			mocks: func(cuc *mock_compute.MockUsageClient) {
+			mocks: func(cuc *mock_adminactions.MockAzureActions) {
 				cuc.EXPECT().
-					List(ctx, "eastus").
+					ListComputeUsage(ctx, "eastus").
 					Return([]mgmtcompute.Usage{
 						{
 							Name: &mgmtcompute.UsageName{
@@ -1298,9 +1007,9 @@ func TestCheckResizeComputeQuota(t *testing.T) {
 			name:           "cross family - regional cores quota exceeded",
 			currentVMSizes: threeMasters("Standard_D8s_v3"),
 			vmSize:         "Standard_E16s_v3",
-			mocks: func(cuc *mock_compute.MockUsageClient) {
+			mocks: func(cuc *mock_adminactions.MockAzureActions) {
 				cuc.EXPECT().
-					List(ctx, "eastus").
+					ListComputeUsage(ctx, "eastus").
 					Return([]mgmtcompute.Usage{
 						{
 							Name: &mgmtcompute.UsageName{
@@ -1327,9 +1036,9 @@ func TestCheckResizeComputeQuota(t *testing.T) {
 			name:           "cross family downsize - regional cores not checked",
 			currentVMSizes: threeMasters("Standard_D8s_v3"),
 			vmSize:         "Standard_E4s_v3",
-			mocks: func(cuc *mock_compute.MockUsageClient) {
+			mocks: func(cuc *mock_adminactions.MockAzureActions) {
 				cuc.EXPECT().
-					List(ctx, "eastus").
+					ListComputeUsage(ctx, "eastus").
 					Return([]mgmtcompute.Usage{
 						{
 							Name: &mgmtcompute.UsageName{
@@ -1352,9 +1061,9 @@ func TestCheckResizeComputeQuota(t *testing.T) {
 			name:           "family not in usage list - no quota limit",
 			currentVMSizes: threeMasters("Standard_D8s_v3"),
 			vmSize:         "Standard_D16s_v3",
-			mocks: func(cuc *mock_compute.MockUsageClient) {
+			mocks: func(cuc *mock_adminactions.MockAzureActions) {
 				cuc.EXPECT().
-					List(ctx, "eastus").
+					ListComputeUsage(ctx, "eastus").
 					Return([]mgmtcompute.Usage{
 						{
 							Name: &mgmtcompute.UsageName{
@@ -1370,8 +1079,8 @@ func TestCheckResizeComputeQuota(t *testing.T) {
 			name:           "unsupported new VM size",
 			currentVMSizes: threeMasters("Standard_D8s_v3"),
 			vmSize:         "Standard_Nonexistent_v99",
-			mocks:          func(cuc *mock_compute.MockUsageClient) {},
-			wantErr:        "400: InvalidParameter: vmSize: The provided VM SKU 'Standard_Nonexistent_v99' is not supported.",
+			mocks:          func(cuc *mock_adminactions.MockAzureActions) {},
+			wantErr:        "the provided VM SKU 'Standard_Nonexistent_v99' is not supported",
 		},
 		{
 			// Mixed sizes: partial resize scenario.
@@ -1380,9 +1089,9 @@ func TestCheckResizeComputeQuota(t *testing.T) {
 			name:           "mixed sizes - partial resize only needs quota for remaining VMs",
 			currentVMSizes: []string{"Standard_D16s_v3", "Standard_D8s_v3", "Standard_D8s_v3"},
 			vmSize:         "Standard_D16s_v3",
-			mocks: func(cuc *mock_compute.MockUsageClient) {
+			mocks: func(cuc *mock_adminactions.MockAzureActions) {
 				cuc.EXPECT().
-					List(ctx, "eastus").
+					ListComputeUsage(ctx, "eastus").
 					Return([]mgmtcompute.Usage{
 						{
 							Name: &mgmtcompute.UsageName{
@@ -1408,9 +1117,9 @@ func TestCheckResizeComputeQuota(t *testing.T) {
 			name:           "mixed sizes - partial resize not enough quota",
 			currentVMSizes: []string{"Standard_D16s_v3", "Standard_D8s_v3", "Standard_D8s_v3"},
 			vmSize:         "Standard_D16s_v3",
-			mocks: func(cuc *mock_compute.MockUsageClient) {
+			mocks: func(cuc *mock_adminactions.MockAzureActions) {
 				cuc.EXPECT().
-					List(ctx, "eastus").
+					ListComputeUsage(ctx, "eastus").
 					Return([]mgmtcompute.Usage{
 						{
 							Name: &mgmtcompute.UsageName{
@@ -1435,7 +1144,7 @@ func TestCheckResizeComputeQuota(t *testing.T) {
 			name:           "all VMs already at desired size - no quota check needed",
 			currentVMSizes: threeMasters("Standard_D16s_v3"),
 			vmSize:         "Standard_D16s_v3",
-			mocks:          func(cuc *mock_compute.MockUsageClient) {},
+			mocks:          func(cuc *mock_adminactions.MockAzureActions) {},
 		},
 		{
 			// Cross-family accumulation: 2 VMs in DSv3, 1 VM in ESv3, resize to D16s_v3.
@@ -1445,9 +1154,9 @@ func TestCheckResizeComputeQuota(t *testing.T) {
 			name:           "cross-family accumulation - same and cross family contribute to same target",
 			currentVMSizes: []string{"Standard_D8s_v3", "Standard_D8s_v3", "Standard_E8s_v3"},
 			vmSize:         "Standard_D16s_v3",
-			mocks: func(cuc *mock_compute.MockUsageClient) {
+			mocks: func(cuc *mock_adminactions.MockAzureActions) {
 				cuc.EXPECT().
-					List(ctx, "eastus").
+					ListComputeUsage(ctx, "eastus").
 					Return([]mgmtcompute.Usage{
 						{
 							Name: &mgmtcompute.UsageName{
@@ -1471,7 +1180,7 @@ func TestCheckResizeComputeQuota(t *testing.T) {
 			name:           "unresolvable current VM size",
 			currentVMSizes: []string{"Standard_D8s_v3", "Standard_Unknown_v99", "Standard_D8s_v3"},
 			vmSize:         "Standard_D16s_v3",
-			mocks:          func(cuc *mock_compute.MockUsageClient) {},
+			mocks:          func(cuc *mock_adminactions.MockAzureActions) {},
 			wantErr:        "500: InternalServerError: currentVMSize: The current VM SKU 'Standard_Unknown_v99' could not be resolved.",
 		},
 	} {
@@ -1481,10 +1190,10 @@ func TestCheckResizeComputeQuota(t *testing.T) {
 			controller := gomock.NewController(t)
 			defer controller.Finish()
 
-			computeUsageClient := mock_compute.NewMockUsageClient(controller)
-			tt.mocks(computeUsageClient)
+			azActions := mock_adminactions.NewMockAzureActions(controller)
+			tt.mocks(azActions)
 
-			err := checkResizeComputeQuota(ctx, computeUsageClient, "eastus", tt.currentVMSizes, tt.vmSize)
+			err := checkResizeComputeQuota(ctx, azActions, "eastus", tt.currentVMSizes, tt.vmSize)
 			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}
@@ -1519,7 +1228,7 @@ func TestValidateVMSP(t *testing.T) {
 						},
 					}), nil)
 			},
-			wantErr: "409: InvalidServicePrincipalCredentials: servicePrincipal: Cluster Service Principal is invalid: secret expired",
+			wantErr: "cluster Service Principal is invalid: secret expired",
 		},
 		{
 			name: "condition not found",
@@ -1528,7 +1237,7 @@ func TestValidateVMSP(t *testing.T) {
 					KubeGet(gomock.Any(), "Cluster.aro.openshift.io", "", arov1alpha1.SingletonClusterName).
 					Return(fakeAROClusterJSON([]operatorv1.OperatorCondition{}), nil)
 			},
-			wantErr: "409: InvalidServicePrincipalCredentials: servicePrincipal: ServicePrincipalValid condition not found on the ARO Cluster resource. The ARO operator may not have reconciled yet.",
+			wantErr: "the ServicePrincipalValid condition not found on the ARO Cluster resource: The ARO operator may not have reconciled yet",
 		},
 		{
 			name: "KubeGet returns error",
@@ -1537,7 +1246,7 @@ func TestValidateVMSP(t *testing.T) {
 					KubeGet(gomock.Any(), "Cluster.aro.openshift.io", "", arov1alpha1.SingletonClusterName).
 					Return(nil, fmt.Errorf("connection refused"))
 			},
-			wantErr: "500: InternalServerError: servicePrincipal: Failed to retrieve ARO Cluster resource: connection refused",
+			wantErr: "failed to retrieve ARO Cluster resource: connection refused",
 		},
 		{
 			name: "KubeGet returns invalid JSON",
@@ -1546,7 +1255,7 @@ func TestValidateVMSP(t *testing.T) {
 					KubeGet(gomock.Any(), "Cluster.aro.openshift.io", "", arov1alpha1.SingletonClusterName).
 					Return([]byte(`{invalid`), nil)
 			},
-			wantErr: "500: InternalServerError: servicePrincipal: Failed to parse ARO Cluster resource: invalid character 'i' looking for beginning of object key string",
+			wantErr: "failed to parse ARO Cluster resource: invalid character 'i' looking for beginning of object key string",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1555,8 +1264,87 @@ func TestValidateVMSP(t *testing.T) {
 
 			k := mock_adminactions.NewMockKubeActions(controller)
 			tt.mocks(k)
+			p := preResizeValidator{
+				k: k,
+			}
+			err := p.validateClusterSP(ctx)
+			utilerror.AssertErrorMessage(t, err, tt.wantErr)
+		})
+	}
+}
 
-			err := validateClusterSP(ctx, k)
+func TestCheckCPMSNotActive(t *testing.T) {
+	ctx := context.Background()
+
+	cpmsGR := schema.GroupResource{Group: "machine.openshift.io", Resource: "controlplanemachinesets"}
+
+	for _, tt := range []struct {
+		name    string
+		mocks   func(*mock_adminactions.MockKubeActions)
+		wantErr string
+	}{
+		{
+			name: "CPMS not found - safe to proceed",
+			mocks: func(k *mock_adminactions.MockKubeActions) {
+				k.EXPECT().
+					KubeGet(gomock.Any(), "ControlPlaneMachineSet.machine.openshift.io", machineNamespace, "cluster").
+					Return(nil, kerrors.NewNotFound(cpmsGR, "cluster"))
+			},
+		},
+		{
+			name: "CPMS inactive - safe to proceed",
+			mocks: func(k *mock_adminactions.MockKubeActions) {
+				k.EXPECT().
+					KubeGet(gomock.Any(), "ControlPlaneMachineSet.machine.openshift.io", machineNamespace, "cluster").
+					Return(cpmsJSON("Inactive"), nil)
+			},
+		},
+		{
+			name: "CPMS active - blocked",
+			mocks: func(k *mock_adminactions.MockKubeActions) {
+				k.EXPECT().
+					KubeGet(gomock.Any(), "ControlPlaneMachineSet.machine.openshift.io", machineNamespace, "cluster").
+					Return(cpmsJSON("Active"), nil)
+			},
+			wantErr: "the ControlPlaneMachineSet is currently Active: Deactivate CPMS before running this operation",
+		},
+		{
+			name: "CPMS with empty state - safe to proceed",
+			mocks: func(k *mock_adminactions.MockKubeActions) {
+				k.EXPECT().
+					KubeGet(gomock.Any(), "ControlPlaneMachineSet.machine.openshift.io", machineNamespace, "cluster").
+					Return(cpmsJSON(""), nil)
+			},
+		},
+		{
+			name: "KubeGet returns non-NotFound error - fails closed",
+			mocks: func(k *mock_adminactions.MockKubeActions) {
+				k.EXPECT().
+					KubeGet(gomock.Any(), "ControlPlaneMachineSet.machine.openshift.io", machineNamespace, "cluster").
+					Return(nil, errors.New("connection refused"))
+			},
+			wantErr: "failed to check ControlPlaneMachineSet state: connection refused",
+		},
+		{
+			name: "CPMS returns invalid JSON - fails closed",
+			mocks: func(k *mock_adminactions.MockKubeActions) {
+				k.EXPECT().
+					KubeGet(gomock.Any(), "ControlPlaneMachineSet.machine.openshift.io", machineNamespace, "cluster").
+					Return([]byte("not-json"), nil)
+			},
+			wantErr: "failed to parse ControlPlaneMachineSet object: invalid character 'o' in literal null (expecting 'u')",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			k := mock_adminactions.NewMockKubeActions(ctrl)
+			tt.mocks(k)
+			p := preResizeValidator{
+				k: k,
+			}
+			err := p.validateCPMSNotActive(ctx)
 			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}
@@ -1589,7 +1377,7 @@ func TestValidateAPIServerHealth(t *testing.T) {
 						{Type: configv1.OperatorDegraded, Status: configv1.ConditionTrue},
 					}), nil)
 			},
-			wantErr: "409: RequestNotAllowed: kube-apiserver: kube-apiserver is not healthy: kube-apiserver Available=True, Progressing=False, Degraded=True. Resize is not safe while the API server is degraded.",
+			wantErr: "kube-apiserver is not healthy: kube-apiserver Available=True, Progressing=False, Degraded=True. Resize is not safe while the API server is degraded",
 		},
 		{
 			name: "kube-apiserver unavailable",
@@ -1602,7 +1390,7 @@ func TestValidateAPIServerHealth(t *testing.T) {
 						{Type: configv1.OperatorDegraded, Status: configv1.ConditionFalse},
 					}), nil)
 			},
-			wantErr: "409: RequestNotAllowed: kube-apiserver: kube-apiserver is not healthy: kube-apiserver Available=False, Progressing=True, Degraded=False. Resize is not safe while the API server is degraded.",
+			wantErr: "kube-apiserver is not healthy: kube-apiserver Available=False, Progressing=True, Degraded=False. Resize is not safe while the API server is degraded",
 		},
 		{
 			name: "KubeGet returns error",
@@ -1611,7 +1399,7 @@ func TestValidateAPIServerHealth(t *testing.T) {
 					KubeGet(gomock.Any(), "ClusterOperator.config.openshift.io", "", "kube-apiserver").
 					Return(nil, fmt.Errorf("connection refused"))
 			},
-			wantErr: "500: InternalServerError: kube-apiserver: Failed to retrieve kube-apiserver ClusterOperator: connection refused",
+			wantErr: "failed to retrieve kube-apiserver ClusterOperator: connection refused",
 		},
 		{
 			name: "KubeGet returns invalid JSON",
@@ -1620,7 +1408,7 @@ func TestValidateAPIServerHealth(t *testing.T) {
 					KubeGet(gomock.Any(), "ClusterOperator.config.openshift.io", "", "kube-apiserver").
 					Return([]byte(`{invalid`), nil)
 			},
-			wantErr: "500: InternalServerError: kube-apiserver: Failed to parse kube-apiserver ClusterOperator: invalid character 'i' looking for beginning of object key string",
+			wantErr: "failed to parse kube-apiserver ClusterOperator: invalid character 'i' looking for beginning of object key string",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1629,8 +1417,10 @@ func TestValidateAPIServerHealth(t *testing.T) {
 
 			k := mock_adminactions.NewMockKubeActions(controller)
 			tt.mocks(k)
-
-			err := validateAPIServerHealth(ctx, k)
+			p := preResizeValidator{
+				k: k,
+			}
+			err := p.validateAPIServerHealth(ctx)
 			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}
@@ -1662,7 +1452,7 @@ func TestValidateAPIServerPods(t *testing.T) {
 						fakeKubeAPIServerPod("kube-apiserver-master-1", corev1.PodRunning, true),
 					), nil)
 			},
-			wantErr: "409: RequestNotAllowed: kube-apiserver-pods: Expected 3 kube-apiserver pods, found 2. Resize is not safe without full API server redundancy.",
+			wantErr: "expected 3 kube-apiserver pods, found 2. Resize is not safe without full API server redundancy",
 		},
 		{
 			name: "kube-apiserver pod unhealthy phase",
@@ -1675,7 +1465,7 @@ func TestValidateAPIServerPods(t *testing.T) {
 						fakeKubeAPIServerPod("kube-apiserver-master-2", corev1.PodRunning, true),
 					), nil)
 			},
-			wantErr: "409: RequestNotAllowed: kube-apiserver-pods: Unhealthy kube-apiserver pods: [kube-apiserver-master-1 (phase: Pending)]. Resize is not safe without full API server redundancy.",
+			wantErr: "unhealthy kube-apiserver pods: [kube-apiserver-master-1 (phase: Pending)]. Resize is not safe without full API server redundancy",
 		},
 		{
 			name: "kube-apiserver pod not ready",
@@ -1688,7 +1478,7 @@ func TestValidateAPIServerPods(t *testing.T) {
 						fakeKubeAPIServerPod("kube-apiserver-master-2", corev1.PodRunning, true),
 					), nil)
 			},
-			wantErr: "409: RequestNotAllowed: kube-apiserver-pods: Unhealthy kube-apiserver pods: [kube-apiserver-master-1 (not ready)]. Resize is not safe without full API server redundancy.",
+			wantErr: "unhealthy kube-apiserver pods: [kube-apiserver-master-1 (not ready)]. Resize is not safe without full API server redundancy",
 		},
 		{
 			name: "uses server-side label selector filtering",
@@ -1709,7 +1499,7 @@ func TestValidateAPIServerPods(t *testing.T) {
 					KubeList(gomock.Any(), "Pod", "openshift-kube-apiserver", "app=openshift-kube-apiserver").
 					Return(nil, fmt.Errorf("connection refused"))
 			},
-			wantErr: "500: InternalServerError: kube-apiserver-pods: Failed to list pods in openshift-kube-apiserver namespace: connection refused",
+			wantErr: "failed to list pods in openshift-kube-apiserver namespace: connection refused",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1718,8 +1508,10 @@ func TestValidateAPIServerPods(t *testing.T) {
 
 			k := mock_adminactions.NewMockKubeActions(controller)
 			tt.mocks(k)
-
-			err := validateAPIServerPods(ctx, k)
+			p := preResizeValidator{
+				k: k,
+			}
+			err := p.validateAPIServerPods(ctx)
 			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}
@@ -1752,7 +1544,7 @@ func TestValidateEtcdHealth(t *testing.T) {
 						{Type: configv1.OperatorDegraded, Status: configv1.ConditionTrue},
 					}), nil)
 			},
-			wantErr: "409: RequestNotAllowed: etcd: etcd is not healthy: etcd Available=True, Progressing=False, Degraded=True. Resize is not safe while etcd quorum is at risk.",
+			wantErr: "etcd is not healthy: etcd Available=True, Progressing=False, Degraded=True - Resize is not safe while etcd quorum is at risk",
 		},
 		{
 			name: "etcd unavailable",
@@ -1765,7 +1557,7 @@ func TestValidateEtcdHealth(t *testing.T) {
 						{Type: configv1.OperatorDegraded, Status: configv1.ConditionFalse},
 					}), nil)
 			},
-			wantErr: "409: RequestNotAllowed: etcd: etcd is not healthy: etcd Available=False, Progressing=True, Degraded=False. Resize is not safe while etcd quorum is at risk.",
+			wantErr: "etcd is not healthy: etcd Available=False, Progressing=True, Degraded=False - Resize is not safe while etcd quorum is at risk",
 		},
 		{
 			name: "KubeGet returns error",
@@ -1774,7 +1566,7 @@ func TestValidateEtcdHealth(t *testing.T) {
 					KubeGet(gomock.Any(), "ClusterOperator.config.openshift.io", "", "etcd").
 					Return(nil, fmt.Errorf("connection refused"))
 			},
-			wantErr: "500: InternalServerError: etcd: Failed to retrieve etcd ClusterOperator: connection refused",
+			wantErr: "failed to retrieve etcd ClusterOperator: connection refused",
 		},
 		{
 			name: "KubeGet returns invalid JSON",
@@ -1783,7 +1575,7 @@ func TestValidateEtcdHealth(t *testing.T) {
 					KubeGet(gomock.Any(), "ClusterOperator.config.openshift.io", "", "etcd").
 					Return([]byte(`{invalid`), nil)
 			},
-			wantErr: "500: InternalServerError: etcd: Failed to parse etcd ClusterOperator: invalid character 'i' looking for beginning of object key string",
+			wantErr: "failed to parse etcd ClusterOperator: invalid character 'i' looking for beginning of object key string",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1792,8 +1584,10 @@ func TestValidateEtcdHealth(t *testing.T) {
 
 			k := mock_adminactions.NewMockKubeActions(controller)
 			tt.mocks(k)
-
-			err := validateEtcdHealth(ctx, k)
+			p := preResizeValidator{
+				k: k,
+			}
+			err := p.validateEtcdHealth(ctx)
 			utilerror.AssertErrorMessage(t, err, tt.wantErr)
 		})
 	}

--- a/pkg/frontend/adminactions/azureactions.go
+++ b/pkg/frontend/adminactions/azureactions.go
@@ -47,6 +47,7 @@ type AzureActions interface {
 	CreateCapacityReservation(ctx context.Context, clusterRG, location, zone, targetSKU, crgName string, capacity int64) error
 	DeleteCRG(ctx context.Context, clusterRG, crgName string) error
 	DeleteCapacityReservation(ctx context.Context, clusterRG, crgName, zone string) error
+	ListComputeUsage(ctx context.Context, location string) ([]mgmtcompute.Usage, error)
 }
 
 type azureActions struct {
@@ -63,6 +64,7 @@ type azureActions struct {
 	securityGroups     armnetwork.SecurityGroupsClient
 	storageAccounts    storage.AccountsClient
 	virtualMachines    compute.VirtualMachinesClient
+	computeUsage       compute.UsageClient
 	virtualNetworks    armnetwork.VirtualNetworksClient
 
 	capacityReservationGroups armcompute.CapacityReservationGroupsClient
@@ -140,6 +142,7 @@ func NewAzureActions(log *logrus.Entry, env env.Interface, oc *api.OpenShiftClus
 		securityGroups:     securityGroups,
 		storageAccounts:    storage.NewAccountsClient(env.Environment(), subscriptionDoc.ID, fpAuth),
 		virtualMachines:    compute.NewVirtualMachinesClient(env.Environment(), subscriptionDoc.ID, fpAuth),
+		computeUsage:       compute.NewUsageClient(env.Environment(), subscriptionDoc.ID, fpAuth),
 		virtualNetworks:    virtualNetworks,
 
 		capacityReservationGroups: armCapacityReservationGroups,
@@ -203,6 +206,10 @@ func (a *azureActions) ResourceGroupHasVM(ctx context.Context, vmName string) (b
 	}
 
 	return false, nil
+}
+
+func (a *azureActions) ListComputeUsage(ctx context.Context, location string) ([]mgmtcompute.Usage, error) {
+	return a.computeUsage.List(ctx, location)
 }
 
 func (a *azureActions) GetEffectiveRouteTable(ctx context.Context, nicName string) ([]byte, error) {

--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -131,7 +131,6 @@ type frontend struct {
 	// these helps us to test and mock easier
 	now                          func() time.Time
 	systemDataClusterDocEnricher func(*api.OpenShiftClusterDocument, *api.SystemData)
-	validateResizeQuota          func(ctx context.Context, environment env.Interface, subscriptionDoc *api.SubscriptionDocument, location string, currentVMSizes []string, desiredVMSize string) error
 
 	streamResponder StreamResponder
 }
@@ -214,7 +213,6 @@ func NewFrontend(ctx context.Context,
 
 		now:                          time.Now,
 		systemDataClusterDocEnricher: enrichClusterSystemData,
-		validateResizeQuota:          defaultValidateResizeQuota,
 
 		streamResponder: defaultResponder{},
 	}

--- a/pkg/frontend/shared_test.go
+++ b/pkg/frontend/shared_test.go
@@ -307,7 +307,7 @@ func validateResponse(resp *http.Response, b []byte, wantStatusCode int, wantErr
 		}
 
 		if diff := cmp.Diff(cloudErr.Error(), wantError, opts...); diff != "" {
-			return fmt.Errorf("unexpected error (-want +got):\n%s", diff)
+			return fmt.Errorf("unexpected error (+want -got):\n%s", diff)
 		}
 
 		return nil

--- a/pkg/util/mocks/adminactions/azureactions.go
+++ b/pkg/util/mocks/adminactions/azureactions.go
@@ -148,6 +148,21 @@ func (mr *MockAzureActionsMockRecorder) GroupResourceList(ctx any) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GroupResourceList", reflect.TypeOf((*MockAzureActions)(nil).GroupResourceList), ctx)
 }
 
+// ListComputeUsage mocks base method.
+func (m *MockAzureActions) ListComputeUsage(ctx context.Context, location string) ([]compute.Usage, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListComputeUsage", ctx, location)
+	ret0, _ := ret[0].([]compute.Usage)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListComputeUsage indicates an expected call of ListComputeUsage.
+func (mr *MockAzureActionsMockRecorder) ListComputeUsage(ctx, location any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListComputeUsage", reflect.TypeOf((*MockAzureActions)(nil).ListComputeUsage), ctx, location)
+}
+
 // NICReconcileFailedState mocks base method.
 func (m *MockAzureActions) NICReconcileFailedState(ctx context.Context, nicName string) error {
 	m.ctrl.T.Helper()

--- a/pkg/util/steps/concurrent.go
+++ b/pkg/util/steps/concurrent.go
@@ -1,0 +1,71 @@
+package steps
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+)
+
+func Concurrent(name string, s []Step) Step {
+	return concurrentStep{
+		name: name,
+		s:    s,
+	}
+}
+
+type concurrentStep struct {
+	name string
+	s    []Step
+}
+
+func (s concurrentStep) run(ctx context.Context, log *logrus.Entry) error {
+	wg := &sync.WaitGroup{}
+	errChan := make(chan error, len(s.s))
+	for _, curStep := range s.s {
+		wg.Go(func() {
+			defer func() {
+				if err := recover(); err != nil {
+					errChan <- fmt.Errorf("panic in step '%s' : %v", curStep.String(), err)
+				}
+			}()
+
+			err := curStep.run(ctx, log)
+			if err != nil {
+				errChan <- err
+			}
+		})
+	}
+
+	wg.Wait()
+	close(errChan)
+
+	errs := []error{}
+	for err := range errChan {
+		errs = append(errs, err)
+	}
+
+	return errors.Join(errs...)
+}
+
+func (s concurrentStep) String() string {
+	stepNames := []string{}
+
+	for _, curStep := range s.s {
+		na := strings.Trim(curStep.String(), "[]")
+		sho := shortName(na)
+		stepNames = append(stepNames, sho)
+	}
+
+	return fmt.Sprintf("[Action %s [%s]]", s.name, strings.Join(stepNames, ", "))
+}
+
+func (s concurrentStep) metricsName() string {
+	return fmt.Sprintf("action.%s", s.name)
+}

--- a/pkg/util/steps/concurrent_test.go
+++ b/pkg/util/steps/concurrent_test.go
@@ -1,0 +1,148 @@
+package steps
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"testing"
+)
+
+type teststructConcurrent struct{}
+
+// functionnames that will be used in the conditionFunction below
+// All the keys of map timeoutConditionErrors
+func (n *teststructConcurrent) attachNSGs(context.Context) error              { return nil }
+func (n *teststructConcurrent) apiServersReady(context.Context) error         { return nil }
+func (n *teststructConcurrent) minimumWorkerNodesReady(context.Context) error { return nil }
+
+func Test_concurrentStep_String(t *testing.T) {
+	ts := teststructConcurrent{}
+	tests := []struct {
+		name  string // description of this test case
+		steps []Step
+		want  string
+	}{
+		{
+			name:  "nosteps",
+			steps: []Step{},
+			want:  "[Action nosteps []]",
+		},
+		{
+			name:  "nilsteps",
+			steps: nil,
+			want:  "[Action nilsteps []]",
+		},
+		{
+			name:  "onestep",
+			steps: []Step{Action(ts.attachNSGs)},
+			want:  "[Action onestep [attachNSGs]]",
+		},
+		{
+			name: "threesteps",
+			steps: []Step{
+				Action(ts.attachNSGs),
+				Action(ts.apiServersReady),
+				Action(ts.minimumWorkerNodesReady),
+			},
+			want: "[Action threesteps [attachNSGs, apiServersReady, minimumWorkerNodesReady]]",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := Concurrent(tt.name, tt.steps)
+			got := s.String()
+			if got != tt.want {
+				t.Errorf("String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+type joinedErr interface {
+	Unwrap() []error
+}
+
+func Test_concurrentStep_run(t *testing.T) {
+	errOne := fmt.Errorf("one")
+	errTwo := fmt.Errorf("two")
+	errThree := fmt.Errorf("three")
+
+	tests := []struct {
+		name     string
+		steps    []Step
+		wantErr  bool
+		wantErrs []error
+	}{
+		{
+			name: "three errors",
+			steps: []Step{
+				Action(func(ctx context.Context) error { return errOne }),
+				Action(func(ctx context.Context) error { return errTwo }),
+				Action(func(ctx context.Context) error { return errThree }),
+			},
+			wantErr:  true,
+			wantErrs: []error{errOne, errTwo, errThree},
+		},
+		{
+			name: "Three runs, one err",
+			steps: []Step{
+				Action(func(ctx context.Context) error { return nil }),
+				Action(func(ctx context.Context) error { return nil }),
+				Action(func(ctx context.Context) error { return errThree }),
+			},
+			wantErr:  true,
+			wantErrs: []error{errThree},
+		},
+		{
+			name: "Three runs, no err",
+			steps: []Step{
+				Action(func(ctx context.Context) error { return nil }),
+				Action(func(ctx context.Context) error { return nil }),
+				Action(func(ctx context.Context) error { return nil }),
+			},
+			wantErrs: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := Concurrent("test", tt.steps)
+
+			gotErr := s.run(context.Background(), nil)
+
+			if gotErr != nil {
+				je, ok := gotErr.(joinedErr)
+				if !ok {
+					t.Errorf("Unexpected error type: %v", gotErr)
+					return
+				}
+
+				gotErrs := je.Unwrap()
+				if len(tt.wantErrs) != len(gotErrs) {
+					t.Errorf("run() = %v, want %v", gotErr, tt.wantErrs)
+					return
+				}
+
+				for _, curErr := range gotErrs {
+					if !slices.Contains(tt.wantErrs, curErr) {
+						t.Errorf("run() = %v, want %v", gotErr, tt.wantErrs)
+						return
+					}
+				}
+
+				for _, curErr := range tt.wantErrs {
+					if !slices.Contains(gotErrs, curErr) {
+						t.Errorf("run() = %v, want %v", gotErr, tt.wantErrs)
+						return
+					}
+				}
+				return
+			}
+			if len(tt.wantErrs) > 0 {
+				t.Fatal("run() succeeded unexpectedly")
+			}
+		})
+	}
+}

--- a/pkg/util/steps/runner.go
+++ b/pkg/util/steps/runner.go
@@ -117,3 +117,26 @@ func Run(ctx context.Context, log *logrus.Entry, pollInterval time.Duration, ste
 	}
 	return stepTimeRun, nil
 }
+
+// RunWithWrappedError executes the provided steps in order until one fails or
+// all steps are completed. Unlike Run, errors from failed steps are wrapped
+// with the step name for additional context, and no Azure-specific error
+// classification is performed. Time cost for each step run will be recorded
+// for metrics usage.
+func RunWithWrappedError(ctx context.Context, log *logrus.Entry, steps []Step) (map[string]int64, error) {
+	stepTimeRun := make(map[string]int64)
+	for _, step := range steps {
+		log.Infof("running step %s", step)
+
+		startTime := time.Now()
+		err := step.run(ctx, log)
+		if err != nil {
+			log.Errorf("step %s encountered error: %s", step, err.Error())
+			return nil, fmt.Errorf("step %s encountered error: %w", step, err)
+		}
+
+		currentTime := time.Now()
+		stepTimeRun[step.metricsName()] = int64(currentTime.Sub(startTime).Seconds())
+	}
+	return stepTimeRun, nil
+}


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-29482](https://redhat.atlassian.net/browse/ARO-29482)

### What this PR does / why we need it:

- Cleanup some of the code for the resize validation
- extends `steps` to support concurrent actions
- use steps framework for orchestrating pre-validation
- remove unnecessary error handling and try to stick to fmt.Errorf
- extend admin_actions to support azure quota action and remove validation dependency on the frontend struct
- possibly other smaller things
### Test plan for issue:

- Unit Tests adjusted, actual business logic wasn't touched
### Is there any documentation that needs to be updated for this PR?

- no
### How do you know this will function as expected in production? 

the whole resize feature isn't prod yet