### PR TITLE
Add GetIDsByClusterResourceGroupID to OpenShiftClusters database

### DIFF
--- a/pkg/database/openshiftclusters.go
+++ b/pkg/database/openshiftclusters.go
@@ -23,6 +23,7 @@ const (
 	OpenshiftClustersPrefixQuery                = `SELECT * FROM OpenShiftClusters doc WHERE STARTSWITH(doc.key, @prefix)`
 	OpenshiftClustersClientIdQuery              = `SELECT * FROM OpenShiftClusters doc WHERE doc.clientIdKey = @clientID`
 	OpenshiftClustersResourceGroupQuery         = `SELECT * FROM OpenShiftClusters doc WHERE doc.clusterResourceGroupIdKey = @resourceGroupID`
+	OpenshiftClustersResourceGroupIDOnlyQuery   = `SELECT doc.id FROM OpenShiftClusters doc WHERE doc.clusterResourceGroupIdKey = @resourceGroupID`
 	OpenshiftClustersClusterResourceIDOnlyQuery = `SELECT doc.id, doc.key, doc.bucket FROM OpenShiftClusters doc WHERE doc.openShiftCluster.properties.provisioningState NOT IN ("Creating", "Deleting")`
 )
 
@@ -56,6 +57,7 @@ type OpenShiftClusters interface {
 	EndLease(context.Context, string, api.ProvisioningState, api.ProvisioningState, *string) (*api.OpenShiftClusterDocument, error)
 	GetByClientID(ctx context.Context, partitionKey, clientID string) (*api.OpenShiftClusterDocuments, error)
 	GetByClusterResourceGroupID(ctx context.Context, partitionKey, resourceGroupID string) (*api.OpenShiftClusterDocuments, error)
+	GetIDsByClusterResourceGroupID(ctx context.Context, partitionKey, resourceGroupID string) (*api.OpenShiftClusterDocuments, error)
 	GetAllResourceIDs(ctx context.Context, continuation string) (cosmosdb.OpenShiftClusterDocumentIterator, error)
 	DoDequeue(ctx context.Context, doc *api.OpenShiftClusterDocument) (*api.OpenShiftClusterDocument, error)
 	NewUUID() string
@@ -362,6 +364,27 @@ func (c *openShiftClusters) GetByClientID(ctx context.Context, partitionKey, cli
 func (c *openShiftClusters) GetByClusterResourceGroupID(ctx context.Context, partitionKey, resourceGroupID string) (*api.OpenShiftClusterDocuments, error) {
 	docs, err := c.c.QueryAll(ctx, partitionKey, &cosmosdb.Query{
 		Query: OpenshiftClustersResourceGroupQuery,
+		Parameters: []cosmosdb.Parameter{
+			{
+				Name:  "@resourceGroupID",
+				Value: resourceGroupID,
+			},
+		},
+	}, nil)
+	if err != nil {
+		return nil, err
+	}
+	return docs, nil
+}
+
+// GetIDsByClusterResourceGroupID returns cluster documents containing only doc.id
+// for the given managed resource group. Unlike GetByClusterResourceGroupID it does
+// not project the full OpenShiftCluster payload, so callers that only need to know
+// which document generations exist avoid decoding fields that may be brittle to
+// schema drift (e.g. stored documents predating a scalar→struct change).
+func (c *openShiftClusters) GetIDsByClusterResourceGroupID(ctx context.Context, partitionKey, resourceGroupID string) (*api.OpenShiftClusterDocuments, error) {
+	docs, err := c.c.QueryAll(ctx, partitionKey, &cosmosdb.Query{
+		Query: OpenshiftClustersResourceGroupIDOnlyQuery,
 		Parameters: []cosmosdb.Parameter{
 			{
 				Name:  "@resourceGroupID",

--- a/pkg/database/openshiftclusters_test.go
+++ b/pkg/database/openshiftclusters_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/Azure/ARO-RP/pkg/api"
@@ -122,5 +123,83 @@ func TestUpdateReturnsErrorWhenCosmosDBReturnsNilNil(t *testing.T) {
 	expectedMsg := fmt.Sprintf("OpenShiftClusters Replace returned nil document with nil error for key %q and partition key %q", doc.Key, doc.PartitionKey)
 	if cosmosErr.Message != expectedMsg {
 		t.Errorf("expected error message %q, got %q", expectedMsg, cosmosErr.Message)
+	}
+}
+
+// mockQueryAllClient captures the query and partition key passed to QueryAll and
+// returns a canned result, so tests can assert the projection query wiring without
+// a live CosmosDB.
+type mockQueryAllClient struct {
+	cosmosdb.OpenShiftClusterDocumentClient
+	gotPartitionKey string
+	gotQuery        *cosmosdb.Query
+	result          *api.OpenShiftClusterDocuments
+}
+
+func (m *mockQueryAllClient) QueryAll(ctx context.Context, partitionKey string, query *cosmosdb.Query, options *cosmosdb.Options) (*api.OpenShiftClusterDocuments, error) {
+	m.gotPartitionKey = partitionKey
+	m.gotQuery = query
+	return m.result, nil
+}
+
+// TestGetIDsByClusterResourceGroupIDProjectsIDOnly verifies that
+// GetIDsByClusterResourceGroupID wires up the id-only projection query with the
+// correct partition key and @resourceGroupID parameter, and that it returns the
+// documents unchanged (ID populated, OpenShiftCluster nil).
+func TestGetIDsByClusterResourceGroupIDProjectsIDOnly(t *testing.T) {
+	ctx := context.Background()
+
+	const (
+		partitionKey    = "00000000-0000-0000-0000-000000000000"
+		resourceGroupID = "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/managed-rg"
+	)
+
+	mockClient := &mockQueryAllClient{
+		result: &api.OpenShiftClusterDocuments{
+			Count: 1,
+			OpenShiftClusterDocuments: []*api.OpenShiftClusterDocument{
+				{ID: "doc-id-1"},
+			},
+		},
+	}
+	db := NewOpenShiftClustersWithProvidedClient(mockClient, nil, "test-uuid", uuid.DefaultGenerator)
+
+	docs, err := db.GetIDsByClusterResourceGroupID(ctx, partitionKey, resourceGroupID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if mockClient.gotPartitionKey != partitionKey {
+		t.Errorf("partition key: expected %q, got %q", partitionKey, mockClient.gotPartitionKey)
+	}
+
+	if mockClient.gotQuery.Query != OpenshiftClustersResourceGroupIDOnlyQuery {
+		t.Errorf("query: expected %q, got %q", OpenshiftClustersResourceGroupIDOnlyQuery, mockClient.gotQuery.Query)
+	}
+
+	// Guard the projection intent itself: doc.id must be the only projected field,
+	// so it must be immediately followed by FROM (rejecting e.g. "SELECT doc.id, doc.key").
+	if q := mockClient.gotQuery.Query; !strings.HasPrefix(q, "SELECT doc.id FROM ") {
+		t.Errorf("query is not an id-only projection: %q", q)
+	}
+
+	if len(mockClient.gotQuery.Parameters) != 1 {
+		t.Fatalf("expected 1 query parameter, got %d", len(mockClient.gotQuery.Parameters))
+	}
+	if param := mockClient.gotQuery.Parameters[0]; param.Name != "@resourceGroupID" || param.Value != resourceGroupID {
+		t.Errorf("parameter: expected {@resourceGroupID %q}, got {%s %v}", resourceGroupID, param.Name, param.Value)
+	}
+
+	if docs.Count != 1 {
+		t.Errorf("count: expected 1, got %d", docs.Count)
+	}
+	if len(docs.OpenShiftClusterDocuments) != 1 {
+		t.Fatalf("expected 1 document, got %d", len(docs.OpenShiftClusterDocuments))
+	}
+	if got := docs.OpenShiftClusterDocuments[0].ID; got != "doc-id-1" {
+		t.Errorf("id: expected %q, got %q", "doc-id-1", got)
+	}
+	if docs.OpenShiftClusterDocuments[0].OpenShiftCluster != nil {
+		t.Error("expected OpenShiftCluster to be nil for an id-only projection")
 	}
 }

--- a/test/database/openshiftclusters.go
+++ b/test/database/openshiftclusters.go
@@ -175,12 +175,40 @@ func fakeOpenShiftClustersOnlyResourceID(client cosmosdb.OpenShiftClusterDocumen
 	return cosmosdb.NewFakeOpenShiftClusterDocumentIterator(newDocs, startingIndex)
 }
 
+// fakeOpenShiftClustersResourceGroupIDOnly mirrors the SELECT doc.id projection:
+// it filters by @resourceGroupID but populates only ID, leaving OpenShiftCluster
+// nil so callers relying on the full payload are caught.
+func fakeOpenShiftClustersResourceGroupIDOnly(client cosmosdb.OpenShiftClusterDocumentClient, query *cosmosdb.Query, options *cosmosdb.Options) cosmosdb.OpenShiftClusterDocumentRawIterator {
+	startingIndex, err := fakeOpenShiftClustersGetContinuation(options)
+	if err != nil {
+		return cosmosdb.NewFakeOpenShiftClusterDocumentErroringRawIterator(err)
+	}
+
+	docs, err := fakeOpenShiftClustersGetAllDocuments(client)
+	if err != nil {
+		return cosmosdb.NewFakeOpenShiftClusterDocumentErroringRawIterator(err)
+	}
+
+	newDocs := make([]*api.OpenShiftClusterDocument, 0)
+
+	for _, d := range docs {
+		if d.ClusterResourceGroupIDKey == query.Parameters[0].Value {
+			newDocs = append(newDocs, &api.OpenShiftClusterDocument{
+				ID: d.ID,
+			})
+		}
+	}
+
+	return cosmosdb.NewFakeOpenShiftClusterDocumentIterator(newDocs, startingIndex)
+}
+
 func injectOpenShiftClusters(c *cosmosdb.FakeOpenShiftClusterDocumentClient) {
 	c.SetQueryHandler(database.OpenShiftClustersDequeueQuery, fakeOpenShiftClustersDequeueQuery)
 	c.SetQueryHandler(database.OpenShiftClustersQueueLengthQuery, fakeOpenShiftClustersQueueLengthQuery)
 	c.SetQueryHandler(database.OpenShiftClustersGetQuery, fakeOpenshiftClustersMatchQuery)
 	c.SetQueryHandler(database.OpenshiftClustersClientIdQuery, fakeOpenshiftClustersMatchQuery)
 	c.SetQueryHandler(database.OpenshiftClustersResourceGroupQuery, fakeOpenshiftClustersMatchQuery)
+	c.SetQueryHandler(database.OpenshiftClustersResourceGroupIDOnlyQuery, fakeOpenShiftClustersResourceGroupIDOnly)
 	c.SetQueryHandler(database.OpenshiftClustersPrefixQuery, fakeOpenshiftClustersPrefixQuery)
 	c.SetQueryHandler(database.OpenshiftClustersClusterResourceIDOnlyQuery, fakeOpenShiftClustersOnlyResourceID)
 

--- a/test/database/openshiftclusters_test.go
+++ b/test/database/openshiftclusters_test.go
@@ -1,0 +1,52 @@
+package database
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Azure/ARO-RP/pkg/api"
+)
+
+func TestFakeGetIDsByClusterResourceGroupID(t *testing.T) {
+	ctx := context.Background()
+
+	const (
+		subscriptionID = "00000000-0000-0000-0000-000000000000"
+		matchingRG     = "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/managed-rg"
+		otherRG        = "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/other-rg"
+	)
+
+	db, _ := NewFakeOpenShiftClusters()
+
+	seed := []*api.OpenShiftClusterDocument{
+		{ID: "doc-1", Key: strings.ToLower(GetResourcePath(subscriptionID, "cluster1")), ClusterResourceGroupIDKey: matchingRG, OpenShiftCluster: &api.OpenShiftCluster{ID: "id-1"}},
+		{ID: "doc-2", Key: strings.ToLower(GetResourcePath(subscriptionID, "cluster2")), ClusterResourceGroupIDKey: otherRG, OpenShiftCluster: &api.OpenShiftCluster{ID: "id-2"}},
+	}
+	for _, doc := range seed {
+		if _, err := db.Create(ctx, doc); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	result, err := db.GetIDsByClusterResourceGroupID(ctx, subscriptionID, matchingRG)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result.Count != 1 {
+		t.Fatalf("count: expected 1, got %d", result.Count)
+	}
+
+	got := result.OpenShiftClusterDocuments[0]
+	if got.ID != "doc-1" {
+		t.Errorf("id: expected %q, got %q", "doc-1", got.ID)
+	}
+	// The id-only projection must not carry the full payload.
+	if got.OpenShiftCluster != nil {
+		t.Errorf("expected OpenShiftCluster nil, got %+v", got.OpenShiftCluster)
+	}
+}


### PR DESCRIPTION
Adds an id-only projection query (SELECT doc.id) mirroring GetByClusterResourceGroupID, so callers that only need to know which cluster-document generations exist for a managed resource group can avoid decoding the full OpenShiftCluster payload (brittle to schema drift for documents predating a scalar->struct field change).