### PR TITLE
Update API js-yaml dependencies to patched versions.

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -346,9 +346,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/@azure/openapi-markdown/node_modules/js-yaml": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
-      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+      "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2237,9 +2237,9 @@
       }
     },
     "node_modules/front-matter/node_modules/js-yaml": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
-      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+      "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2519,9 +2519,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [GHSA-2883-xcg3-v3hh](https://github.com/advisories/GHSA-2883-xcg3-v3hh), a js-yaml vulnerability that can cause excessive CPU consumption when processing YAML merges.

### What this PR does / why we need it:

Updates `api/package-lock.json` to use patched js-yaml versions: **4.3.1 to 4.3.2**, and **3.15.1 to 3.15.2** for nested copies under `@azure/openapi-markdown` and `front-matter`. All updates remain within existing dependency ranges.

### Test plan for issue:

- Ran `npm ci --ignore-scripts --no-audit --no-fund --registry=https://registry.npmjs.org` successfully.
- Ran `npm run swagger -- --no-emit` successfully to validate TypeSpec compilation.
- Confirmed `npm audit --omit=dev` no longer reports the js-yaml advisory.

### Is there any documentation that needs to be updated for this PR?

No. This is a dependency security patch with no user-facing configuration or API changes.

### How do you know this will function as expected in production?

The updated dependencies are used by API-generation tooling. The patch versions satisfy existing dependency constraints, installation and TypeSpec compilation succeed, and no generated API files are changed.