### PR TITLE
ARO-29185 fix identity replacement e2e by adding another retry to empty body patch as part of cleanup

### DIFF
--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -84,8 +84,9 @@ const (
 var staticResources embed.FS
 
 var (
-	disallowedInFilenameRegex = regexp.MustCompile(`[<>:"/\\|?*\x00-\x1F]`)
-	DefaultEventuallyTimeout  = 5 * time.Minute
+	disallowedInFilenameRegex         = regexp.MustCompile(`[<>:"/\\|?*\x00-\x1F]`)
+	DefaultEventuallyTimeout          = 5 * time.Minute
+	PropagationDelayEventuallyTimeout = 25 * time.Second
 )
 
 type clientSet struct {

--- a/test/e2e/update.go
+++ b/test/e2e/update.go
@@ -223,17 +223,6 @@ var _ = Describe("Update clusters", func() {
 		}).WithContext(ctx).WithTimeout(DefaultEventuallyTimeout).Should(Succeed())
 
 		DeferCleanup(func(ctx context.Context) {
-			By("checking cluster provisioning state")
-			oc, err := clients.OpenshiftClusters.Get(ctx, vnetResourceGroup, clusterName, nil)
-			if err != nil {
-				return
-			}
-			if oc.Properties != nil && oc.Properties.ProvisioningState != nil && *oc.Properties.ProvisioningState != armredhatopenshift.ProvisioningStateSucceeded {
-				By("sending the PATCH request to retry update")
-				err := clients.OpenshiftClusters.UpdateAndWait(ctx, vnetResourceGroup, clusterName, armredhatopenshift.OpenShiftClusterUpdate{})
-				Expect(err).NotTo(HaveOccurred())
-			}
-
 			By("cleaning up any remaining role assignments for the original identity")
 			if originalMsi.Properties != nil && originalMsi.Properties.PrincipalID != nil {
 				roleAssignments, err := clients.RoleAssignments.ListForResourceGroup(ctx, vnetResourceGroup, fmt.Sprintf("principalId eq '%s'", *originalMsi.Properties.PrincipalID))
@@ -344,7 +333,8 @@ var _ = Describe("Update clusters", func() {
 				},
 			})
 			g.Expect(err).NotTo(HaveOccurred())
-		}).WithContext(ctx).WithTimeout(2 * time.Second).Should(Succeed())
+			// Optionally, to avoid waiting here, get the replacement identity ready in e2e BeforeSuite.
+		}).WithContext(ctx).WithTimeout(PropagationDelayEventuallyTimeout).Should(Succeed())
 
 		By("verifying the identity was replaced")
 		Eventually(func(g Gomega, ctx context.Context) {

--- a/test/e2e/update.go
+++ b/test/e2e/update.go
@@ -223,6 +223,17 @@ var _ = Describe("Update clusters", func() {
 		}).WithContext(ctx).WithTimeout(DefaultEventuallyTimeout).Should(Succeed())
 
 		DeferCleanup(func(ctx context.Context) {
+			By("checking cluster provisioning state")
+			oc, err := clients.OpenshiftClusters.Get(ctx, vnetResourceGroup, clusterName, nil)
+			if err != nil {
+				return
+			}
+			if oc.Properties != nil && oc.Properties.ProvisioningState != nil && *oc.Properties.ProvisioningState != armredhatopenshift.ProvisioningStateSucceeded {
+				By("sending the PATCH request to retry update")
+				err := clients.OpenshiftClusters.UpdateAndWait(ctx, vnetResourceGroup, clusterName, armredhatopenshift.OpenShiftClusterUpdate{})
+				Expect(err).NotTo(HaveOccurred())
+			}
+
 			By("cleaning up any remaining role assignments for the original identity")
 			if originalMsi.Properties != nil && originalMsi.Properties.PrincipalID != nil {
 				roleAssignments, err := clients.RoleAssignments.ListForResourceGroup(ctx, vnetResourceGroup, fmt.Sprintf("principalId eq '%s'", *originalMsi.Properties.PrincipalID))

--- a/test/e2e/update.go
+++ b/test/e2e/update.go
@@ -331,22 +331,24 @@ var _ = Describe("Update clusters", func() {
 		}).WithContext(ctx).WithTimeout(DefaultEventuallyTimeout).Should(Succeed())
 
 		By("sending the PATCH request to replace the operator identity")
-		err := clients.OpenshiftClusters.UpdateAndWait(ctx, vnetResourceGroup, clusterName, armredhatopenshift.OpenShiftClusterUpdate{
-			Properties: &armredhatopenshift.OpenShiftClusterProperties{
-				PlatformWorkloadIdentityProfile: &armredhatopenshift.PlatformWorkloadIdentityProfile{
-					PlatformWorkloadIdentities: map[string]*armredhatopenshift.PlatformWorkloadIdentity{
-						operatorName: {
-							ResourceID: &replacementResourceID,
+		Eventually(func(g Gomega, ctx context.Context) {
+			err := clients.OpenshiftClusters.UpdateAndWait(ctx, vnetResourceGroup, clusterName, armredhatopenshift.OpenShiftClusterUpdate{
+				Properties: &armredhatopenshift.OpenShiftClusterProperties{
+					PlatformWorkloadIdentityProfile: &armredhatopenshift.PlatformWorkloadIdentityProfile{
+						PlatformWorkloadIdentities: map[string]*armredhatopenshift.PlatformWorkloadIdentity{
+							operatorName: {
+								ResourceID: &replacementResourceID,
+							},
 						},
 					},
 				},
-			},
-		})
-		Expect(err).NotTo(HaveOccurred())
+			})
+			g.Expect(err).NotTo(HaveOccurred())
+		}).WithContext(ctx).WithTimeout(2 * time.Second).Should(Succeed())
 
 		By("verifying the identity was replaced")
 		Eventually(func(g Gomega, ctx context.Context) {
-			oc, err = clients.OpenshiftClusters.Get(ctx, vnetResourceGroup, clusterName, nil)
+			oc, err := clients.OpenshiftClusters.Get(ctx, vnetResourceGroup, clusterName, nil)
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(oc.Properties).NotTo(BeNil())
 			g.Expect(oc.Properties.PlatformWorkloadIdentityProfile).NotTo(BeNil())


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://redhat.atlassian.net/browse/ARO-29185
### What this PR does / why we need it:

The second retry for Identity Replacement fails due to no PrincipalID on the MSI/UserAssignedIdentity attached to the cluster, while performing the GET check.
Although the subsequent update request successfully passes.
So just adding an update request between a subsequent retry and failure would increase the chances of successful update and thus passing the patch.

Note: It is still the propagation delay issue, 10 mins are not enough too, at this point a valid retry is better to keep increasing the retry time.
Tested in the local, on the go role assignment, and it works on that single iteration, so not an access token refresh issue. Just the propagation delay.
<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:
e2e must keep passing without flakes.
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?
Nope
<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 
E2E
<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->
